### PR TITLE
V3.x.x  csv export using blob api for large file support

### DIFF
--- a/client-v3/lite-server/app.js
+++ b/client-v3/lite-server/app.js
@@ -31,8 +31,8 @@ async function setup() {
 
   // Set up the app database.
   try {
-    await http.put(`${DB_ADMIN_URL}/todos`);
-    console.log("Todos database created.");
+    await http.put(`${DB_ADMIN_URL}/${config.appDatabase}`);
+    console.log("App database created.");
   }
   catch (err) {
     console.log("We already have an app database."); 

--- a/client-v3/src/app/tangerine-forms/components/tangerine-form-links/tangerine-form-links.component.html
+++ b/client-v3/src/app/tangerine-forms/components/tangerine-form-links/tangerine-form-links.component.html
@@ -2,3 +2,4 @@
 <button (click)="newSession()">new session</button> 
 <button (click)="toggleSessions()">{{toggleSessionText}}</button>
 <tangerine-form-sessions *ngIf="showSessions" [formId]="formId" [link]="link"></tangerine-form-sessions>
+<tangerine-form-sessions-csv></tangerine-form-sessions-csv>

--- a/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.html
+++ b/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.html
@@ -1,1 +1,1 @@
-<button (click)="downloadCsv()">{{status}}</button>
+<button (click)="do()">{{status}}</button>

--- a/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.html
+++ b/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.html
@@ -1,0 +1,1 @@
+<button (click)="downloadCsv()">{{status}}</button>

--- a/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.spec.ts
+++ b/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TangerineFormSessionsCsvComponent } from './tangerine-form-sessions-csv.component';
+
+describe('TangerineFormSessionsCsvComponent', () => {
+  let component: TangerineFormSessionsCsvComponent;
+  let fixture: ComponentFixture<TangerineFormSessionsCsvComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TangerineFormSessionsCsvComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TangerineFormSessionsCsvComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.ts
+++ b/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.ts
@@ -15,7 +15,7 @@ export class TangerineFormSessionsCsvComponent implements OnInit {
   @Input() link: string;
   sessions: Array<TangerineFormSession> = [];
   service: TangerineFormSessionsService;
-  status = 'preparing csv';
+  status = 'click to prepare csv';
 
   window: any;
   constructor(service: TangerineFormSessionsService, windowRef: WindowRef) {
@@ -24,8 +24,21 @@ export class TangerineFormSessionsCsvComponent implements OnInit {
   }
 
   async ngOnInit() {
-    this.sessions = await this.service.getAll(this.formId);
-    this.status = 'download csv';
+  }
+
+  async do() {
+    if (this.status === 'click to prepare csv') {
+      this.status = 'getting all form sessions';
+      setTimeout(async () => {
+        // @TODO: Instead of getting all, get one at a time and append to the blob
+        // so we don't end up creating a big javascript array in memory.
+        this.sessions = await this.service.getAll(this.formId);
+        this.status = 'download csv';
+      }, 2000);
+    }
+    else {
+      this.downloadCsv();
+    }
   }
 
   downloadCsv() {
@@ -79,13 +92,13 @@ export class TangerineFormSessionsCsvComponent implements OnInit {
   }
 
   generateCSV(filename, rows) {
-    let csvBuilder = new BlobBuilder();
+    const csvRows = [];
+    let blob = new Blob([], {type: 'application/csv;charset=utf-8;' });
     for (const row of rows) {
-      csvBuilder.append(rows.join(',') + '\n');
+      blob = new Blob([blob, rows.join(',') + '\n'], { type: 'application/csv;charset=utf-8;' });
     }
     console.log('creating element');
     const element = this.window.document.createElement('a');
-    const blob = csvBuilder.getBlob('application/csv;charset=utf-8;');
     element.setAttribute('href', URL.createObjectURL(blob));
     element.setAttribute('download', filename);
     console.log('appending to DOM');

--- a/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.ts
+++ b/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.ts
@@ -79,15 +79,13 @@ export class TangerineFormSessionsCsvComponent implements OnInit {
   }
 
   generateCSV(filename, rows) {
-    let csvString = '';
+    let csvBuilder = new BlobBuilder();
     for (const row of rows) {
-      csvString += rows.join(',') + '\n';
+      csvBuilder.append(rows.join(',') + '\n');
     }
     console.log('creating element');
     const element = this.window.document.createElement('a');
-    const blob = new Blob([ csvString ], {
-              type : 'application/csv;charset=utf-8;'
-          });
+    const blob = csvBuilder.getBlob('application/csv;charset=utf-8;');
     element.setAttribute('href', URL.createObjectURL(blob));
     element.setAttribute('download', filename);
     console.log('appending to DOM');

--- a/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.ts
+++ b/client-v3/src/app/tangerine-forms/components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component.ts
@@ -1,0 +1,101 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { TangerineFormSessionsService } from '../../services/tangerine-form-sessions.service';
+import { TangerineFormSession } from '../../models/tangerine-form-session';
+import { WindowRef } from '../../../core/window-ref.service';
+import * as Csv from 'csv-file-creator';
+declare const Buffer;
+@Component({
+  selector: 'tangerine-form-sessions-csv',
+  templateUrl: './tangerine-form-sessions-csv.component.html',
+  styleUrls: ['./tangerine-form-sessions-csv.component.css']
+})
+export class TangerineFormSessionsCsvComponent implements OnInit {
+
+  @Input() formId: string;
+  @Input() link: string;
+  sessions: Array<TangerineFormSession> = [];
+  service: TangerineFormSessionsService;
+  status = 'preparing csv';
+
+  window: any;
+  constructor(service: TangerineFormSessionsService, windowRef: WindowRef) {
+    this.window = windowRef.nativeWindow;
+    this.service = service;
+  }
+
+  async ngOnInit() {
+    this.sessions = await this.service.getAll(this.formId);
+    this.status = 'download csv';
+  }
+
+  downloadCsv() {
+    // TODO: Flatten all sessions.
+    const flatSessions = [];
+    this.sessions.forEach((session) => {
+      flatSessions.push(this.flatten(session));
+    });
+    // Get unique keys.
+    let keys = [];
+    flatSessions.forEach((session) => {
+      keys = keys.concat(Object.keys(session).filter(function (item) {
+        return keys.indexOf(item) < 0;
+      }));
+    });
+    const rows = [keys];
+    flatSessions.forEach((session) => {
+      const row = [];
+      keys.forEach((key) => {
+        row.push(session[key]);
+      });
+      rows.push(row);
+    });
+    this.generateCSV(this.formId + '.csv', rows);
+  }
+
+  // Flatten a deep object.
+  // From https://gist.github.com/penguinboy/762197#gistcomment-2130571
+  flatten(object: object, separator = '.'): object {
+    const isValidObject = (value: {}): boolean => {
+        if (!value) {
+            return false;
+        }
+
+        const isArray = Array.isArray(value);
+        const isBuffer = Buffer.isBuffer(value);
+        const isΟbject = Object.prototype.toString.call(value) === '[object Object]';
+        const hasKeys = !!Object.keys(value).length;
+
+        return !isArray && !isBuffer && isΟbject && hasKeys;
+    };
+
+    const walker = (child: {}, path: Array<string> = []): Object => {
+        return Object.assign({}, ...Object.keys(child).map(key => isValidObject(child[key])
+            ? walker(child[key], path.concat([key]))
+            : { [path.concat([key]).join(separator)]: child[key] })
+        );
+    };
+
+    return Object.assign({}, walker(object));
+  }
+
+  generateCSV(filename, rows) {
+    let csvString = '';
+    for (const row of rows) {
+      csvString += rows.join(',') + '\n';
+    }
+    console.log('creating element');
+    const element = this.window.document.createElement('a');
+    const blob = new Blob([ csvString ], {
+              type : 'application/csv;charset=utf-8;'
+          });
+    element.setAttribute('href', URL.createObjectURL(blob));
+    element.setAttribute('download', filename);
+    console.log('appending to DOM');
+    element.style.display = 'none';
+    this.window.document.body.appendChild(element);
+    console.log('Triggering download.');
+    element.click();
+    console.log('Cleaning up.');
+    this.window.document.body.removeChild(element);
+  }
+}

--- a/client-v3/src/app/tangerine-forms/tangerine-forms.module.ts
+++ b/client-v3/src/app/tangerine-forms/tangerine-forms.module.ts
@@ -31,6 +31,7 @@ import { TangerineFormLinksComponent } from './components/tangerine-form-links/t
 import { TangerineFormSessionsComponent } from './components/tangerine-form-sessions/tangerine-form-sessions.component';
 import { TangerineFormSessionItemComponent } from './components/tangerine-form-session-item/tangerine-form-session-item.component';
 import { TangerineFormTimedComponent } from './components/tangerine-form-timed/tangerine-form-timed.component';
+import { TangerineFormSessionsCsvComponent } from './components/tangerine-form-sessions-csv/tangerine-form-sessions-csv.component';
 
 
 @NgModule({
@@ -67,6 +68,7 @@ import { TangerineFormTimedComponent } from './components/tangerine-form-timed/t
     TangerineFormSessionsComponent,
     TangerineFormSessionItemComponent,
     TangerineFormTimedComponent,
+    TangerineFormSessionsCsvComponent,
  //   TangerineFormCarouselComponent
   ],
   exports: [


### PR DESCRIPTION
Blob is an API that allows you to manipulate files in code and on disk. It's what the File API is built on top of. You can append to blobs and they have a URL on disk so you don't have to insert their file contents into the DOM like we have in the past. 

https://developer.mozilla.org/en-US/docs/Web/API/Blob

There is a bug in this code currently where, for example, if you export 15,000 form responses it will put those 15,000 form responses on a line in a CSV 15,000 times which is like generating a CSV with 225 million form responses. Watch out for that! Funny thing is I know that because my browser actually was able to do that. It took ten minutes to render, never took more than 4GB of RAM (I have 16GB on my MBP) and generated a file 26GB large. 

<img width="1240" alt="screen shot 2017-07-26 at 12 39 50 am" src="https://user-images.githubusercontent.com/156575/28620628-c03f5902-71db-11e7-848f-2856b1f8da51.png">


We can reduce RAM usage by by not hitting the pouchdb all docs, instead get them in batches and append to the blob.

https://developer.mozilla.org/en-US/docs/Web/API/Blob