### PR TITLE
Empower users to import results and assessments from files

### DIFF
--- a/editor/src/js/modules/assessment/AssessmentImportView.coffee
+++ b/editor/src/js/modules/assessment/AssessmentImportView.coffee
@@ -189,9 +189,32 @@ class AssessmentImportView extends Backbone.View
 
       <h1>Tangerine Central Import</h1>
 
+      <input type='file' id='fileinput' />
+
       #{importStep}
 
     "
+
+    readSingleFile = (evt) -> 
+
+      f = evt.target.files[0]  
+
+      if (f) 
+        r = new FileReader()
+        r.onload = (e) -> 
+            contents = e.target.result             
+            ct = r.result
+            try 
+              docs = JSON.parse(ct)
+              Tangerine.$db.bulkSave {docs: docs}
+            catch 
+              alert('Could not parse the file you uploaded.')
+              console.log e
+        r.readAsText(f)
+      else 
+        alert("Failed to load file")
+
+    @$el.find('#fileinput')[0].addEventListener('change', readSingleFile, false)
 
     @trigger "rendered"
 


### PR DESCRIPTION
![screen shot 2016-07-08 at 2 17 40 pm](https://cloud.githubusercontent.com/assets/156575/16697384/67b2f056-4517-11e6-972a-e5f607bcdb7d.png)

Upload a file of results to this checkbox and they are then saved to the database. There is still some funkyness to it though..
- some of the docs are apparently `undefined` and alert an pops up.
- this UI is in the "Assessment" import screen when really it's just a general importer.
- Needs some help text, also a confirmation when upload is complete with some stats about what happened.
- We do not yet have a way for users to export Assessment as a file. That's fine for now, could be completed later.