### PR TITLE
Add ability to Tree to create Zip packages

### DIFF
--- a/tree/index.js
+++ b/tree/index.js
@@ -35,6 +35,9 @@ app.get('/', function(req, res){ res.status(HttpStatus.OK).send(`<body><canvas i
 // make an apk
 app.post('/:group', require('./routes/makeApk'));
 
+// make a zip
+app.post('/make/zip/:group', require('./routes/makeZip'));
+
 // get an apk
 app.get('/:token',  require('./routes/getApk'));
 

--- a/tree/routes/getApk.js
+++ b/tree/routes/getApk.js
@@ -41,21 +41,27 @@ const getApk = function(req, res){
 
   // differentiate between default requests and requests for x86 apks.
   const x86Request = token.indexOf('.x86') !== -1;
-  let apkPath = '';
+  const zipRequest = token.indexOf('.zip') !== -1;
+  let packagePath = '';
   let downloadName = '';
 
   if (x86Request) {
-    apkPath = Path.join(Conf.APP_ROOT_PATH, 'apks', `${token.substr(0,token.length-4)}-x86`);
+    packagePath = Path.join(Conf.APP_ROOT_PATH, 'apks', `${token.substr(0,token.length-4)}-x86`);
     downloadName = 'tangerine-x86.apk';
-  } else {
-    apkPath = Path.join(Conf.APP_ROOT_PATH, 'apks', token);
+  } 
+  else if (zipRequest) {
+    packagePath = Path.join(Conf.APP_ROOT_PATH, 'apks', `${token.substr(0,token.length-4)}.zip`);
+    downloadName = 'tangerine.zip';
+  } 
+  else {
+    packagePath = Path.join(Conf.APP_ROOT_PATH, 'apks', token);
     downloadName = 'tangerine.apk';
   }
 
   // see if the file is there
-  fs.access(apkPath, fs.F_OK, function(err) {
+  fs.access(packagePath, fs.F_OK, function(err) {
     if (!err) {
-      res.download(apkPath, downloadName);
+      res.download(packagePath, downloadName);
     } else {
       res.status(HttpStatus.NOT_FOUND)
         .json({

--- a/tree/routes/makeZip.js
+++ b/tree/routes/makeZip.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const Conf = require('../Conf');
+
+const Token = require('../Token');
+
+const logger = require('../logger');
+
+require('shelljs/global');
+
+// for writeFile
+const fs = require('fs');
+
+// for mkdirp
+const fse = require('fs-extra');
+
+// a REST client
+const unirest = require('unirest');
+
+// for simple deleting with callbacks
+const del = require('del');
+
+// for standard http responses
+const HttpStatus = require('http-status-codes');
+
+// shell response idiom
+const notOk = function(output, res, status) {
+  if (output === undefined) { return; }
+  const badExit = output.code !== 0;
+  if (badExit) {
+    logger.error(output.output);
+    res
+      .status(status)
+      .json({msg:output.output})
+      .end();
+    return true;
+  } else {
+    return false;
+  }
+};
+
+/** */
+const makeTangerine = function(req, res) {
+
+  // assert a group name
+  const group = req.params.group;
+  const emptyGroup = !group || group == ''
+  if (emptyGroup) {
+    return res
+      .status(HttpStatus.BAD_REQUEST)
+      .json({
+        message : 'Missing group'
+      });
+  }
+
+  // assert authorized user
+  const notEvenLoggedIn = req.couchAuth.body.userCtx === undefined;
+  if (notEvenLoggedIn) {
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({
+        message : "You're not logged in."
+      });
+  }
+
+  // assert a valid user within requested group
+  const notAssociated = req.couchAuth.body.userCtx.roles.indexOf(`admin-${group}`) === -1;
+  if (notAssociated) {
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({
+        message : "Must be an admin to create APKs."
+      });
+  }
+
+
+  // sanitize the group name
+  const groupName = group.replace(/[^a-zA-Z0-9_\-]/,'')
+
+  // make a token
+  const token = Token.make();
+
+  // load the json packs
+  cd(`${__dirname}/../client`);
+  const preload = exec(`npm run treeload --group=${groupName}`);
+  if (notOk(preload, res, HttpStatus.INTERNAL_SERVER_ERROR)) { return; }
+
+  // build the zip 
+  cd(`${__dirname}/..`);
+  const buildApk = exec(`zip -r ${Conf.APK_PATH}/${token}.zip client/`);
+  if (notOk(buildApk, res, HttpStatus.INTERNAL_SERVER_ERROR)) { return; }
+
+  res.status(HttpStatus.OK).json({
+    token : token
+  });
+
+};
+
+module.exports = makeApk;


### PR DESCRIPTION
## Zip packages for offline deployment

Many users of Tangerine prepare tablets for deployment in environments with limited bandwidth. For this reason, Tangerine's "Tree" produces a single file package containing application, content, and configuration that can be downloaded once and then transferred to tablets locally via USB. The package file that Tree has been producing is an APK. This pull request adds another kind of package that wraps up application, content, and configuration in one file that can be transferred to tablets locally via USB. This new package type is a Zipped folder of HTML, Javascript, and JSON that can be opened from an App icon and into a web browser on the device.
## User Story: User downloads group Zip package and opens it on an Android Tablet
1. From Tangerine online in group g1, user clicks "Download Zip Package".
2. Tree creates a zip folder called tangerine-group-g1.zip that contains group-data.json and client codebase.
3. User downloads tangerine-group-g1.zip, unzips it to find a tangerine-group-g1 folder.
4. User drag and drops the tangerine-group-g1 folder into an Android's Downloads folder using Android File Transfer.
5. From Android Device, User opens file browser, opens Downloads/tangerine-group-g1, opens tangerine.html, then bookmarks the page and chooses to add bookmark to homescreen.
## The upsides
### More time spent developing the application, less time wrangling APK generation

In the 6 months since I've been working on Tangerine, we have been unable to **reliably reproduce environments that can reliably reproduce Client as an Android App**. Note that when we are lucky enough to create an environment that is functioning, that environment reliably reproduces Client as an Android App. We are however not able to reliably create that environment (see [here](https://github.com/Tangerine-Community/docker-tangerine-tree/issues/21)). It's not tree that is the issue, it's our ability to reproduce fertile ground where Tree can produce fruit (APKs).

For this reason, the major upside to this approach is the amount of time we will be spending on improving the application and not on "**reliably reproduce environments that can reliably reproduce Client as an Android App**". It's also not clear to me that Tangerine has the level of investment to support "**reliably reproduce environments that can reliably reproduce Client as an Android App**" so this could be seen as a way to unblock a major blocker for Tangerine reproducibility. 
### Faster QA, less complicated code, and better privacy

The current approach of generating APKs and the difficulties we have encountered getting to "**reliably reproduce environments that can reliably reproduce Client as an Android App**" has left us in a situation where we need to keep the APK generating tree service centralized (bigtree.tangerinecentral.org) and outside of the main Tangerine repository (https://github.com/Tangerine-Community/docker-tangerine-tree). This has led to a very complicated QA process ([it can take a day to set up QA](https://github.com/ICTatRTI/Tangerine-DevOps/issues/53)), complicated code, and risk of privacy exposure to anyone running Tangerine given that their server credentials are all being sent to bigtree.tangerinecentral.org. 

If we pursue the Zip package approach, we can consolidate tree code back into the Tangerine repository and have it running in parallel with an instance of Tangerine. This gives us faster QA, less complicated code, and better privacy.
## The downsides

The first downside that one might think of is how every browser is different, we may be trading time spent dealing with building APKs for time spent dealing with browser inconsistencies. Including a standard APK build of Firefox is the key here to guaranteeing a consistent environment for Tangerine to run in. Why Firefox? Because Mozilla [publishes Firefox.apk downloads](https://wiki.mozilla.org/Mobile/Platforms/Android) and Google only allows you to install Google Chrome via the Google Play store (last I checked but worth checking into).

Another downside is the additional steps in deployment compared to the APK route. I would like to argue the case that we will have a net user happiness with this approach because of the additional time we spend improving the application and not troubleshooting APK generation and the complexity this adds to our QA process. 
