### PR TITLE
Add a widget route in client that the editor can use for playing assessments

### DIFF
--- a/client/src/examples/embedded-widget-assessment.json
+++ b/client/src/examples/embedded-widget-assessment.json
@@ -1,0 +1,159 @@
+
+[
+  {
+    "_id": "55dc047844330b8f6be2045c5f0c7c22",
+    "_rev": "1-4530ee4a525976ea9d0c3df1d65d940b",
+    "studentDialog": "",
+    "enumeratorHelp": "",
+    "transitionComment": "",
+    "skippable": false,
+    "order": 0,
+    "prototype": "location",
+    "locations": [],
+    "name": "01. School location",
+    "assessmentId": "5d48f628-ced9-7af6-529c-48dc8d42d267",
+    "editedBy": "tangerine",
+    "updated": "Wed Jan 13 2016 15:13:32 GMT-0500 (EST)",
+    "hash": "DrAnswAdlVFREHSr8NlJsatEZCQ=",
+    "fromInstanceId": "lxxc-xtip-ozwg",
+    "collection": "subtest"
+  },
+  {
+    "_id": "55dc047844330b8f6be2045c5f0c8411",
+    "_rev": "12-5d3c3f0a88baae600beaffc14c917d08",
+    "studentDialog": "",
+    "enumeratorHelp": "",
+    "transitionComment": "",
+    "skippable": false,
+    "order": 1,
+    "prototype": "survey",
+    "locations": [],
+    "name": "02. Student info",
+    "assessmentId": "5d48f628-ced9-7af6-529c-48dc8d42d267",
+    "gridLinkId": "",
+    "editedBy": "tangerine",
+    "updated": "Wed Jan 13 2016 15:18:08 GMT-0500 (EST)",
+    "hash": "AX/3yStqVXJpfqfZWb942zL62hA=",
+    "fromInstanceId": "lxxc-xtip-ozwg",
+    "collection": "subtest",
+    "rtl": false,
+    "backButton": false,
+    "language": "",
+    "displayCode": "",
+    "fontFamily": "",
+    "autostopLimit": 0,
+    "focusMode": true
+  },
+  {
+    "_id": "55dc047844330b8f6be2045c5f0c8e47",
+    "_rev": "6-ee154ce729746ecb61e25829dabbe61f",
+    "prompt": "Say foo",
+    "name": "question_foo",
+    "hint": "",
+    "order": 0,
+    "linkedGridScore": 0,
+    "type": "single",
+    "options": [
+      {
+        "label": "foo",
+        "value": "foo"
+      },
+      {
+        "label": "bar",
+        "value": "bar"
+      }
+    ],
+    "subtestId": "55dc047844330b8f6be2045c5f0c8411",
+    "assessmentId": "5d48f628-ced9-7af6-529c-48dc8d42d267",
+    "id": "cf7a8e42-6570-5d43-80b2-1224c6e0b93d",
+    "editedBy": "tangerine",
+    "updated": "Wed Jan 13 2016 15:18:06 GMT-0500 (EST)",
+    "hash": "V911Xw0i+RzRZ4lrdQgmw6+ILfw=",
+    "fromInstanceId": "lxxc-xtip-ozwg",
+    "collection": "question",
+    "skipLogic": "",
+    "skippable": false,
+    "customValidationCode": "",
+    "customValidationMessage": "",
+    "displayCode": ""
+  },
+  {
+    "_id": "55dc047844330b8f6be2045c5f0c9bef",
+    "_rev": "5-95c81f00f7f6f1909a33992b54624754",
+    "prompt": "Say bar",
+    "name": "question_bar",
+    "hint": "",
+    "order": 1,
+    "linkedGridScore": 0,
+    "type": "single",
+    "options": [
+      {
+        "label": "foo",
+        "value": "foo"
+      },
+      {
+        "label": "bar",
+        "value": "bar"
+      }
+    ],
+    "subtestId": "55dc047844330b8f6be2045c5f0c8411",
+    "assessmentId": "5d48f628-ced9-7af6-529c-48dc8d42d267",
+    "id": "7cec685e-aec2-4012-a3d0-5500b311aeb0",
+    "editedBy": "tangerine",
+    "updated": "Wed Jan 13 2016 15:17:56 GMT-0500 (EST)",
+    "hash": "sLu8F09rlgImr+ChBzdjljCtRIQ=",
+    "fromInstanceId": "lxxc-xtip-ozwg",
+    "collection": "question",
+    "skipLogic": "",
+    "skippable": false,
+    "customValidationCode": "",
+    "customValidationMessage": "",
+    "displayCode": ""
+  },
+  {
+    "_id": "55dc047844330b8f6be2045c5f0c9e98",
+    "_rev": "4-5d6e4f73630a5f2c09b8c105f8ea152a",
+    "prompt": "Say quo",
+    "name": "quo",
+    "hint": "",
+    "order": 2,
+    "linkedGridScore": 0,
+    "type": "single",
+    "options": [
+      {
+        "label": "foo",
+        "value": "foo"
+      },
+      {
+        "label": "quo",
+        "value": "quo"
+      }
+    ],
+    "subtestId": "55dc047844330b8f6be2045c5f0c8411",
+    "assessmentId": "5d48f628-ced9-7af6-529c-48dc8d42d267",
+    "id": "60e3e399-bc65-d003-671e-bc1e2542421d",
+    "editedBy": "tangerine",
+    "updated": "Wed Jan 13 2016 15:18:16 GMT-0500 (EST)",
+    "hash": "dC/CZNn5iU8PISmUDdsU/Ma5+eA=",
+    "fromInstanceId": "lxxc-xtip-ozwg",
+    "collection": "question",
+    "skipLogic": "",
+    "skippable": false,
+    "customValidationCode": "",
+    "customValidationMessage": "",
+    "displayCode": ""
+  },
+  {
+    "_id": "5d48f628-ced9-7af6-529c-48dc8d42d267",
+    "_rev": "1-135e5ab69129208ac805d8147834c1f0",
+    "name": "Test: School Location and Then Focus Mode",
+    "assessmentId": "5d48f628-ced9-7af6-529c-48dc8d42d267",
+    "archived": false,
+    "editedBy": "tangerine",
+    "updated": "Wed Jan 13 2016 15:05:54 GMT-0500 (EST)",
+    "hash": "QNaKFw9nUAMDrt/lpQ+3c1E3IQY=",
+    "fromInstanceId": "lxxc-xtip-ozwg",
+    "collection": "assessment"
+  }
+]
+

--- a/client/src/examples/embedded-widget.html
+++ b/client/src/examples/embedded-widget.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+      <title>Tangerine Embedded Widget Example</title>
+      <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+
+      <script type="text/javascript">
+        $(document).ready(function() {
+          $.get('embedded-widget-assessment.json', function(response) {
+            var $assessmentWidget = $(document.createElement('iframe'))
+            $assessmentWidget.attr('src', '../index-dev.html')
+            $assessmentWidget.attr('data-assessment', JSON.stringify(response))
+            $assessmentWidget.attr('data-result', '{}')
+            $assessmentWidget.attr('width', 400)
+            $assessmentWidget.attr('height', 500)
+            $assessmentWidget.on('result-save', function(event) {
+              $('.result').html(event.target.getAttribute('data-result'))
+            })
+            $('.assessment').html($assessmentWidget)
+          })
+        })
+      </script>
+    </head>
+
+    <body>
+      <h1>Embedded Assessment Example</h1>
+      <h2> Assessment Widget </h2>
+      <div class="assessment"></div>
+      <h2>Output of result</h2>
+      <div class="result"></div>
+    </body>
+
+</html>

--- a/client/src/examples/embedded-widget.html
+++ b/client/src/examples/embedded-widget.html
@@ -9,7 +9,7 @@
         $(document).ready(function() {
           $.get('embedded-widget-assessment.json', function(response) {
             var $assessmentWidget = $(document.createElement('iframe'))
-            $assessmentWidget.attr('src', '../index-dev.html')
+            $assessmentWidget.attr('src', '../index.html#widget')
             $assessmentWidget.attr('data-assessment', JSON.stringify(response))
             $assessmentWidget.attr('data-result', '{}')
             $assessmentWidget.attr('width', 400)

--- a/client/src/js/boot.coffee
+++ b/client/src/js/boot.coffee
@@ -19,7 +19,13 @@ Tangerine.bootSequence =
     Pouch configuration
     ###
 
-    Tangerine.db = new PouchDB(Tangerine.conf.db_name)
+    if (window.location.hash == '#widget')
+      # This is a widget and we should keep our memory temporary.
+      Tangerine.db = new PouchDB("tangerine-" + Date.now() + Math.random(), {storage: 'temporary'})
+    else 
+      # This is not a widget and we'll hang onto our long term memory.
+      Tangerine.db = new PouchDB(Tangerine.conf.db_name)
+
     Backbone.sync = BackbonePouch.sync
       db: Tangerine.db
       fetch: 'view'

--- a/client/src/js/router.coffee
+++ b/client/src/js/router.coffee
@@ -421,7 +421,6 @@ class Router extends Backbone.Router
             vm.show new AssessmentRunView model: assessment
 
   widgetLoad: () ->
-    Tangerine.db = new PouchDB("tangerine-" + Date.now() + Math.random(), {storage: 'temporary'})
     assessmentDocs = JSON.parse(window.frameElement.getAttribute('data-assessment'))
     assessmentId = ''
     resultId = ''

--- a/client/src/js/router.coffee
+++ b/client/src/js/router.coffee
@@ -19,7 +19,7 @@ class Router extends Backbone.Router
 
   routes:
     'widget'   : 'widgetLoad'
-    'widget-play' : 'widgetPlay'
+    'widget-play/:id' : 'widgetPlay'
     'login'    : 'login'
     'register' : 'register'
     'logout'   : 'logout'


### PR DESCRIPTION
Instead of making a separate Tangerine Widget, for now our best code is in the client. This pull request adds a `widget` route to the client router so that the client codebase can be referred to from an iframe like so... 

```
<iframe src="client/index.html#widget" data-assessment="..." width="400" height="500"></iframe>
```

The widget route creates a temporary Pouch database, places data from the iframe's `data-assessment` property into the database, and then runs that assessment in the `widget-play` route. As the assessment is played, a `data-results` property is populated in the iframe. To see an example...

```
cd client
npm install
bower install
npm start
```

Then go to `localhost:8080/example/embedded-widget.html`.