### PR TITLE
SubtestRunItemView as a Base Class for Subtest Classes and clean up AssessmentCompositeView

### DIFF
--- a/client/src/js/modules/assessment/Assessment.coffee
+++ b/client/src/js/modules/assessment/Assessment.coffee
@@ -43,3 +43,29 @@ Assessment = Backbone.Model.extend
             subtests.ensureOrder()
             opts.success.apply subtests.assessment, arguments
 
+  # @todo The Assessment model should know how to sort itself.
+  getOrderMap: ->
+
+    # Figure out the @orderMap which is either derived from the assessment, the
+    # result with a prior orderMap, or lastly no specified order map in which case
+    # we create a linear orderMap.
+
+    orderMap = []
+    hasSequences = @has("sequences") && not _.isEmpty(_.compact(_.flatten(@get("sequences"))))
+    if hasSequences
+      sequences = @get("sequences")
+      # get or initialize sequence places
+      places = Tangerine.settings.get("sequencePlaces")
+      places = {} unless places?
+      places[@id] = 0 unless places[@id]?
+      if places[@id] < sequences.length - 1
+        places[@id]++
+      else
+        places[@id] = 0
+      Tangerine.settings.save("sequencePlaces", places)
+      orderMap = sequences[places[@id]]
+      orderMap[orderMap.length] = @subtests.models.length
+    else
+      for i in [0..@subtests.models.length]
+        orderMap[i] = i
+    return orderMap

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -213,9 +213,7 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
       else
         @index + increment
 
-    if @abortAssessment
-      # TODO: Make sure this is doing what we want when aborting.
-      @saveResult( @currentChildView )
+    @saveResult( @currentChildView )
 
     # Now that we've prepared, let's render again.
     @trigger "assessment:step"
@@ -233,16 +231,7 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     @step 1
 
   skip: ->
-    console.log 'adding'
-    @result.add
-      name      : @currentChildView.model.get "name"
-      data      : @currentChildView.getSkipped()
-      subtestId : @currentChildView.model.id
-      skipped   : true
-      prototype : @currentChildView.model.get "prototype"
-    ,
-      success: =>
-        @step 1
+    @step 1
 
 
   #
@@ -389,12 +378,13 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     grid = @assessment.subtests.get @currentChildModel.get('gridLinkId')
     gridWasAutostopped = @result.gridWasAutostopped grid.id
 
+
   #
   # Helper methods for working with Results.
   #
 
   # TODO: Documentation
-  saveResult: ( currentView, increment ) ->
+  saveResult: ( currentView ) ->
 
     subtestResult = currentView.getResult()
     subtestId = currentView.model.id
@@ -418,7 +408,6 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
           subtestId   : currentView.model.id
           prototype   : currentView.model.get "prototype"
           sum         : getSum
-      @reset increment
 
     else
       @result.add
@@ -428,9 +417,6 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
         subtestId   : currentView.model.id
         prototype   : currentView.model.get "prototype"
         sum         : getSum
-      ,
-        success : =>
-          @reset increment
 
   # TODO: Documentation
   getSum: ->

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -134,6 +134,10 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     # Get @currentChildView
     childViewClass = @getChildViewClass(@currentChildModel)
     @currentChildView = new childViewClass({model: @currentChildModel})
+    # @todo It looks like Skip Logic requires us to put this in a global. We should
+    # look into how to localize this.
+    Tangerine.progress =
+      currentSubview : @currentChildView
 
     this.$el.html "
       <h1>#{@assessment.get('name')}</h1>
@@ -189,7 +193,7 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
     # Run validation on the current Subtest View before we move on.
     if @currentChildView.hasOwnProperty('testValid')
-      valid = @currentSubtestView.testValid()
+      valid = @currentChildView.testValid()
       if valid
         @saveResult( @currentChildView, increment )
       else
@@ -380,17 +384,17 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
   # TODO: Documentation
   getGridScore: ->
-    link = @model.get("subtest").gridLinkId || ""
+    link = @currentChildModel.get('gridLinkId') || ""
     if link == "" then return
-    grid = @model.subtests.get @model.get("subtest").gridLinkId
+    grid = @model.subtests.get @currentChildModel.get('gridLinkId')
     gridScore = @result.getGridScore grid.id
     gridScore
 
   # TODO: Documentation
   gridWasAutostopped: ->
-    link = @model.get("subtest").gridLinkId || ""
+    link = @currentChildModel.get('gridLinkId') || ""
     if link == "" then return
-    grid = @model.subtests.get @model.get("subtest").gridLinkId
+    grid = @assessment.subtests.get @currentChildModel.get('gridLinkId')
     gridWasAutostopped = @result.gridWasAutostopped grid.id
 
   #

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -9,9 +9,6 @@
 # or back is clicked, the step(incrementToMoveToSubtestReferencedByViewIndex) method is
 # eventually called which calls render.
 #
-# Listens for "result:saved" and "result:another" events triggered by the ResultItemView subtest and makes it
-# available for consumption (via triggerSaved and triggerAnother) by external users such as Widget.
-#
 # Options:
 #   assessment (required) - An Assessment Model
 #   result: (optional) - A Result model to pick up where you left off.
@@ -76,16 +73,9 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
 
   #
-  # Configure the View
+  # Handle Rendering.
   #
 
-  # for Backbone.Marionette.CompositeView Composite Model
-  template: JST["AssessmentView"],
-
-  # for Backbone.Marionette.CompositeView
-  childViewContainer: '#subtest_wrapper',
-
-  # TODO: Documentation
   i18n: ->
     @text =
       "next" : t("SubtestRunView.button.next")
@@ -95,12 +85,6 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
       "previousQuestion" : t("SurveyRunView.button.previous_question")
       "nextQuestion" : t("SurveyRunView.button.next_question")
 
-
-  #
-  # Bind Events.
-  #
-
-  # for Backbone.View
   events:
     'click .subtest-next' : 'next'
     'click .subtest-back' : 'back'
@@ -110,12 +94,6 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     'click .prev_question' : 'prevQuestion'
     'nextQuestionRendered': 'nextQuestionRenderedBoom'
 
-
-  #
-  # Handle Rendering and Closing of the View.
-  #
-
-  # Set up before render.
   render:->
     console.log('AssessmentCompositeView.onBeforeRender')
 
@@ -189,33 +167,43 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     @$el.find('#progress').progressbar value : ( ( @index + 1 ) / ( @model.subtests.length + 1 ) * 100 )
 
 
-  # TODO: Documentation
-  onClose: ->
-    for view in @subtestViews
-      view.close()
-    @result.clear()
-    Tangerine.nav.setStudent ""
+  #
+  # Method for deciding what Subtest View Class to use.
+  #
 
-  # TODO: Documentation
-  toggleHelp: -> @$el.find(".enumerator_help").fadeToggle(250)
-
-  # TODO: Documentation
-  displaySkip: (skippable)->
-    if skippable
-      $( ".skip" ).show();
+  getChildViewClass: (model) ->
+    # TODO: This is probably breaking the separation of concerns.
+    model.parent = @
+    # TODO: Every Subtest Model gets a Questions Collection? This doesn't seem right.
+    if !model.questions
+      model.questions     = new Questions()
+    if model.get("collection") == 'result'
+      currentSubview =  ResultItemView
     else
-      $( ".skip" ).hide();
+      prototypeName = model.get('prototype').titleize() + "RunItemView"
+      if  (prototypeName == 'SurveyRunItemView')
+        currentSubview = SurveyRunItemView
+      else if  (prototypeName == 'GridRunItemView')
+        currentSubview = GridRunItemView
+      else if  (prototypeName == 'GpsRunItemView')
+        currentSubview = GpsRunItemView
+      else if  (prototypeName == 'DatetimeRunItemView')
+        currentSubview = DatetimeRunItemView
+      else if  (prototypeName == 'IdRunItemView')
+        currentSubview = IdRunItemView
+      else if  (prototypeName == 'LocationRunItemView')
+        currentSubview = LocationRunItemView
+      else if  (prototypeName == 'ConsentRunItemView')
+        currentSubview = ConsentRunItemView
+      else
+        currentSubview =  null
+        console.log(prototypeName + "  Subview is not defined.")
 
-  # TODO: Documentation
-  displayBack: (backable)->
-    if backable
-      $( ".subtest-back" ).removeClass("hidden");
-    else
-      $( ".subtest-back" ).addClass("hidden");
+    return currentSubview
 
 
   #
-  # Methods for handling flow of Subtests: step, abort, and skip
+  # Methods for handling flow of Subtests: step, next, back, abort, and skip
   #
 
   # Step to another Subtest.
@@ -258,156 +246,9 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
 
   #
-  # Methods for handling Subtest Views
+  # Helper method for working with Results.
   #
 
-  # for Backbone.Marionette.CollectionView
-  childEvents:
-    'render:collection': 'addChildPostRender'
-
-  getChildViewClass: (model) ->
-    # TODO: This is probably breaking the separation of concerns.
-    model.parent = @
-    # TODO: Every Subtest Model gets a Questions Collection? This doesn't seem right.
-    if !model.questions
-      model.questions     = new Questions()
-    if model.get("collection") == 'result'
-      currentSubview =  ResultItemView
-    else
-      prototypeName = model.get('prototype').titleize() + "RunItemView"
-      if  (prototypeName == 'SurveyRunItemView')
-        currentSubview = SurveyRunItemView
-      else if  (prototypeName == 'GridRunItemView')
-        currentSubview = GridRunItemView
-      else if  (prototypeName == 'GpsRunItemView')
-        currentSubview = GpsRunItemView
-      else if  (prototypeName == 'DatetimeRunItemView')
-        currentSubview = DatetimeRunItemView
-      else if  (prototypeName == 'IdRunItemView')
-        currentSubview = IdRunItemView
-      else if  (prototypeName == 'LocationRunItemView')
-        currentSubview = LocationRunItemView
-      else if  (prototypeName == 'ConsentRunItemView')
-        currentSubview = ConsentRunItemView
-      else
-        currentSubview =  null
-        console.log(prototypeName + "  Subview is not defined.")
-
-    return currentSubview
-
-  # TODO: Documentation
-  subTestRenderCollection:->
-    console.log("onRenderCollection")
-    currentSubtest = @children.findByIndex(0)
-    focusMode = currentSubtest.model.getBoolean("focusMode")
-    if focusMode
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-
-
-  #    This is simply used to alert the test it('Should contain a next question button') that the page has finished rendering.
-  nextQuestionRenderedBoom: ->
-    console.log("nextQuestionRenderedBoom")
-
-  # Triggered by `add:child` of this.childEvents
-  addChildPostRender: ->
-    currentSubtest = @children.findByIndex(0)
-    focusMode = currentSubtest.model.getBoolean("focusMode")
-    if focusMode
-      if !@$el.find("#summary_container").length
-        @$el.find("#subtest_wrapper").after $ "
-              <div id='summary_container'></div>
-              <button class='navigation prev_question'>#{@text.previousQuestion}</button>
-              <button class='navigation next_question'>#{@text.nextQuestion}</button>
-            "
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-      @trigger "nextQuestionRendered"
-
-
-  #
-  # Methods for handling Focus Mode on Survey Subtests.
-  #
-
-  nextQuestion: ->
-
-    currentSubtest = @children.findByIndex(0)
-
-    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
-
-    # show errors before doing anything if there are any
-    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
-
-    # find the non-skipped questions
-    isAvailable = []
-    for qv, i in currentSubtest.questionViews
-      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
-    isAvailable  = _.filter isAvailable, (e) => e > currentSubtest.questionIndex
-
-    # don't go anywhere unless we have somewhere to go
-    if isAvailable.length == 0
-      plannedIndex = currentSubtest.questionIndex
-    else
-      plannedIndex = Math.min.apply(plannedIndex, isAvailable)
-
-    if currentSubtest.questionIndex != plannedIndex
-      currentSubtest.questionIndex = plannedIndex
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-
-  # TODO: Documentation.
-  prevQuestion: ->
-
-    currentSubtest = @children.findByIndex(0)
-
-    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
-
-    # show errors before doing anything if there are any
-    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
-
-    # find the non-skipped questions
-    isAvailable = []
-    for qv, i in currentSubtest.questionViews
-      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
-    isAvailable  = _.filter isAvailable, (e) => e < currentSubtest.questionIndex
-
-    # don't go anywhere unless we have somewhere to go
-    if isAvailable.length == 0
-      plannedIndex = currentSubtest.questionIndex
-    else
-      plannedIndex = Math.max.apply(plannedIndex, isAvailable)
-
-    if currentSubtest.questionIndex != plannedIndex
-      currentSubtest.questionIndex = plannedIndex
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-
-
-  #
-  # Helper methods for working with Grid Subtest.
-  #
-
-  # TODO: Documentation
-  getGridScore: ->
-    link = @currentChildModel.get('gridLinkId') || ""
-    if link == "" then return
-    grid = @model.subtests.get @currentChildModel.get('gridLinkId')
-    gridScore = @result.getGridScore grid.id
-    gridScore
-
-  # TODO: Documentation
-  gridWasAutostopped: ->
-    link = @currentChildModel.get('gridLinkId') || ""
-    if link == "" then return
-    grid = @assessment.subtests.get @currentChildModel.get('gridLinkId')
-    gridWasAutostopped = @result.gridWasAutostopped grid.id
-
-
-  #
-  # Helper methods for working with Results.
-  #
-
-  # TODO: Documentation
   saveResult: ( currentView ) ->
 
     subtestResult = currentView.getResult()
@@ -442,7 +283,139 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
         prototype   : currentView.model.get "prototype"
         sum         : getSum
 
-  # TODO: Documentation
+
+
+
+
+
+
+
+
+
+
+
+  #
+  # Poorly understood and potentially removeable methods and documentation.
+  #
+
+  # Listens for "result:saved" and "result:another" events triggered by the ResultItemView subtest and makes it
+  # available for consumption (via triggerSaved and triggerAnother) by external users such as Widget.
+
+  onClose: ->
+    for view in @subtestViews
+      view.close()
+    @result.clear()
+    Tangerine.nav.setStudent ""
+
+  toggleHelp: -> @$el.find(".enumerator_help").fadeToggle(250)
+
+  displaySkip: (skippable)->
+    if skippable
+      $( ".skip" ).show();
+    else
+      $( ".skip" ).hide();
+
+  displayBack: (backable)->
+    if backable
+      $( ".subtest-back" ).removeClass("hidden");
+    else
+      $( ".subtest-back" ).addClass("hidden");
+
+  subTestRenderCollection:->
+    console.log("onRenderCollection")
+    currentSubtest = @children.findByIndex(0)
+    focusMode = currentSubtest.model.getBoolean("focusMode")
+    if focusMode
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+
+  childEvents:
+    'render:collection': 'addChildPostRender'
+
+  # This is simply used to alert the test it('Should contain a next question button') that the page has finished rendering.
+  nextQuestionRenderedBoom: ->
+    console.log("nextQuestionRenderedBoom")
+
+  # Triggered by `add:child` of this.childEvents
+  addChildPostRender: ->
+    currentSubtest = @children.findByIndex(0)
+    focusMode = currentSubtest.model.getBoolean("focusMode")
+    if focusMode
+      if !@$el.find("#summary_container").length
+        @$el.find("#subtest_wrapper").after $ "
+              <div id='summary_container'></div>
+              <button class='navigation prev_question'>#{@text.previousQuestion}</button>
+              <button class='navigation next_question'>#{@text.nextQuestion}</button>
+            "
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+      @trigger "nextQuestionRendered"
+
+  nextQuestion: ->
+
+    currentSubtest = @children.findByIndex(0)
+
+    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
+
+    # show errors before doing anything if there are any
+    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
+
+    # find the non-skipped questions
+    isAvailable = []
+    for qv, i in currentSubtest.questionViews
+      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
+    isAvailable  = _.filter isAvailable, (e) => e > currentSubtest.questionIndex
+
+    # don't go anywhere unless we have somewhere to go
+    if isAvailable.length == 0
+      plannedIndex = currentSubtest.questionIndex
+    else
+      plannedIndex = Math.min.apply(plannedIndex, isAvailable)
+
+    if currentSubtest.questionIndex != plannedIndex
+      currentSubtest.questionIndex = plannedIndex
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+
+  prevQuestion: ->
+
+    currentSubtest = @children.findByIndex(0)
+
+    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
+
+    # show errors before doing anything if there are any
+    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
+
+    # find the non-skipped questions
+    isAvailable = []
+    for qv, i in currentSubtest.questionViews
+      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
+    isAvailable  = _.filter isAvailable, (e) => e < currentSubtest.questionIndex
+
+    # don't go anywhere unless we have somewhere to go
+    if isAvailable.length == 0
+      plannedIndex = currentSubtest.questionIndex
+    else
+      plannedIndex = Math.max.apply(plannedIndex, isAvailable)
+
+    if currentSubtest.questionIndex != plannedIndex
+      currentSubtest.questionIndex = plannedIndex
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+
+  getGridScore: ->
+    link = @currentChildModel.get('gridLinkId') || ""
+    if link == "" then return
+    grid = @model.subtests.get @currentChildModel.get('gridLinkId')
+    gridScore = @result.getGridScore grid.id
+    gridScore
+
+  gridWasAutostopped: ->
+    link = @currentChildModel.get('gridLinkId') || ""
+    if link == "" then return
+    grid = @assessment.subtests.get @currentChildModel.get('gridLinkId')
+    gridWasAutostopped = @result.gridWasAutostopped grid.id
+
   getSum: ->
     if Tangerine.progress.currentSubview.getSum?
       return Tangerine.progress.currentSubview.getSum()

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -31,16 +31,11 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     # Set properties.
     #
 
-    # Set @collection to an empty collection because before:render we will determine
-    # which Subtest model to place in @collection.models.
-    @collection = new Backbone.Collection()
-
-    # Set @model and @assessment to the same options.assessment. @model satisfies
-    # Marionette.CompositeView while @assessment satisfies code readability.
+    # Set @assessment.
     if options.assessment
       @assessment = options.assessment
-      @model = options.assessment
       # TODO: This most likely violates the separation of concerns.
+      @model = @assessment
       @model.parent = @
 
     # Set @result.
@@ -134,6 +129,11 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
       console.log 'AssessmentCompositeView detected skip'
       @skip()
 
+    @currentChildView.on 'back', =>
+      @back()
+
+    @currentChildView.on 'next', =>
+      @next()
 
     #
     # Set Globals to be accessed in Subtest Display Logic.

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -15,45 +15,6 @@
 
 AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
-  #
-  # Configure the View
-  #
-
-  # for Backbone.Marionette.CompositeView Composite Model
-  template: JST["AssessmentView"],
-
-  # for Backbone.Marionette.CompositeView
-  childViewContainer: '#subtest_wrapper',
-
-  # @todo Documentation
-  i18n: ->
-    @text =
-      "next" : t("SubtestRunView.button.next")
-      "back" : t("SubtestRunView.button.back")
-      "skip" : t("SubtestRunView.button.skip")
-      "help" : t("SubtestRunView.button.help")
-      "previousQuestion" : t("SurveyRunView.button.previous_question")
-      "nextQuestion" : t("SurveyRunView.button.next_question")
-
-  #
-  # Bind Events.
-  #
-
-  # for Backbone.View
-  events:
-    'click .subtest-next' : 'next'
-    'click .subtest-back' : 'back'
-    'click .subtest_help' : 'toggleHelp'
-    'click .skip'         : 'skip'
-    'click .next_question' : 'nextQuestion'
-    'click .prev_question' : 'prevQuestion'
-    'nextQuestionRendered': 'nextQuestionRenderedBoom'
-
-  # for Backbone.Marionette.CollectionView
-  childEvents:
-    'render:collection': 'addChildPostRender'
-    'subRendered': 'subRendered'
-
   # Initialize
   #
   # @params
@@ -93,24 +54,55 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     # Set States.
     #
 
-    #@index = if options.hasOwnProperty('result') options.result.get('subtestData').length else 0
-    @index = 0
+    @index = if options.hasOwnProperty('result') then options.result.get('subtestData').length else 0
     @abortAssessment = false
     @enableCorrections = false  # toggled if user hits the back button.
 
+    #
     # Initialize i18n strings.
+    #
+
     @i18n()
 
-    # @todo Assessment.subtests should come out of the box sorted so we don't
-    # need to use an awkward order map.
-    #
-    #      @assessment.subtests.models[@orderMap[@index]]
-    #                         VS
-    #      @assessment.subtests.models[@index]
-    #
-    @orderMap = @assessment.getOrderMap()
-    @result.set("order_map" : @orderMap)
 
+  #
+  # Configure the View
+  #
+
+  # for Backbone.Marionette.CompositeView Composite Model
+  template: JST["AssessmentView"],
+
+  # for Backbone.Marionette.CompositeView
+  childViewContainer: '#subtest_wrapper',
+
+  # @todo Documentation
+  i18n: ->
+    @text =
+      "next" : t("SubtestRunView.button.next")
+      "back" : t("SubtestRunView.button.back")
+      "skip" : t("SubtestRunView.button.skip")
+      "help" : t("SubtestRunView.button.help")
+      "previousQuestion" : t("SurveyRunView.button.previous_question")
+      "nextQuestion" : t("SurveyRunView.button.next_question")
+
+  #
+  # Bind Events.
+  #
+
+  # for Backbone.View
+  events:
+    'click .subtest-next' : 'next'
+    'click .subtest-back' : 'back'
+    'click .subtest_help' : 'toggleHelp'
+    'click .skip'         : 'skip'
+    'click .next_question' : 'nextQuestion'
+    'click .prev_question' : 'prevQuestion'
+    'nextQuestionRendered': 'nextQuestionRenderedBoom'
+
+  # for Backbone.Marionette.CollectionView
+  childEvents:
+    'render:collection': 'addChildPostRender'
+    'subRendered': 'subRendered'
 
 
   #
@@ -124,8 +116,8 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     # Depending on the @index, set appropriate child model for the collection.
     # In most cases this will be a subtest model, except for when there are no
     # more subtests, then set it to be the result model.
-    if @assessment.subtests.models[@orderMap[@index]]
-      currentChildModel = @assessment.subtests.models[@orderMap[@index]]
+    if @assessment.subtests.models[@assessment.getOrderMap()[@index]]
+      currentChildModel = @assessment.subtests.models[@assessment.getOrderMap()[@index]]
     else
       @trigger('assessment:complete')
       currentChildModel = @result
@@ -151,7 +143,7 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
   # @todo Are there subtest views that have an afterRender function?
   afterRender: ->
-    @subtestViews[@orderMap[@index]]?.afterRender?()
+    @subtestViews[@assessment.getOrderMap()[@index]]?.afterRender?()
 
   # @todo Documentation
   onClose: ->

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -135,6 +135,9 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     # Get @currentChildView
     childViewClass = @getChildViewClass(@currentChildModel)
     @currentChildView = new childViewClass({model: @currentChildModel})
+    @currentChildView.on 'skip', =>
+      console.log 'AssessmentCompositeView detected skip'
+      @skip()
 
     # TODO: It looks like Skip Logic requires us to put this in a global. We should
     # look into how to localize this.
@@ -229,14 +232,14 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     @abortAssessment = true
     @step 1
 
-  skip: =>
-    currentSubtestView = @children.findByIndex(0)
+  skip: ->
+    console.log 'adding'
     @result.add
-      name      : currentSubtestView.model.get "name"
-      data      : currentSubtestView.getSkipped()
-      subtestId : currentSubtestView.model.id
+      name      : @currentChildView.model.get "name"
+      data      : @currentChildView.getSkipped()
+      subtestId : @currentChildView.model.id
       skipped   : true
-      prototype : currentSubtestView.model.get "prototype"
+      prototype : @currentChildView.model.get "prototype"
     ,
       success: =>
         @step 1

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -15,192 +15,13 @@
 
 AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
-  # for Backbone.Marionette.CompositeView Composite Model
-  template: JST["AssessmentView"],
-
-  # for Backbone.Marionette.CompositeView
-  getChildView: (model) ->
-    model.parent = @
-    if !model.questions
-      model.questions     = new Questions()
-    if model.get("collection") == 'result'
-      currentSubview =  ResultItemView
-    else
-      prototypeName = model.get('prototype').titleize() + "RunItemView"
-      if  (prototypeName == 'SurveyRunItemView')
-        currentSubview = SurveyRunItemView
-      else if  (prototypeName == 'GridRunItemView')
-        currentSubview = GridRunItemView
-      else if  (prototypeName == 'GpsRunItemView')
-        currentSubview = GpsRunItemView
-      else if  (prototypeName == 'DatetimeRunItemView')
-        currentSubview = DatetimeRunItemView
-      else if  (prototypeName == 'IdRunItemView')
-        currentSubview = IdRunItemView
-      else if  (prototypeName == 'LocationRunItemView')
-        currentSubview = LocationRunItemView
-      else if  (prototypeName == 'ConsentRunItemView')
-        currentSubview = ConsentRunItemView
-      else
-        currentSubview =  null
-        console.log(prototypeName + "  Subview is not defined.")
-
-    @ready = true
-    return currentSubview
-
-  # for Backbone.Marionette.CompositeView
-  # Populate the questions in the model of the subtest.
-  childViewOptions: (model, index) ->
-    model.questions.fetch
-      viewOptions:
-        key: "question-#{model.id}"
-      success: (collection) =>
-#        console.log("collection.size: " + collection.size())
-        model.questions.sort()
-        model.collection = model.questions
-        @collection.models = collection.models
-#        The trigger collectionPopulated is use for unit tests
-#        @trigger "collectionPopulated"
-      error: (model, err, cb) ->
-        console.log("childViewOptions id: " +  model.id + " err:" + JSON.stringify(err))
-
-  # for Backbone.Marionette.CompositeView
-  childViewContainer: '#subtest_wrapper',
-
-  # for Backbone.View
-  events:
-    'click .subtest-next' : 'next'
-    'click .subtest-back' : 'back'
-    'click .subtest_help' : 'toggleHelp'
-    'click .skip'         : 'skip'
-    'click .next_question' : 'nextQuestion'
-    'click .prev_question' : 'prevQuestion'
-    'nextQuestionRendered': 'nextQuestionRenderedBoom'
-
-  # for Backbone.Marionette.CollectionView
-  childEvents:
-#    'add:child': 'addChildPostRender'
-#    'collection:rendered': 'addChildPostRender'
-    'render:collection': 'addChildPostRender'
-    'subRendered': 'subRendered'
-#    'attach': 'childAttach'
-#    'childAttached': 'childChildAttach'
-#    'collectionPopulated': 'collectionPopulated'
-
-#    TODO: This is a work-around: it may be fixed by doing something better. This code was added to resolve an issue
-#    where the SurveyRunItemView was rendering twice, and the second time it rendered, updateSkipLogic() was not getting executed.
-  subRendered: ->
-#    console.log("subRendered")
-    currentSubtest = @children.findByIndex(0)
-    currentSubtest.updateSkipLogic()
-
-#  onDomRefresh: ->
-#    console.log("ACV: I get too attached to people.")
-
-#  renderCollection: ->
-##    console.log("renderCollection")
-
-#  childAttach: ->
-#    console.log("child attached.")
-#  childChildAttach: ->
-#    console.log("childChildAttach attached.")
-#  collectionPopulated: ->
-#    console.log("collectionPopulated.")
-
-#    This is simply used to alert the test it('Should contain a next question button') that the page has finished rendering.
-  nextQuestionRenderedBoom: ->
-#    console.log("nextQuestionRenderedBoom")
-
-  # Triggered by `add:child` of this.childEvents
-  addChildPostRender: ->
-    currentSubtest = @children.findByIndex(0)
-    focusMode = currentSubtest.model.getBoolean("focusMode")
-    if focusMode
-#      if !$( "#summary_container" ).length
-      if !@$el.find("#summary_container").length
-#        $('#subtest_wrapper').after $ "
-        @$el.find("#subtest_wrapper").after $ "
-              <div id='summary_container'></div>
-              <button class='navigation prev_question'>#{@text.previousQuestion}</button>
-              <button class='navigation next_question'>#{@text.nextQuestion}</button>
-            "
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-      @trigger "nextQuestionRendered"
-
-  nextQuestion: ->
-
-    currentSubtest = @children.findByIndex(0)
-
-    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
-
-    # show errors before doing anything if there are any
-    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
-
-    # find the non-skipped questions
-    isAvailable = []
-    for qv, i in currentSubtest.questionViews
-      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
-    isAvailable  = _.filter isAvailable, (e) => e > currentSubtest.questionIndex
-
-    # don't go anywhere unless we have somewhere to go
-    if isAvailable.length == 0
-      plannedIndex = currentSubtest.questionIndex
-    else
-      plannedIndex = Math.min.apply(plannedIndex, isAvailable)
-
-    if currentSubtest.questionIndex != plannedIndex
-      currentSubtest.questionIndex = plannedIndex
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-
-  # @todo
-  prevQuestion: ->
-
-    currentSubtest = @children.findByIndex(0)
-
-    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
-
-    # show errors before doing anything if there are any
-    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
-
-    # find the non-skipped questions
-    isAvailable = []
-    for qv, i in currentSubtest.questionViews
-      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
-    isAvailable  = _.filter isAvailable, (e) => e < currentSubtest.questionIndex
-
-    # don't go anywhere unless we have somewhere to go
-    if isAvailable.length == 0
-      plannedIndex = currentSubtest.questionIndex
-    else
-      plannedIndex = Math.max.apply(plannedIndex, isAvailable)
-
-    if currentSubtest.questionIndex != plannedIndex
-      currentSubtest.questionIndex = plannedIndex
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-
-  # @todo Documentation
-  i18n: ->
-    @text =
-      "next" : t("SubtestRunView.button.next")
-      "back" : t("SubtestRunView.button.back")
-      "skip" : t("SubtestRunView.button.skip")
-      "help" : t("SubtestRunView.button.help")
-      "previousQuestion" : t("SurveyRunView.button.previous_question")
-      "nextQuestion" : t("SurveyRunView.button.next_question")
-
-  #
-  # AssessmentCompositeView.initialize overrides Backbone.View.initialize
-  #
-  # @params
+  # Initialize
   #
   # options = {
   #   assessment: An Assessment Model.
   #   result: (optional) A Result model to pick up where you left off.
   # }
-  #
+
   initialize: (options) ->
 
     @i18n()
@@ -306,17 +127,48 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     @model.set('ui', ui)
     @.on "nextQuestionRendered", => @nextQuestionRenderedBoom()
 
-  triggerSaved: ->
-    console.log("Reslt has been saved to internal PouchDB.")
-    @trigger "result:saved"
-
-  triggerAnother: ->
-    console.log("User wishes to do another Assessment.")
-    @trigger "result:another"
-
   # @todo Documentation
   setChromeData:->
     @model.set('subtest', @subtestViews[@orderMap[@index]].model.toJSON())
+
+  #
+  # Configure the View
+  #
+
+  # for Backbone.View
+  events:
+    'click .subtest-next' : 'next'
+    'click .subtest-back' : 'back'
+    'click .subtest_help' : 'toggleHelp'
+    'click .skip'         : 'skip'
+    'click .next_question' : 'nextQuestion'
+    'click .prev_question' : 'prevQuestion'
+    'nextQuestionRendered': 'nextQuestionRenderedBoom'
+
+  # for Backbone.Marionette.CompositeView Composite Model
+  template: JST["AssessmentView"],
+
+  # for Backbone.Marionette.CompositeView
+  childViewContainer: '#subtest_wrapper',
+
+  # for Backbone.Marionette.CollectionView
+  childEvents:
+    'render:collection': 'addChildPostRender'
+    'subRendered': 'subRendered'
+
+  # @todo Documentation
+  i18n: ->
+    @text =
+      "next" : t("SubtestRunView.button.next")
+      "back" : t("SubtestRunView.button.back")
+      "skip" : t("SubtestRunView.button.skip")
+      "help" : t("SubtestRunView.button.help")
+      "previousQuestion" : t("SurveyRunView.button.previous_question")
+      "nextQuestion" : t("SurveyRunView.button.next_question")
+
+  #
+  # Handle Rendering and Closing.
+  #
 
   # @todo Documentation
   onRender:->
@@ -336,7 +188,6 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     @$el.find('#progress').progressbar value : ( ( @index + 1 ) / ( @model.subtests.length + 1 ) * 100 )
     Tangerine.progress.currentSubview.on "rendered",    => @flagRender "subtest"
     Tangerine.progress.currentSubview.on "subRendered", => @trigger "subRendered"
-#    Tangerine.progress.currentSubview.on "nextQuestionRendered", => @trigger "nextQuestionRendered"
 
     Tangerine.progress.currentSubview.on "next",    =>
       console.log("currentView next")
@@ -344,22 +195,6 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     Tangerine.progress.currentSubview.on "back",    => @step -1
 
     @flagRender "assessment"
-
-  # @todo Documentation
-  subTestRenderCollection:->
-    console.log("onRenderCollection")
-    currentSubtest = @children.findByIndex(0)
-    focusMode = currentSubtest.model.getBoolean("focusMode")
-    if focusMode
-      currentSubtest.updateQuestionVisibility()
-      currentSubtest.updateProgressButtons()
-
-  # @todo Documentation
-  flagRender: (object) ->
-    @rendered[object] = true
-
-    if @rendered.assessment && @rendered.subtest
-      @trigger "rendered"
 
   # @todo Documentation
   afterRender: ->
@@ -373,22 +208,43 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     Tangerine.nav.setStudent ""
 
   # @todo Documentation
-  abort: ->
-    @abortAssessment = true
-    @step 1
+  toggleHelp: -> @$el.find(".enumerator_help").fadeToggle(250)
 
   # @todo Documentation
-  skip: =>
-    currentView = Tangerine.progress.currentSubview
-    @result.add
-      name      : currentView.model.get "name"
-      data      : currentView.getSkipped()
-      subtestId : currentView.model.id
-      skipped   : true
-      prototype : currentView.model.get "prototype"
-    ,
-      success: =>
-        @reset 1
+  displaySkip: (skippable)->
+    if skippable
+      $( ".skip" ).show();
+    else
+      $( ".skip" ).hide();
+
+  # @todo Documentation
+  displayBack: (backable)->
+    if backable
+      $( ".subtest-back" ).removeClass("hidden");
+    else
+      $( ".subtest-back" ).addClass("hidden");
+
+  #
+  # Callbacks to handle flow of Subtests
+  #
+
+  # @todo Documentation
+  reset: (increment) ->
+    @rendered.subtest = false
+    @rendered.assessment = false
+    Tangerine.progress.currentSubview.close();
+    @index =
+      if @abortAssessment == true
+        @subtestViews.length-1
+      else
+        @index + increment
+    model = @subtestViews[@orderMap[@index]].model
+    # Now that we have our model we want to render, assign that model to the
+    # Composite View's Collection as the ONLY model to render.
+    @collection.models = [model]
+    @.trigger('assessment:reset')
+    @render()
+    window.scrollTo 0, 0
 
   # @todo Documentation
   step: (increment) ->
@@ -418,7 +274,186 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     @step -1
 
   # @todo Documentation
-  toggleHelp: -> @$el.find(".enumerator_help").fadeToggle(250)
+  abort: ->
+    @abortAssessment = true
+    @step 1
+
+  # @todo Documentation
+  skip: =>
+    currentView = Tangerine.progress.currentSubview
+    @result.add
+      name      : currentView.model.get "name"
+      data      : currentView.getSkipped()
+      subtestId : currentView.model.id
+      skipped   : true
+      prototype : currentView.model.get "prototype"
+    ,
+      success: =>
+        @reset 1
+
+
+  #
+  # Methods for handling Subtest Views
+  #
+
+  # for Backbone.Marionette.CompositeView
+  getChildView: (model) ->
+    model.parent = @
+    if !model.questions
+      model.questions     = new Questions()
+    if model.get("collection") == 'result'
+      currentSubview =  ResultItemView
+    else
+      prototypeName = model.get('prototype').titleize() + "RunItemView"
+      if  (prototypeName == 'SurveyRunItemView')
+        currentSubview = SurveyRunItemView
+      else if  (prototypeName == 'GridRunItemView')
+        currentSubview = GridRunItemView
+      else if  (prototypeName == 'GpsRunItemView')
+        currentSubview = GpsRunItemView
+      else if  (prototypeName == 'DatetimeRunItemView')
+        currentSubview = DatetimeRunItemView
+      else if  (prototypeName == 'IdRunItemView')
+        currentSubview = IdRunItemView
+      else if  (prototypeName == 'LocationRunItemView')
+        currentSubview = LocationRunItemView
+      else if  (prototypeName == 'ConsentRunItemView')
+        currentSubview = ConsentRunItemView
+      else
+        currentSubview =  null
+        console.log(prototypeName + "  Subview is not defined.")
+
+    @ready = true
+    return currentSubview
+
+  # for Backbone.Marionette.CompositeView
+  # Populate the questions in the model of the subtest.
+  childViewOptions: (model, index) ->
+    model.questions.fetch
+      viewOptions:
+        key: "question-#{model.id}"
+      success: (collection) =>
+        model.questions.sort()
+        model.collection = model.questions
+        @collection.models = collection.models
+      error: (model, err, cb) ->
+        console.log("childViewOptions id: " +  model.id + " err:" + JSON.stringify(err))
+
+  #    TODO: This is a work-around: it may be fixed by doing something better. This code was added to resolve an issue
+  #    where the SurveyRunItemView was rendering twice, and the second time it rendered, updateSkipLogic() was not getting executed.
+  subRendered: ->
+    currentSubtest = @children.findByIndex(0)
+    currentSubtest.updateSkipLogic()
+
+  # @todo Documentation
+  subTestRenderCollection:->
+    console.log("onRenderCollection")
+    currentSubtest = @children.findByIndex(0)
+    focusMode = currentSubtest.model.getBoolean("focusMode")
+    if focusMode
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+
+
+  #    This is simply used to alert the test it('Should contain a next question button') that the page has finished rendering.
+  nextQuestionRenderedBoom: ->
+    console.log("nextQuestionRenderedBoom")
+
+  # Triggered by `add:child` of this.childEvents
+  addChildPostRender: ->
+    currentSubtest = @children.findByIndex(0)
+    focusMode = currentSubtest.model.getBoolean("focusMode")
+    if focusMode
+      if !@$el.find("#summary_container").length
+        @$el.find("#subtest_wrapper").after $ "
+              <div id='summary_container'></div>
+              <button class='navigation prev_question'>#{@text.previousQuestion}</button>
+              <button class='navigation next_question'>#{@text.nextQuestion}</button>
+            "
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+      @trigger "nextQuestionRendered"
+
+
+  #
+  # Methods for handling Focus Mode on Survey Subtests.
+  #
+
+  nextQuestion: ->
+
+    currentSubtest = @children.findByIndex(0)
+
+    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
+
+    # show errors before doing anything if there are any
+    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
+
+    # find the non-skipped questions
+    isAvailable = []
+    for qv, i in currentSubtest.questionViews
+      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
+    isAvailable  = _.filter isAvailable, (e) => e > currentSubtest.questionIndex
+
+    # don't go anywhere unless we have somewhere to go
+    if isAvailable.length == 0
+      plannedIndex = currentSubtest.questionIndex
+    else
+      plannedIndex = Math.min.apply(plannedIndex, isAvailable)
+
+    if currentSubtest.questionIndex != plannedIndex
+      currentSubtest.questionIndex = plannedIndex
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+
+  # @todo
+  prevQuestion: ->
+
+    currentSubtest = @children.findByIndex(0)
+
+    currentQuestionView = currentSubtest.questionViews[currentSubtest.questionIndex]
+
+    # show errors before doing anything if there are any
+    return currentSubtest.showErrors(currentQuestionView) unless currentSubtest.isValid(currentQuestionView)
+
+    # find the non-skipped questions
+    isAvailable = []
+    for qv, i in currentSubtest.questionViews
+      isAvailable.push i if not (qv.isAutostopped or qv.isSkipped)
+    isAvailable  = _.filter isAvailable, (e) => e < currentSubtest.questionIndex
+
+    # don't go anywhere unless we have somewhere to go
+    if isAvailable.length == 0
+      plannedIndex = currentSubtest.questionIndex
+    else
+      plannedIndex = Math.max.apply(plannedIndex, isAvailable)
+
+    if currentSubtest.questionIndex != plannedIndex
+      currentSubtest.questionIndex = plannedIndex
+      currentSubtest.updateQuestionVisibility()
+      currentSubtest.updateProgressButtons()
+
+  #
+  # Trigger methods that should probably should not be used, trigger directly instead.
+  #
+
+  triggerSaved: ->
+    console.log("Reslt has been saved to internal PouchDB.")
+    @trigger "result:saved"
+
+  triggerAnother: ->
+    console.log("User wishes to do another Assessment.")
+    @trigger "result:another"
+
+  # @todo Documentation
+  flagRender: (object) ->
+    @rendered[object] = true
+
+    if @rendered.assessment && @rendered.subtest
+      @trigger "rendered"
+
+  #
+  # Helper methods for working with Grid Subtest.
+  #
 
   # @todo Documentation
   getGridScore: ->
@@ -435,23 +470,9 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     grid = @model.subtests.get @model.get("subtest").gridLinkId
     gridWasAutostopped = @result.gridWasAutostopped grid.id
 
-  # @todo Documentation
-  reset: (increment) ->
-    @rendered.subtest = false
-    @rendered.assessment = false
-    Tangerine.progress.currentSubview.close();
-    @index =
-      if @abortAssessment == true
-        @subtestViews.length-1
-      else
-        @index + increment
-    model = @subtestViews[@orderMap[@index]].model
-    # Now that we have our model we want to render, assign that model to the
-    # Composite View's Collection as the ONLY model to render.
-    @collection.models = [model]
-    @.trigger('assessment:reset')
-    @render()
-    window.scrollTo 0, 0
+  #
+  # Helper methods for working with Results.
+  #
 
   # @todo Documentation
   saveResult: ( currentView, increment ) ->
@@ -499,17 +520,3 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     else
       # maybe a better fallback
       return {correct:0,incorrect:0,missing:0,total:0}
-
-  # @todo Documentation
-  displaySkip: (skippable)->
-    if skippable
-      $( ".skip" ).show();
-    else
-      $( ".skip" ).hide();
-
-  # @todo Documentation
-  displayBack: (backable)->
-    if backable
-      $( ".subtest-back" ).removeClass("hidden");
-    else
-      $( ".subtest-back" ).addClass("hidden");

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -280,21 +280,6 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
 
     return currentSubview
 
-  # for Backbone.Marionette.CompositeView
-  # Populate the questions in the model of the subtest.
-  childViewOptions: (model, index) ->
-    # TODO: Every Subtest model does not have questions. Also this should have
-    # probably already been fetched by Assessment.deepFetch.
-    model.questions.fetch
-      viewOptions:
-        key: "question-#{model.id}"
-      success: (collection) =>
-        model.questions.sort()
-        model.collection = model.questions
-        @collection.models = collection.models
-      error: (model, err, cb) ->
-        console.log("childViewOptions id: " +  model.id + " err:" + JSON.stringify(err))
-
   # TODO: Documentation
   subTestRenderCollection:->
     console.log("onRenderCollection")

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -11,7 +11,7 @@
 #
 # Options:
 #   assessment (required) - An Assessment Model
-#   result: (optional) - A Result model to pick up where you left off.
+#   result (optional) - A Result model to pick up where you left off.
 #
 # Events:
 #   assessment:complete - Triggers when all Subtests have completed.

--- a/client/src/js/modules/assessment/AssessmentCompositeView.coffee
+++ b/client/src/js/modules/assessment/AssessmentCompositeView.coffee
@@ -2,13 +2,9 @@
 # AssessmentCompositeView
 #
 # AssessmentCompositeView renders every time a new subtest is shown. When next
-# or back is clicked, the reset(incrementToMoveToSubtestReferencedByViewIndex) method is
-# eventually called which calls render. `reset` method seems familiar because
-# there is `reset` on Backbone.Collection, but this reset on a View is it's own
-# thing. `AssessmentCompositeView.reset` and `AssessmentCompositeView.initialize`
-# ensure that there is only one model in `AssessmentCompositeView.collection` for
-# `AssessmentCompositeView.render` to render. Which Model should be in that
-# `AssessmentCompositeView.collection` is determined by `AssessmentCompositeView.index`.
+# or back is clicked, the step(incrementToMoveToSubtestReferencedByViewIndex) method is
+# eventually called which calls render.
+#
 # Listens for "result:saved" and "result:another" events triggered by the ResultItemView subtest and makes it
 # available for consumption (via triggerSaved and triggerAnother) by external users such as Widget.
 
@@ -63,6 +59,11 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     #
 
     @i18n()
+
+    #
+    # Set some globals for Skip Logic code to use.
+    #
+    Tangerine.tempData = {}
 
 
   #
@@ -134,10 +135,13 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
     # Get @currentChildView
     childViewClass = @getChildViewClass(@currentChildModel)
     @currentChildView = new childViewClass({model: @currentChildModel})
-    # @todo It looks like Skip Logic requires us to put this in a global. We should
+
+    # TODO: It looks like Skip Logic requires us to put this in a global. We should
     # look into how to localize this.
     Tangerine.progress =
       currentSubview : @currentChildView
+      index: @index
+    Tangerine.tempData.index = @index
 
     this.$el.html "
       <h1>#{@assessment.get('name')}</h1>
@@ -151,7 +155,7 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
       </div>
       "
 
-    # Attach @currentChildView
+    # Attach and Render @currentChildView.
     subtestWrapper = this.$el.find('#subtest_wrapper')
     $(subtestWrapper).html(@currentChildView.el)
     @currentChildView.render()
@@ -351,7 +355,7 @@ AssessmentCompositeView = Backbone.Marionette.CompositeView.extend
       currentSubtest.updateQuestionVisibility()
       currentSubtest.updateProgressButtons()
 
-  # TODO:
+  # TODO: Documentation.
   prevQuestion: ->
 
     currentSubtest = @children.findByIndex(0)

--- a/client/src/js/modules/result/Result.coffee
+++ b/client/src/js/modules/result/Result.coffee
@@ -15,6 +15,7 @@ class Result extends Backbone.Model
         'userAgent' : navigator.userAgent
 
       @set
+        'collection'        : 'result'
         'subtestData'       : []
         'start_time'        : (new Date()).getTime()
         'enumerator'        : Tangerine.user.name()

--- a/client/src/js/modules/subtest/SubtestRunItemView.coffee
+++ b/client/src/js/modules/subtest/SubtestRunItemView.coffee
@@ -45,6 +45,22 @@
     ui.text = @text
     @model.set('ui', ui)
 
+    @on 'rendered', =>
+      displayCode = @model.getString("displayCode")
+      console.log displayCode
+
+      if not _.isEmptyString(displayCode)
+
+        try
+          CoffeeScript.eval.apply(@, [displayCode])
+        catch error
+          name = ((/function (.{1,})\(/).exec(error.constructor.toString())[1])
+          message = error.message
+          alert "#{name}\n\n#{message}"
+          console.log "displayCode Error: " + JSON.stringify(error)
+
+      @prototypeView?.updateExecuteReady?(true)
+
   onRender: ->
 
     _render = =>
@@ -156,4 +172,4 @@
 
   next: -> @trigger "next"
   back: -> @trigger "back"
-  skip: -> @parent.skip()
+  skip: -> @trigger "skip"

--- a/client/src/js/modules/subtest/SubtestRunItemView.coffee
+++ b/client/src/js/modules/subtest/SubtestRunItemView.coffee
@@ -45,21 +45,19 @@
     ui.text = @text
     @model.set('ui', ui)
 
-    @on 'rendered', =>
-      displayCode = @model.getString("displayCode")
-      console.log displayCode
+  runDisplayCode: -> 
+    displayCode = @model.getString("displayCode")
+    console.log displayCode
 
-      if not _.isEmptyString(displayCode)
+    if not _.isEmptyString(displayCode)
 
-        try
-          CoffeeScript.eval.apply(@, [displayCode])
-        catch error
-          name = ((/function (.{1,})\(/).exec(error.constructor.toString())[1])
-          message = error.message
-          alert "#{name}\n\n#{message}"
-          console.log "displayCode Error: " + JSON.stringify(error)
-
-      @prototypeView?.updateExecuteReady?(true)
+      try
+        CoffeeScript.eval.apply(@, [displayCode])
+      catch error
+        name = ((/function (.{1,})\(/).exec(error.constructor.toString())[1])
+        message = error.message
+        alert "#{name}\n\n#{message}"
+        console.log "displayCode Error: " + JSON.stringify(error)
 
   onRender: ->
 

--- a/client/src/js/modules/subtest/SubtestRunItemView.coffee
+++ b/client/src/js/modules/subtest/SubtestRunItemView.coffee
@@ -1,51 +1,44 @@
- SubtestRunItemView = Backbone.Marionette.ItemView.extend
 
-  tagName: 'p'
-  template: JST["SubtestRunItemView"]
+###
+  SubtestRunItemView
 
-  className : "SubtestRunItemView"
+  This is the Base Class for all Subtest Views.
 
-  events:
-    'click .subtest-next' : 'next'
-    'click .subtest-back' : 'back'
-    'click .subtest_help' : 'toggleHelp'
-    'click .skip'         : 'skip'
+  Events:
+    next
+    back
+    skip
 
-  toggleHelp: -> @$el.find(".enumerator_help").fadeToggle(250)
+  Options:
+    model
+###
 
-  i18n: ->
-    @text =
-      "next" : t("SubtestRunView.button.next")
-      "back" : t("SubtestRunView.button.back")
-      "skip" : t("SubtestRunView.button.skip")
-      "help" : t("SubtestRunView.button.help")
+SubtestRunItemView = Backbone.Marionette.ItemView.extend
 
-  initialize: (options) ->
+  #
+  # Functions to override.
+  #
+  # TODO: Document more required functions.
 
-    @i18n()
+  # AssessmentCompositeView uses this for validation before proceeding to the next Subtest.
+  isValid: ->
+    true
 
-    @model       = options.model
-    @parent      = @model.parent
-    @fontStyle = "style=\"font-family: #{@model.get('fontFamily')} !important;\"" if @model.get("fontFamily") != ""
+  # AssessmentCompositeView uses this for adding to it's results before the next Subtest.
+  getResult: ->
+    return new Result()
 
-    @prototypeRendered = false
 
-    @delegateEvents()
+  #
+  # Helper functions.
+  #
 
-    ui = {}
-    ui.enumeratorHelp = if (@model.get("enumeratorHelp") || "") != "" then "<div class='enumerator_help' #{@fontStyle || ""}>#{@model.get 'enumeratorHelp'}</div>" else ""
-    ui.studentDialog  = if (@model.get("studentDialog")  || "") != "" then "<div class='student_dialog' #{@fontStyle || ""}>#{@model.get 'studentDialog'}</div>" else ""
-    ui.transitionComment  = if (@model.get("transitionComment")  || "") != "" then "<div class='student_dialog' #{@fontStyle || ""}>#{@model.get 'transitionComment'}</div> <br>" else ""
-
-    skippable = @model.get("skippable") == true || @model.get("skippable") == "true"
-    backable = ( @model.get("backButton") == true || @model.get("backButton") == "true" ) and @parent.index isnt 0
-
-    ui.skipButton = "<button class='skip navigation'>#{@text.skip}</button>" if skippable
-    ui.backButton = "<button class='subtest-back navigation'>#{@text.back}</button>" if backable
-    ui.text = @text
-    @model.set('ui', ui)
-
-  runDisplayCode: -> 
+  # Use this to run the displayCode property on your Subtest Model. You must
+  # include this where it makes sense for your Subtest View. For some Views, this
+  # can be included in the beginning of a render function, for others it needs
+  # to be later. Including this in the initialize function will result in potential
+  # events like `skip` being emitted before AssessmentCompositeView is listening.
+  runDisplayCode: ->
     displayCode = @model.getString("displayCode")
     console.log displayCode
 
@@ -59,115 +52,15 @@
         alert "#{name}\n\n#{message}"
         console.log "displayCode Error: " + JSON.stringify(error)
 
-  onRender: ->
 
-    _render = =>
-
-      # Prototype specific views follow this capitalization convention: GpsRunView
-      console.log @model
-      @prototypeView = new window["#{@model.get('prototype').titleize()}RunView"]
-        model  : @model
-        parent : @
-      @prototypeView.on "rendered",    => @flagRender("prototype")
-      @prototypeView.on "subRendered", => @trigger "subRendered"
-      @prototypeView.on "showNext",    => @showNext()
-      @prototypeView.on "hideNext",    => @hideNext()
-      @prototypeView.on "ready",       => @prototypeRendered = true
-      @prototypeView.setElement(@$el.find('#prototype_wrapper'))
-      @prototypeView.render()
-
-      @flagRender "subtest"
-
-    languageCode = @model.get("language")
-    if languageCode
-      i18n.setLng languageCode, (t) =>
-        window.t = t
-        _render()
-    else
-      i18n.setLng Tangerine.settings.get("language"), (t) =>
-        _render()
-
-  flagRender: ( flag ) =>
-    @renderFlags = {} if not @renderFlags
-    @renderFlags[flag] = true
-
-    if @renderFlags['subtest'] && @renderFlags['prototype']
-      @trigger "rendered"
-
-  afterRender: =>
-    @prototypeView?.afterRender?()
-    @onShow()
-
-  showNext: => @$el.find(".controlls").show()
-  hideNext: => @$el.find(".controlls").hide()
-
-  onShow: ->
-    displayCode = @model.getString("displayCode")
-
-    if not _.isEmptyString(displayCode)
-
-      try
-        CoffeeScript.eval.apply(@, [displayCode])
-      catch error
-        name = ((/function (.{1,})\(/).exec(error.constructor.toString())[1])
-        message = error.message
-        alert "#{name}\n\n#{message}"
-        console.log "displayCode Error: " + JSON.stringify(error)
-
-    @prototypeView?.updateExecuteReady?(true)
-
-  getGridScore: ->
-    link = @model.get("gridLinkId") || ""
-    if link == "" then return
-    grid = @parent.model.subtests.get @model.get("gridLinkId")
-    gridScore = @parent.result.getGridScore grid.id
-    gridScore
-
-  gridWasAutostopped: ->
-    link = @model.get("gridLinkId") || ""
-    if link == "" then return
-    grid = @parent.model.subtests.get @model.get("gridLinkId")
-    gridWasAutostopped = @parent.result.gridWasAutostopped grid.id
-
-  onClose: ->
-    @prototypeView?.close?()
-
-  isValid: ->
-    if not @prototypeRendered then return false
-    if @prototypeView.isValid?
-      return @prototypeView.isValid()
-    else
-      return false
-    true
-
-  showErrors: ->
-    @prototypeView.showErrors()
-
-  getSum: ->
-    if @prototypeView.getSum?
-      return @prototypeView.getSum()
-    else
-      # maybe a better fallback
-      return {correct:0,incorrect:0,missing:0,total:0}
-
-  abort: ->
-    @parent.abort()
-
-  getResult: ->
-    result = @prototypeView.getResult()
-    hash = @model.get("hash") if @model.has("hash")
-    return {
-      'body' : result
-      'meta' :
-        'hash' : hash
-    }
-
-  getSkipped: ->
-    if @prototypeView.getSkipped?
-      return @prototypeView.getSkipped()
-    else
-      throw "Prototype skipping not implemented"
+  #
+  # Methods instead of using @trigger because some Display Logic code depends on them.
+  #
+  # TODO: Add these to migrations so we can remove them. @trigger should be the standard.
 
   next: -> @trigger "next"
   back: -> @trigger "back"
   skip: -> @trigger "skip"
+  abort: ->
+    @trigger('abort')
+    @parent.abort()

--- a/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
@@ -37,8 +37,8 @@
     @parent.displaySkip(@skippable)
     @parent.displayBack(@backable)
 
+
   render: ->
-    @runDisplayCode()
     @$el.html "
         <div class='question'>
           <label>#{@model.get('prompt') || @text.defaultConsent}</label>
@@ -64,14 +64,14 @@
       mode      : "single"
       dataEntry : false
       answer    : answer or ""
-    
     @consentButton.setElement @$el.find(".consent-button")
     @consentButton.on "change", @onConsentChange
     @consentButton.render()
 
     @trigger "rendered"
     @trigger "ready"
-  
+    @runDisplayCode()
+
   isValid: ->
     if @confirmedNonConsent is false
       if @consentButton.answer is "yes"

--- a/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
@@ -22,7 +22,6 @@
       "help" : t("SubtestRunView.button.help")
 
   initialize: (options) ->
-    Tangerine.progress.currentSubview = @
     @i18n()
 
     @confirmedNonConsent = false
@@ -86,7 +85,6 @@
   testValid: ->
 #    console.log("ConsentRunItemView testValid.")
 #    if not @prototypeRendered then return false
-#    currentView = Tangerine.progress.currentSubview
     if @isValid?
       return @isValid()
     else

--- a/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
@@ -36,11 +36,9 @@
     @backable = ( @model.get("backButton") == true || @model.get("backButton") == "true" ) and @parent.index isnt 0
     @parent.displaySkip(@skippable)
     @parent.displayBack(@backable)
-    ConsentRunItemView.__super__.initialize.apply(this, arguments)
-
 
   render: ->
-
+    @runDisplayCode()
     @$el.html "
         <div class='question'>
           <label>#{@model.get('prompt') || @text.defaultConsent}</label>

--- a/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/ConsentRunItemView.coffee
@@ -1,4 +1,4 @@
- class ConsentRunItemView extends Backbone.Marionette.ItemView
+ class ConsentRunItemView extends SubtestRunItemView
 
   className : "ConsentRunView"
 
@@ -36,6 +36,7 @@
     @backable = ( @model.get("backButton") == true || @model.get("backButton") == "true" ) and @parent.index isnt 0
     @parent.displaySkip(@skippable)
     @parent.displayBack(@backable)
+    ConsentRunItemView.__super__.initialize.apply(this, arguments)
 
 
   render: ->

--- a/client/src/js/modules/subtest/prototypes/DatetimeRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/DatetimeRunItemView.coffee
@@ -13,7 +13,6 @@ class DatetimeRunItemView extends Backbone.Marionette.ItemView
       "help" : t("SubtestRunView.button.help")
 
   initialize: (options) ->
-    Tangerine.progress.currentSubview = @
     @i18n()
 
     @model  = options.model

--- a/client/src/js/modules/subtest/prototypes/DatetimeRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/DatetimeRunItemView.coffee
@@ -1,4 +1,4 @@
-class DatetimeRunItemView extends Backbone.Marionette.ItemView
+class DatetimeRunItemView extends SubtestRunItemView 
 
   template: JST["Datetime"]
   className: "datetimeitem"
@@ -59,6 +59,7 @@ class DatetimeRunItemView extends Backbone.Marionette.ItemView
     @model.set('formElements', formElements)
     @trigger "rendered"
     @trigger "ready"
+    @runDisplayLogic()
 
   getResult: ->
     result =

--- a/client/src/js/modules/subtest/prototypes/GpsRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/GpsRunItemView.coffee
@@ -9,7 +9,6 @@ class GpsRunItemView extends Backbone.Marionette.ItemView
     @updateDisplay()
 
   initialize: (options) ->
-    Tangerine.progress.currentSubview = @
     @i18n()
     @model   = options.model
     @parent = @model.parent

--- a/client/src/js/modules/subtest/prototypes/GpsRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/GpsRunItemView.coffee
@@ -1,4 +1,4 @@
-class GpsRunItemView extends Backbone.Marionette.ItemView
+class GpsRunItemView extends SubtestRunItemView
 
   className: "GpsRunItemView"
 
@@ -124,8 +124,10 @@ class GpsRunItemView extends Backbone.Marionette.ItemView
 
   render: ->
 
+    @runDisplayCode()
+
     if not Modernizr.geolocation
-      
+
       @$el.html @text.notSupported
 
       @position = @easify(null)

--- a/client/src/js/modules/subtest/prototypes/GridRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/GridRunItemView.coffee
@@ -1,4 +1,4 @@
-class GridRunItemView extends Backbone.Marionette.ItemView
+class GridRunItemView extends SubtestRunItemView
   className: "gridItem"
   template: JST["Grid"],
 
@@ -270,18 +270,6 @@ class GridRunItemView extends Backbone.Marionette.ItemView
         console.log "displaycodeFixed Error: " + message
 
     @prototypeView?.updateExecuteReady?(true)
-
-# @todo Documentation
-  skip: =>
-    @parent.result.add
-      name      : currentView.model.get "name"
-      data      : currentView.getSkipped()
-      subtestId : currentView.model.id
-      skipped   : true
-      prototype : currentView.model.get "prototype"
-    ,
-      success: =>
-        @parent.reset 1
 
   restartTimer: ->
     @stopTimer(simpleStop:true) if @timeRunning

--- a/client/src/js/modules/subtest/prototypes/GridRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/GridRunItemView.coffee
@@ -109,6 +109,8 @@ class GridRunItemView extends SubtestRunItemView
 
   onBeforeRender: ->
 
+    @runDisplayCode()
+
     done = 0
 
     startTimerHTML = "<div class='timer_wrapper'><button class='start_time time'>#{@text.start}</button><div class='timer'>#{@timer}</div></div>"
@@ -252,7 +254,6 @@ class GridRunItemView extends SubtestRunItemView
         $target.addClass "element_last"
 
   onShow: ->
-    displayCode = @model.getString("displayCode")
 
     if not _.isEmptyString(displayCode)
 #      displaycodeFixed = displayCode.replace("vm.currentView.subtestViews[vm.currentView.index].prototypeView","Tangerine.progress.currentSubview")

--- a/client/src/js/modules/subtest/prototypes/GridRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/GridRunItemView.coffee
@@ -37,7 +37,6 @@ class GridRunItemView extends Backbone.Marionette.ItemView
 
   initialize: (options) ->
 
-    Tangerine.progress.currentSubview = @
     @i18n()
 
     @fontStyle = "style=\"font-family: #{@model.get('fontFamily')} !important;\"" if @model.get("fontFamily") != ""
@@ -274,7 +273,6 @@ class GridRunItemView extends Backbone.Marionette.ItemView
 
 # @todo Documentation
   skip: =>
-    currentView = Tangerine.progress.currentSubview
     @parent.result.add
       name      : currentView.model.get "name"
       data      : currentView.getSkipped()

--- a/client/src/js/modules/subtest/prototypes/IdRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/IdRunItemView.coffee
@@ -35,6 +35,8 @@ class IdRunItemView extends SubtestRunItemView
     @parent.displayBack(@backable)
 
   render: ->
+    
+    @runDisplayCode()
 
     unless @dataEntry
       previous = @model.parent.result.getByHash(@model.get('hash'))

--- a/client/src/js/modules/subtest/prototypes/IdRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/IdRunItemView.coffee
@@ -1,4 +1,5 @@
-class IdRunItemView extends Backbone.Marionette.ItemView
+class IdRunItemView extends SubtestRunItemView
+
   template: JST["ItemView"],
 
   className: "idItem"

--- a/client/src/js/modules/subtest/prototypes/IdRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/IdRunItemView.coffee
@@ -25,7 +25,6 @@ class IdRunItemView extends SubtestRunItemView
     @dataEntry = options.dataEntry
 
     @validator = new CheckDigit
-    Tangerine.progress.currentSubview = @
     labels = {}
     labels.text = @text
     @model.set('labels', labels)
@@ -72,9 +71,6 @@ class IdRunItemView extends SubtestRunItemView
     @updateNavigation()
 
   testValid: ->
-#    console.log("IdRinItemView testValid.")
-#    if not @prototypeRendered then return false
-#    currentView = Tangerine.progress.currentSubview
     if @isValid?
       return @isValid()
     else

--- a/client/src/js/modules/subtest/prototypes/LocationRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/LocationRunItemView.coffee
@@ -9,12 +9,11 @@ class LocationRunItemView extends Backbone.Marionette.ItemView
     "change select" : "onSelectChange"
 
   i18n: ->
-    @text = 
+    @text =
       clear : t("LocationRunView.button.clear")
       "help" : t("SubtestRunView.button.help")
 
   initialize: (options) ->
-    Tangerine.progress.currentSubview = @
     @i18n()
 
     @model  = options.model
@@ -255,9 +254,6 @@ class LocationRunItemView extends Backbone.Marionette.ItemView
     true
 
   testValid: ->
-#    console.log("LocationRunItemView testValid.")
-  #    if not @prototypeRendered then return false
-#    currentView = Tangerine.progress.currentSubview
     if @isValid?
       return @isValid()
     else

--- a/client/src/js/modules/subtest/prototypes/LocationRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/LocationRunItemView.coffee
@@ -1,4 +1,4 @@
-class LocationRunItemView extends Backbone.Marionette.ItemView
+class LocationRunItemView extends SubtestRunItemView
 
   className: "LocationRunItemView"
 
@@ -104,6 +104,8 @@ class LocationRunItemView extends Backbone.Marionette.ItemView
     return @li templateInfo
 
   render: ->
+
+    @runDisplayCode()
 
     schoolListElements = ""
 

--- a/client/src/js/modules/subtest/prototypes/SurveyRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/SurveyRunItemView.coffee
@@ -1,4 +1,4 @@
-class SurveyRunItemView extends Backbone.Marionette.CompositeView
+class SurveyRunItemView extends SubtestRunItemView
 
   template: JST["Survey"],
   childView: QuestionRunItemView,
@@ -346,6 +346,8 @@ class SurveyRunItemView extends Backbone.Marionette.CompositeView
 
   onRender: ->
 
+    @runDisplayCode()
+
     notAskedCount = 0
     if @model.questions?
       @model.questions.models.forEach (question, i) =>
@@ -430,18 +432,6 @@ class SurveyRunItemView extends Backbone.Marionette.CompositeView
 
 #  onDomRefresh: ->
 #    console.log("I get too attached to people.")
-
-# @todo Documentation
-  skip: =>
-    @parent.result.add
-      name      : currentView.model.get "name"
-      data      : currentView.getSkipped()
-      subtestId : currentView.model.id
-      skipped   : true
-      prototype : currentView.model.get "prototype"
-    ,
-      success: =>
-        @parent.reset 1
 
   # Doubt this is happening after the question was rendered. TODO: find the right place.
   onQuestionRendered:->

--- a/client/src/js/modules/subtest/prototypes/SurveyRunItemView.coffee
+++ b/client/src/js/modules/subtest/prototypes/SurveyRunItemView.coffee
@@ -26,8 +26,6 @@ class SurveyRunItemView extends Backbone.Marionette.CompositeView
     @renderCount   = 0
     @notAskedCount = 0
     @notAskedIds = []
-    vm =
-      currentView: Tangerine.progress.currentSubview
 #    @childViewOptions =
 #        parent: this
 
@@ -48,7 +46,6 @@ class SurveyRunItemView extends Backbone.Marionette.CompositeView
 #        @model.collection.models = collection.models
 #        @render()
 
-    Tangerine.progress.currentSubview = @
     labels = {}
     labels.text = @text
     @model.set('labels', labels)
@@ -218,15 +215,7 @@ class SurveyRunItemView extends Backbone.Marionette.CompositeView
     return true
 
   testValid: ->
-#    console.log("SurveyRinItem testValid.")
-#    if not @prototypeRendered then return false
-#    currentView = Tangerine.progress.currentSubview
-#    if @isValid?
-#    console.log("testvalid: " + @isValid?)
     return @isValid()
-#    else
-#      return false
-#    true
 
 
   # @TODO this should probably be returning multiple, single type hash values
@@ -444,7 +433,6 @@ class SurveyRunItemView extends Backbone.Marionette.CompositeView
 
 # @todo Documentation
   skip: =>
-    currentView = Tangerine.progress.currentSubview
     @parent.result.add
       name      : currentView.model.get "name"
       data      : currentView.getSkipped()
@@ -482,7 +470,6 @@ class SurveyRunItemView extends Backbone.Marionette.CompositeView
     @rendered.assessment = false
     #    currentView = @subtestViews[@orderMap[@index]]
     #    currentView.close()
-    Tangerine.progress.currentSubview.close();
     @index =
       if @abortAssessment == true
         @subtestViews.length-1


### PR DESCRIPTION
Refactor `AssessmentCompositeView->SubtestRunItemView->{Prototype}RunItemView` to be`AssessmentCompositeView->{{Prototype}RunItemView that extends SubtesRunItemViewRunItemView}`.
- [Video walkthrough of this code](https://youtu.be/xGW996VydpU)
## Improvements in this PR
- AssessmentCompositeView and SubtestRunItemView are well documented, improved code flow, and less cruft.
- SubtestRunItemView is now the Base Class for all Subtest View classes in the prototypes folder. This results in less duplication of code and because SubtestRunItemView is well documented, it's easier to understand how the expectations of a Subtest View and how it will behave.
## Known issues
- [ ] Focus mode showing up blank.
- [ ] Missing some variables that Display Logic code sometimes depends on. Turns out to be a lot of Global variables. Global variables that we were sometimes using in Views. We're no longer using those in the Views but not all of the Globals are implemented for the Display Logic. It would be nice to design a way to pass those variable needed to the Display Logic without globals.
- [ ] Transition comments not currently implemented. There is some parts of the template that needed some extra variables that we haven't wired up yet so they are removed from the inline markup in the render function.
- [ ] No Subtest View cleanup.
## Things to check
- [ ] Use of the widget route in editor. 
- [ ] Check that output of results are still what we expect.