### PR TITLE
#114 Add support for default and overridden settings

### DIFF
--- a/client/src/js/boot.coffee
+++ b/client/src/js/boot.coffee
@@ -161,14 +161,8 @@ Tangerine.bootSequence =
   # these do tend to change depending on the particular install of the
   fetchSettings : ( callback ) ->
     Tangerine.settings = new Settings "_id" : "settings"
-    Tangerine.settings.fetch
-      success: callback
-      error: ->
-        Tangerine.settings.save Tangerine.defaults.settings,
-          error: ->
-            console.error arguments
-            alert "Could not save default settings"
-          success: callback
+    Tangerine.settings.fetch()
+    Tangerine.settings.on('sync', callback)
 
   # for upgrades
   guaranteeInstanceId: ( callback ) ->


### PR DESCRIPTION
Now when calling `Tangerine.settings.get('foo')`, if there is a `foo` property in the `configuration` document, that property will be returned. This PR does this by overriding the sync method for the `Settings` Class. On `Settings.fetch()`, the sync method will get called and it will first get the settings doc, then get the configuration doc, apply configuration doc over settings doc, and then finish.

Still to do is to include the configuration doc when compiling an APK and then port this from client to editor so it behaves the same way.