### PR TITLE
v3.x.x  `npm run publish-to-dat`

### DIFF
--- a/client-v3/.gitignore
+++ b/client-v3/.gitignore
@@ -1,5 +1,9 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+# Dat
+.dat
+dat
+
 # Angular Pages
 src/app/pages
 

--- a/client-v3/package-lock.json
+++ b/client-v3/package-lock.json
@@ -162,6 +162,11 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.1.tgz",
       "integrity": "sha1-+QFKVmm3RkGOFFFo3qSaBErhWQA="
     },
+    "abstract-random-access": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/abstract-random-access/-/abstract-random-access-1.1.2.tgz",
+      "integrity": "sha1-mo6sj/eYZvP5tLsUQ8p3jxWYrto="
+    },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
@@ -171,8 +176,7 @@
     "acorn": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
-      "dev": true
+      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0="
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
@@ -239,8 +243,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "angular-pages": {
       "version": "0.1.1",
@@ -268,6 +271,11 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true
     },
+    "ansi-diff-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-diff-stream/-/ansi-diff-stream-1.2.0.tgz",
+      "integrity": "sha1-6zJcIKw2I+zVkgEakpXXbZfeRg4="
+    },
     "ansi-escapes": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
@@ -283,14 +291,12 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -301,8 +307,12 @@
     "anymatch": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc="
+    },
+    "ap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ap/-/ap-0.1.0.tgz",
+      "integrity": "sha1-2KPyZhU3k5ihtTymzBpmag+/4VA="
     },
     "app-root-path": {
       "version": "2.0.1",
@@ -315,6 +325,18 @@
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true
+    },
+    "append-tree": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/append-tree/-/append-tree-2.3.6.tgz",
+      "integrity": "sha512-GVOpyVDH6ynEQykoKN7kXB3uewyZSlcCoBoelffCgBDCSWQTNlTOhnJ85ofxMmsNmGifgAgXVTxs2LP5BOSfhA==",
+      "dependencies": {
+        "varint": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+          "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+        }
+      }
     },
     "aproba": {
       "version": "1.1.2",
@@ -353,14 +375,12 @@
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8="
     },
     "arr-flatten": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
-      "dev": true
+      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -378,6 +398,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k="
+    },
+    "array-lru": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-lru/-/array-lru-1.1.1.tgz",
+      "integrity": "sha1-DH4bTgIq4Wb/HoRIxZXzGB/NMzc="
     },
     "array-slice": {
       "version": "0.2.3",
@@ -400,8 +425,7 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "arraybuffer.slice": {
       "version": "0.0.6",
@@ -412,8 +436,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.5",
@@ -471,6 +494,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atomic-batcher": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
+      "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -566,6 +594,11 @@
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
+    "base64-to-uint8array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64-to-uint8array/-/base64-to-uint8array-1.0.0.tgz",
+      "integrity": "sha512-drjWQcees55+XQSVHYxiUF05Fj6ko3XJUoxykZEXbm0BMmNz2ieWiZGJ+6TFWnjN2saucG6pI13LS92O4kaiAg=="
+    },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
@@ -583,6 +616,11 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true
+    },
+    "bencode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-1.0.0.tgz",
+      "integrity": "sha512-N+VOSP5MkoX+xgnp6Y056iCY5TmCZg9rgPNPQe0bIiXchxYFP4vs/Tf0dTdQ+qQhP7HM2gvfFq+sUVjQsGy5Zw=="
     },
     "better-assert": {
       "version": "1.0.2",
@@ -607,6 +645,23 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
     },
+    "bitfield-rle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bitfield-rle/-/bitfield-rle-2.1.0.tgz",
+      "integrity": "sha1-rinpOCp7pImN6fSLsj/TOMT73Pg=",
+      "dependencies": {
+        "varint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-4.0.1.tgz",
+          "integrity": "sha1-SQgpuULSSEY7KzUJeZXDv3NxmOk="
+        }
+      }
+    },
+    "bittorrent-dht": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-7.6.0.tgz",
+      "integrity": "sha512-KinBmIQo4wL742f+4QjMjRHrW6GzDLUeeO+JK5dcGWyOeSKhkPQ7wditN/h0hK88wYjatIAYOC1fEU/WUI3ecw=="
+    },
     "bl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
@@ -618,6 +673,16 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
         }
       }
+    },
+    "blake2b": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.2.tgz",
+      "integrity": "sha1-aIDt3KNc/t6SxPsnJCITNPmJFFo="
+    },
+    "blake2b-wasm": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.3.tgz",
+      "integrity": "sha512-4Wt1zsffEytMMGkRxjs5Ttm2mw+0vJgWnQlE1vdA3RcL8JKddajtnKbXv8yj1Hjciqeu9JMh07gVp77kiHK+Yg=="
     },
     "blob": {
       "version": "0.0.4",
@@ -647,6 +712,11 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
       "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
       "dev": true
+    },
+    "body": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-0.1.0.tgz",
+      "integrity": "sha1-5xT+KM2ISKo0zfLJ8kK74uFdHNg="
     },
     "body-parser": {
       "version": "1.17.2",
@@ -719,8 +789,12 @@
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
+    },
+    "brfs": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.3.tgz",
+      "integrity": "sha1-22ddb16SPm3wh/ylhZyQkKrtMhY="
     },
     "brorand": {
       "version": "1.1.0",
@@ -776,10 +850,30 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true
     },
+    "buffer-alloc-unsafe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.0.0.tgz",
+      "integrity": "sha1-R0qojzTnvHX6MR0uZFdAnFhGw/4="
+    },
+    "buffer-equal": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+    },
+    "buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
+    },
     "buffer-from": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
       "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114="
+    },
+    "buffer-indexof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz",
+      "integrity": "sha1-9U9kfE9OJSKLqmVqLlfkPV8nCYI="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -799,11 +893,33 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bulk-write-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.3.tgz",
+      "integrity": "sha1-0pyjhfvVPzV67lvT0wKHMrYq4nU=",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+        }
+      }
+    },
     "bytes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
       "integrity": "sha1-1baAoWW2IBc5rLYRVCqrwtjOsHA=",
       "dev": true
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "callsite": {
       "version": "1.0.0",
@@ -870,13 +986,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "dependencies": {
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -921,11 +1035,21 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true
     },
+    "cli-truncate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.0.0.tgz",
+      "integrity": "sha1-IeuR9Hs/ZWDwBNt3p2m0Zo2cVRg="
+    },
     "cli-width": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
+    },
+    "cliclopts": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
+      "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8="
     },
     "cliui": {
       "version": "3.2.0",
@@ -981,6 +1105,11 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "codecs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/codecs/-/codecs-1.2.0.tgz",
+      "integrity": "sha1-UUhUnj0VbF+gU9fLtBlxWgz0PRY="
+    },
     "codelyzer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-2.0.1.tgz",
@@ -1020,8 +1149,7 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combine-lists": {
       "version": "1.0.1",
@@ -1093,6 +1221,23 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+        }
+      }
     },
     "concurrently": {
       "version": "3.5.0",
@@ -1170,6 +1315,11 @@
       "integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk=",
       "dev": true
     },
+    "connections": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/connections/-/connections-1.4.2.tgz",
+      "integrity": "sha1-eJBIK/XHGvbFyhkr4xNq7XRCiq0="
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -1199,6 +1349,11 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
       "dev": true
+    },
+    "content-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/content-types/-/content-types-0.1.0.tgz",
+      "integrity": "sha1-DnkLOr/vkPbst3roWF25CZyvdXg="
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -1233,6 +1388,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "corsify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/corsify/-/corsify-2.1.0.tgz",
+      "integrity": "sha1-EaRbxHqzDFTQC7hp6hgC+82aCdA="
     },
     "cosmiconfig": {
       "version": "2.1.3",
@@ -1281,6 +1441,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+    },
+    "crypto": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
+      "integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
     },
     "crypto-browserify": {
       "version": "3.11.0",
@@ -1371,6 +1536,11 @@
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -1388,6 +1558,100 @@
         }
       }
     },
+    "dat": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/dat/-/dat-13.7.0.tgz",
+      "integrity": "sha512-u6ASSwnHFfGQ7eCLULRj9lgZ0HMV9TLHVCDfE3t3vVBD4yJushkPbiX27PTSt/yXUHg1uCs68p9Lnhg2SGwtyw==",
+      "dependencies": {
+        "bytes": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
+          "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "dat-dns": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dat-dns/-/dat-dns-1.3.2.tgz",
+      "integrity": "sha512-Tbk9UacyHcnxWXOeU3UHYkMfnH5VyxcuKXLFjZcUddRqOO4aTA5MV4l3mLmYNnb8TXvsG7ED+7rhfVtFiTXlPQ=="
+    },
+    "dat-doctor": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/dat-doctor/-/dat-doctor-1.3.0.tgz",
+      "integrity": "sha512-iSW3E1u0NUgbLiFHnN4d8aPYPbJ/bF6WvlwNOK+S+NRIaoR6e3TIgMEwzjKANjuldj+/IlLswwC3Mg8gyQqHng=="
+    },
+    "dat-encoding": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/dat-encoding/-/dat-encoding-4.0.2.tgz",
+      "integrity": "sha1-sBBo/g0IDz0+SYWgxK0ht8FGdfY="
+    },
+    "dat-ignore": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dat-ignore/-/dat-ignore-1.1.1.tgz",
+      "integrity": "sha512-dLTveSPTqdvAQ4ROw+3dK3K74WSRidF/r/Tt4vr4/eG2wQTYX9Uxp2YBBe24Plq3QAN+joFzUPN/6gvmR2khrA=="
+    },
+    "dat-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dat-json/-/dat-json-1.0.0.tgz",
+      "integrity": "sha1-JskGwGhQyzDK/S6Aa7keHGtqP3k="
+    },
+    "dat-link-resolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dat-link-resolve/-/dat-link-resolve-1.1.1.tgz",
+      "integrity": "sha512-xwzZ9/8j+Pn8td4NKYRTafchQxJWKvr/0BLnEmCI8DwyqhCsFtwzhHBLHKXWK761+nm2hElu+xYfkA8ym9c81A==",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "dat-log": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dat-log/-/dat-log-1.1.1.tgz",
+      "integrity": "sha1-aUSayKNoWTqPcZArKCOQw2VatLg="
+    },
+    "dat-node": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/dat-node/-/dat-node-3.5.1.tgz",
+      "integrity": "sha512-z1kUQ823PVqZuemP3YWDPIvbQpLaaWGaKcf6MOVBZr3HHVvRRydxTqnidP0sQg3FhbOnxldSRNCO4ZvQ7swPdQ=="
+    },
+    "dat-registry": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dat-registry/-/dat-registry-3.0.3.tgz",
+      "integrity": "sha512-BWxQlSFQWc5BsIepOw9ZvbzsKkb2h+3lfCFC5pisNjzLdRbvyRuCQn0MicsBYeyCxAe/bNah21KgVPYbp6G1Ng=="
+    },
+    "dat-secret-storage": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dat-secret-storage/-/dat-secret-storage-4.0.0.tgz",
+      "integrity": "sha1-AbIZpbwWGe/A9YEio8bOux64tAo="
+    },
+    "dat-storage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dat-storage/-/dat-storage-1.0.3.tgz",
+      "integrity": "sha512-6qTeWDLCbn4DG5NmTSnCAikivjXXn5ukMLafEbqBn/15zcqdpNgsOx/QnCqXdDoAeP1WWXjJp3GBDtls/et3bA=="
+    },
+    "dat-swarm-defaults": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dat-swarm-defaults/-/dat-swarm-defaults-1.0.0.tgz",
+      "integrity": "sha1-un1YwwnPYMOSSvrYabdRkrYf41Q="
+    },
     "date-fns": {
       "version": "1.28.5",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz",
@@ -1399,6 +1663,11 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "datland-swarm-defaults": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/datland-swarm-defaults/-/datland-swarm-defaults-1.0.2.tgz",
+      "integrity": "sha1-J3uJWjnxqn+WpJWgL7NmKl7Z8uA="
+    },
     "debug": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
@@ -1409,6 +1678,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -1523,6 +1797,55 @@
         }
       }
     },
+    "directory-index-html": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/directory-index-html/-/directory-index-html-2.1.0.tgz",
+      "integrity": "sha1-TVr8UYftumfsarDlX2QioOLLczg="
+    },
+    "discovery-channel": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.4.4.tgz",
+      "integrity": "sha1-M2MZazS61fQj4T8AE31s23yQJys=",
+      "dependencies": {
+        "thunky": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+          "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
+        }
+      }
+    },
+    "discovery-swarm": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-4.4.0.tgz",
+      "integrity": "sha512-oRT9RCrMtbC5fUTa71WCBG6nxxy3LFVkTs/YYU82TTErUL+Zn+/19jyml4LhuhLoImHn0z8Um3MOFkDo7MEZdg=="
+    },
+    "dns-discovery": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/dns-discovery/-/dns-discovery-5.6.0.tgz",
+      "integrity": "sha1-hZT1/zUzfA7y5Jegf1xAwMWGtuQ=",
+      "dependencies": {
+        "lru": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lru/-/lru-2.0.1.tgz",
+          "integrity": "sha1-+XmHHhYuP1yiVL5GhExT1MU2RUQ="
+        }
+      }
+    },
+    "dns-packet": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.1.tgz",
+      "integrity": "sha1-I2nUUDivBF84mOb6VoYq7T9AKWw="
+    },
+    "dns-socket": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.2.tgz",
+      "integrity": "sha512-Ztbaf5fToBfm/4+sVEJi7mT2mJOLYYpI+TpgOhxwp5l28UwunTpHMccVhTe9L0F6pQ2cUF0ja9ukuTCtzYq2Ig=="
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY="
+    },
     "dom-converter": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
@@ -1562,6 +1885,11 @@
       "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "dev": true
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domain-browser": {
       "version": "1.1.7",
@@ -1620,6 +1948,33 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "duplexify": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+      "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+          "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4="
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+        }
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1793,10 +2148,38 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "escodegen": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+      "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
+      "dependencies": {
+        "esprima": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+          "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk="
+        },
+        "esutils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "optional": true
+        }
+      }
+    },
     "esprima": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "estraverse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+      "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
     },
     "esutils": {
       "version": "2.0.2",
@@ -1891,14 +2274,12 @@
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
     },
     "expand-template": {
       "version": "1.0.3",
@@ -1951,8 +2332,7 @@
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
     },
     "extract-text-webpack-plugin": {
       "version": "2.1.2",
@@ -1972,6 +2352,23 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "falafel": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
+      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
     },
     "fast-deep-equal": {
       "version": "0.1.0",
@@ -1996,6 +2393,23 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true
     },
+    "fd-read-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-read-stream/-/fd-read-stream-1.1.0.tgz",
+      "integrity": "sha1-0wPMv+4CqaVqNJP7CLy1lpGqU7E=",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+        }
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2011,8 +2425,7 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fileset": {
       "version": "2.0.3",
@@ -2024,13 +2437,11 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
       "dependencies": {
         "isobject": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
         }
       }
     },
@@ -2080,23 +2491,37 @@
         }
       }
     },
+    "flat-tree": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.6.0.tgz",
+      "integrity": "sha1-/KMM3bkAb7ZW6168ea6ydOf96e0="
+    },
     "flatten": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2119,6 +2544,23 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+        }
+      }
     },
     "fs-access": {
       "version": "1.0.1",
@@ -2909,8 +3351,7 @@
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
-      "dev": true
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
     },
     "gauge": {
       "version": "1.2.7",
@@ -2923,6 +3364,16 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "optional": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -2992,14 +3443,24 @@
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q="
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        }
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -3097,14 +3558,12 @@
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg="
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-binary": {
       "version": "0.1.7",
@@ -3289,6 +3748,11 @@
       "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
       "dev": true
     },
+    "http-methods": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/http-methods/-/http-methods-0.1.0.tgz",
+      "integrity": "sha1-KWkbb8WPT36Bo2BdyoJoKwaORDA="
+    },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
@@ -3332,6 +3796,55 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true
     },
+    "hypercore": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.6.4.tgz",
+      "integrity": "sha512-okm1u79votk4qG/H1RREL+nOtrHKx0QY9QYZdJoYvAaJhRLwwa7VLhXlkUEcEridRpoZakUeVoFl6Y+nwbldbQ==",
+      "dependencies": {
+        "unordered-set": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.0.tgz",
+          "integrity": "sha1-mFon6XW6oguCY66np5HpMAlBqew="
+        }
+      }
+    },
+    "hypercore-protocol": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.4.0.tgz",
+      "integrity": "sha1-iXpvoLeSa0iZXdp+A9qtB31jODg=",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+        },
+        "varint": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+          "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+        }
+      }
+    },
+    "hyperdrive": {
+      "version": "9.4.7",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.4.7.tgz",
+      "integrity": "sha512-ctJ4ri2o+Pga+OuYjd57FiIb8Uhgq8UQ+kUPXecD8/ebq3pHgnQ6nht80B5bfpSnm/i/29ra+bF40ldmFSKZHw=="
+    },
+    "hyperdrive-http": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdrive-http/-/hyperdrive-http-4.2.0.tgz",
+      "integrity": "sha1-NBTHM7g19gd/e+6Np3ilDzSir8M="
+    },
+    "hyperdrive-network-speed": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hyperdrive-network-speed/-/hyperdrive-network-speed-2.0.1.tgz",
+      "integrity": "sha1-QNr4LjG511Pyrm368IGGYe0k/hU="
+    },
     "hyperquest": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
@@ -3343,6 +3856,11 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg="
         }
       }
+    },
+    "i": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
+      "integrity": "sha1-HSuFQVjsgWkRPGy39raAHpniEdU="
     },
     "iconv-lite": {
       "version": "0.4.18",
@@ -3500,6 +4018,11 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "ipaddr.js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
@@ -3532,8 +4055,7 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3550,26 +4072,22 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ="
     },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3580,8 +4098,12 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-function-x": {
       "version": "1.3.0",
@@ -3591,8 +4113,7 @@
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
     },
     "is-npm": {
       "version": "1.0.0",
@@ -3603,8 +4124,7 @@
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
     },
     "is-obj": {
       "version": "1.0.1",
@@ -3650,8 +4170,7 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-primitive": {
       "version": "2.0.0",
@@ -3663,6 +4182,11 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -3681,6 +4205,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
     },
     "is-svg": {
       "version": "2.1.0",
@@ -3876,6 +4405,11 @@
         }
       }
     },
+    "iterators": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/iterators/-/iterators-0.1.0.tgz",
+      "integrity": "sha1-0D9mbKTmEwE4VlmXys6lQWQgMVY="
+    },
     "jasmine": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
@@ -4010,6 +4544,21 @@
         }
       }
     },
+    "k-bucket": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.2.1.tgz",
+      "integrity": "sha1-IA0H8CATQ27WcmWVDsmPYrspL2I="
+    },
+    "k-rpc": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-4.1.0.tgz",
+      "integrity": "sha512-Qvetvl34ZXrOWDXMMeP/WQMN3/ep3SASGxcJhUZLgQb1U7VA+/SzwxhDi9KRZWBEqrU0FUWr/yqLP44TfzSwzw=="
+    },
+    "k-rpc-socket": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.7.1.tgz",
+      "integrity": "sha512-FmHDmrT6sIs2MM/uMYW0Jmjd01wk2NxzPd6+9iH7onvutqhWXZ8PoZ9p/mVS58SQILC7jKZacC72V5QNkvAXew=="
+    },
     "karma": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.4.1.tgz",
@@ -4075,8 +4624,12 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+    },
+    "last-one-wins": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
+      "integrity": "sha1-wb/Qy8tGeQ7JFWuNGu6Py4bNoio="
     },
     "latest-version": {
       "version": "3.1.0",
@@ -4101,6 +4654,11 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true
+    },
+    "length-prefixed-message": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.3.tgz",
+      "integrity": "sha1-JFR01pq8BhTco2jcNaqAdJgqI6w="
     },
     "less": {
       "version": "2.7.2",
@@ -4285,6 +4843,11 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -4334,6 +4897,11 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
+    },
+    "lru": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
+      "integrity": "sha1-6n+4VG2DczOWoTCR12z+tMBoN9U="
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -4414,6 +4982,11 @@
         }
       }
     },
+    "memory-pager": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.0.3.tgz",
+      "integrity": "sha1-A3gSAD5mq+3MhMynIsQlWQ6Pqog="
+    },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -4431,6 +5004,23 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
+    "merkle-tree-stream": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-3.0.3.tgz",
+      "integrity": "sha1-+KBkdg0355eK1fn208EZpJT1cIE=",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+        }
+      }
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -4440,8 +5030,7 @@
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
     },
     "miller-rabin": {
       "version": "4.0.0",
@@ -4452,8 +5041,7 @@
     "mime": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-      "dev": true
+      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
     },
     "mime-db": {
       "version": "1.27.0",
@@ -4470,6 +5058,11 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU="
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -4492,6 +5085,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mirror-folder": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mirror-folder/-/mirror-folder-2.1.1.tgz",
+      "integrity": "sha1-GtO3d7OeQDzCe/UghsI+Qe9MlgQ="
     },
     "mixin-object": {
       "version": "2.0.1",
@@ -4534,16 +5132,57 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
       "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
     },
+    "multi-random-access": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multi-random-access/-/multi-random-access-2.1.1.tgz",
+      "integrity": "sha1-ZGLxsgQQnMxkRgFlARCoKEQ9ZuI="
+    },
+    "multicast-dns": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
+      "integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+      "dependencies": {
+        "thunky": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+          "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
+        }
+      }
+    },
+    "multicb": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.1.tgz",
+      "integrity": "sha1-4kmd9Han+PjVLe0mXROywaadmCc="
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "mutexify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.1.0.tgz",
+      "integrity": "sha1-u+AXdD5UQifuWANM0Q8VmSHxhE0="
     },
     "nan": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
       "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+    },
+    "nanoassert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.0.0.tgz",
+      "integrity": "sha1-VVoRIL8mXh0zMy73tYA3ENXiCv8="
+    },
+    "nanobus": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/nanobus/-/nanobus-3.3.0.tgz",
+      "integrity": "sha1-vOXV1DWlNix9rX+ekM0hlZWJvoY="
+    },
+    "nanotiming": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-1.0.1.tgz",
+      "integrity": "sha1-E+ei4nZ5Z5dP7f/wce3Tkyf0TsM="
     },
     "ncname": {
       "version": "1.0.0",
@@ -4551,11 +5190,31 @@
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
       "dev": true
     },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
+    },
+    "neat-log": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/neat-log/-/neat-log-1.1.0.tgz",
+      "integrity": "sha1-Rfe/1KjDvEmBYjbX9feVNDTQP74="
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "nets": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nets/-/nets-3.2.0.tgz",
+      "integrity": "sha1-1RH7q3rxHaAT8huX7pF0fTOFLTg="
+    },
+    "network-address": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/network-address/-/network-address-1.1.2.tgz",
+      "integrity": "sha1-Sqe/1D8D8LgclwKxPWqFjdsybz4="
     },
     "ng-formly": {
       "version": "1.0.0-rc.10",
@@ -4572,6 +5231,12 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA="
+    },
+    "node-gyp-build": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.0.tgz",
+      "integrity": "sha1-KDvgdJJKq7kkDOP4gMfKDI56ANw=",
+      "optional": true
     },
     "node-libs-browser": {
       "version": "2.0.0",
@@ -4668,8 +5333,7 @@
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -4735,17 +5399,25 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
+    "object-inspect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
       "dependencies": {
         "for-own": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
         }
       }
     },
@@ -4864,8 +5536,12 @@
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
+    },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY="
     },
     "parse-json": {
       "version": "2.2.0",
@@ -4934,8 +5610,7 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -4977,6 +5652,11 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true
+    },
+    "pkginfo": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
+      "integrity": "sha1-NJ27f/04CB/K3AhT32h/DHdEzWU="
     },
     "portfinder": {
       "version": "1.0.13",
@@ -5359,8 +6039,12 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "prettier-bytes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prettier-bytes/-/prettier-bytes-1.0.4.tgz",
+      "integrity": "sha1-mUsCqkb2mcULYle1+qp/4lV+YtY="
     },
     "pretty-bytes": {
       "version": "4.0.2",
@@ -5374,6 +6058,11 @@
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true
     },
+    "pretty-hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-hash/-/pretty-hash-1.0.1.tgz",
+      "integrity": "sha1-FuBXkYje9WvbVliSvNBaXWUySAc="
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5385,12 +6074,39 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "progress-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/progress-string/-/progress-string-1.2.1.tgz",
+      "integrity": "sha1-FqQOGGDPRJDbKf9EbB6KWWK8QeI="
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "optional": true
+    },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4="
+    },
+    "protocol-buffers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers/-/protocol-buffers-3.2.1.tgz",
+      "integrity": "sha1-NyWOF+JKCC8G67F3MekoUdHHaIk=",
+      "dependencies": {
+        "varint": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+          "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+        }
+      }
+    },
+    "protocol-buffers-schema": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.1.tgz",
+      "integrity": "sha1-rRURQYd8aviChkeFGvZqDbaSdfU="
     },
     "protractor": {
       "version": "5.1.2",
@@ -5506,45 +6222,54 @@
       "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
       "dev": true
     },
+    "quote-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+      "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI="
+    },
+    "random-access-file": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-1.8.1.tgz",
+      "integrity": "sha512-+Uhk0Of+dWHWjpbL2hizcwSV1UomcN3S0iUGV6BTZ2Js1BP9jHx3E5CT7y0eLbqTQNkVi4iehkHmia7Mdqa47w=="
+    },
+    "random-access-memory": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-2.4.0.tgz",
+      "integrity": "sha1-cvPYZbS1WiWYeUc+L7LeNWnGnuI="
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
             }
           }
         },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
         }
       }
     },
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg=="
     },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-      "dev": true
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.2.0",
@@ -5576,6 +6301,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU="
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ="
     },
     "read-all-stream": {
       "version": "3.1.0",
@@ -5641,6 +6371,11 @@
         }
       }
     },
+    "recursive-watch": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.2.tgz",
+      "integrity": "sha1-kS4tYqg8iziNKIxDQ0lfJHvEP44="
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -5695,8 +6430,7 @@
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU="
     },
     "regexpu-core": {
       "version": "1.0.0",
@@ -5737,8 +6471,7 @@
     "remove-trailing-separator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-      "dev": true
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
     },
     "renderkid": {
       "version": "2.0.1",
@@ -5757,14 +6490,12 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
@@ -5804,14 +6535,18 @@
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU="
     },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
     },
     "right-align": {
       "version": "0.1.3",
@@ -6083,11 +6818,28 @@
         }
       }
     },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "signed-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+      "dependencies": {
+        "varint": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+          "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+        }
+      }
     },
     "silent-error": {
       "version": "1.1.0",
@@ -6104,6 +6856,16 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/simple-mime/-/simple-mime-0.1.0.tgz",
       "integrity": "sha1-lfUXxPRm18/1YacfydqyWW6p7y4="
+    },
+    "siphash24": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.0.2.tgz",
+      "integrity": "sha512-/yUF5S4+z46QxpT/mW/wdlsQQTdO1yl3H36aql6u2m3Ve6u9iATS+yHN+rMXr4jm1qQ0wJUDK2ofdkZeQjMmig=="
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
     "slide": {
       "version": "1.1.6",
@@ -6224,11 +6986,42 @@
         }
       }
     },
+    "sodium-javascript": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.1.tgz",
+      "integrity": "sha512-M8H34jbD8WPaNVx7LfLyk3fabujOppnjEskJYXSlYqJ83BMFyO3wYFzvhSW3/yL4j0JFgYRYm5c/dzGK1AqxFA=="
+    },
+    "sodium-native": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-1.10.2.tgz",
+      "integrity": "sha512-mMO7CMMOuZLbTq1omps+/2WsHK30UTtz2/KBOFH8DnUm22U4kPVA9rwoz/On0QpIOOyMpzO7oNFOtGlFCBe9Hw==",
+      "optional": true
+    },
+    "sodium-signatures": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-signatures/-/sodium-signatures-2.1.0.tgz",
+      "integrity": "sha512-kNTta6Nyc5VR8OHvLHGpjTvdBfTz9+yC+fJBvrdPOquKgyYAE0tfvxoL286uIkHbP/IkdDjiiMbhjsDqUrRMbw=="
+    },
+    "sodium-universal": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-1.4.0.tgz",
+      "integrity": "sha512-hMQ4uoqoyUES9Q8CAeUFYcc2ODq72cq+riSTO+XsuZZjYDTvKlvFIK+v/wMTbv5woa/omMwFvsxib5gVz0qEXg=="
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true
+    },
+    "sorted-array-functions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.0.0.tgz",
+      "integrity": "sha1-wLVU2ecJr/y+VtNMGyUUGX/Tgnk="
+    },
+    "sorted-indexof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sorted-indexof/-/sorted-indexof-1.0.0.tgz",
+      "integrity": "sha1-F8dC/3zxh+L1mhXfm4HxemLOCJk="
     },
     "source-list-map": {
       "version": "0.1.8",
@@ -6239,8 +7032,7 @@
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-      "dev": true
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-loader": {
       "version": "0.2.1",
@@ -6278,6 +7070,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.0.tgz",
       "integrity": "sha1-NyIifFTi+vJLHcbZM8wUTm9xv+8="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE="
     },
     "spawn-command": {
       "version": "0.0.2-1",
@@ -6354,6 +7151,11 @@
         }
       }
     },
+    "speedometer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+      "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6370,6 +7172,70 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "static-eval": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
+      "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
+      "dependencies": {
+        "escodegen": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+          "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M="
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        },
+        "estraverse": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+          "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
+        }
+      }
+    },
+    "static-module": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.4.0.tgz",
+      "integrity": "sha1-vvDZtviVhfbyNZuBYb7qsGBV29I=",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "quote-stream": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
+          "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs="
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s="
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
+        }
+      }
+    },
+    "status-logger": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/status-logger/-/status-logger-3.1.0.tgz",
+      "integrity": "sha1-Y5X8Bzki/rQN1nbj28W8+8h/a2A="
     },
     "statuses": {
       "version": "1.3.1",
@@ -6420,6 +7286,16 @@
         }
       }
     },
+    "stream-collector": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz",
+      "integrity": "sha1-TU5V8XE1YSGyxfZVn5RHBaso2xU="
+    },
+    "stream-each": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
+      "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE="
+    },
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
@@ -6440,6 +7316,16 @@
         }
       }
     },
+    "stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M="
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -6455,19 +7341,16 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
       "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8="
         }
       }
     },
@@ -6479,8 +7362,7 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "strip-bom": {
       "version": "2.0.0",
@@ -6542,6 +7424,11 @@
       "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.1.tgz",
       "integrity": "sha1-d/SzT9Aw0lsmF7z1UT21sHMMQIk=",
       "dev": true
+    },
+    "subcommand": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz",
+      "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A="
     },
     "supports-color": {
       "version": "3.2.3",
@@ -6756,6 +7643,11 @@
       "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
       "dev": true
     },
+    "throttle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/throttle/-/throttle-1.0.3.tgz",
+      "integrity": "sha1-ijLkoV8XY9mXlIMXxevjrYpB5Lc="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6778,6 +7670,11 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
         }
       }
+    },
+    "thunky": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+      "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
     },
     "timed-out": {
       "version": "4.0.1",
@@ -6809,6 +7706,11 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "to-buffer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.0.tgz",
+      "integrity": "sha1-N1vAPtrlw1qPoLP+laHzmF2x3Po="
+    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -6819,6 +7721,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.3.0.tgz",
       "integrity": "sha512-1OxhYAfFFvjjpGoc0qTRPvxpuWIzyMRpNTQjwE4T7oMlo0NiHrgVwoM96NojjWDCoctVo/PASdipNL/JzdiSjw=="
+    },
+    "toiletdb": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/toiletdb/-/toiletdb-1.4.0.tgz",
+      "integrity": "sha1-bG+HGDSyIXjFSQ+fgytYw8fLqFI="
     },
     "toposort": {
       "version": "1.0.3",
@@ -6831,10 +7738,20 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
     },
+    "township-client": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/township-client/-/township-client-1.3.1.tgz",
+      "integrity": "sha1-wBY7DLXZl/6NDWDrH1Uqj70VI9A="
+    },
     "tree-kill": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.1.0.tgz",
       "integrity": "sha1-yWPc8DciiS7FnLpWnpQLcZVNFyk="
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -6897,6 +7814,11 @@
       "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
       "dev": true
     },
+    "ttl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ttl/-/ttl-1.3.0.tgz",
+      "integrity": "sha1-AK2hwNevCQ0+9HlTIbTw1hK0cKU="
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -6920,6 +7842,11 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "dev": true
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "typescript": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz",
@@ -6938,6 +7865,11 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
+    },
+    "uint64be": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.1.tgz",
+      "integrity": "sha1-oxDZTk5eCwKpXWeOMzI/gCvchCg="
     },
     "ultron": {
       "version": "1.0.2",
@@ -6975,11 +7907,31 @@
       "integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g=",
       "dev": true
     },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA="
+    },
+    "unordered-array-remove": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unordered-array-remove/-/unordered-array-remove-1.0.2.tgz",
+      "integrity": "sha1-xUbo+I4xegzyZEyX7LV9umbSUO8="
+    },
+    "unordered-set": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-1.1.0.tgz",
+      "integrity": "sha1-K6fvMW7dC5WQzFR8dPdqLxZP7Mo="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "untildify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
+      "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
     },
     "unzip-response": {
       "version": "1.0.2",
@@ -7099,11 +8051,49 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
+      }
+    },
     "utils-merge": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
+    },
+    "utp-native": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-1.5.2.tgz",
+      "integrity": "sha512-EqNZUlvNygH7wANjqGPMGi0PYlJYYhCHgucNqecOawN6LHn1DNKS1736g1zirTeW9X08g3RnwLY5DzlINiN3Jw==",
+      "optional": true,
+      "dependencies": {
+        "nan": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "optional": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "optional": true
+        }
+      }
     },
     "uuid": {
       "version": "3.1.0",
@@ -7126,6 +8116,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
       "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
+    },
+    "varint": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-3.0.1.tgz",
+      "integrity": "sha1-nT9T4DbAqxIACnS8LSTL8JOlgdk="
     },
     "vary": {
       "version": "1.1.1",
@@ -7494,6 +8489,28 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
     },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+        }
+      }
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -7566,6 +8583,11 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
+    "xhr": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
+      "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM="
+    },
     "xml-char-classes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
@@ -7595,6 +8617,11 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
       "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
       "dev": true
+    },
+    "xsalsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.0.2.tgz",
+      "integrity": "sha512-g1DFmZ5JJ9Qzvt4dMw6m9IydqoCSP381ucU5zm46Owbk3bwmqAr8eEJirOPc7PrXRn45drzOpAyDp8jsnoyXyw=="
     },
     "xtend": {
       "version": "4.0.1",

--- a/client-v3/package.json
+++ b/client-v3/package.json
@@ -13,6 +13,7 @@
     "precache": "sw-precache --verbose --config=sw-precache-config.js",
     "lite-server": "cd lite-server && node app.js",
     "publish": "npm run build && git clone git@github.com:tangerine-v3-demo/tangerine-v3-demo.github.io .publish-tmp && mv .publish-tmp/.git dist/ && rm -r .publish-tmp && cd dist && git add . && git commit -m \"npm publish\" && git push && cd ..",
+    "publish-to-dat-web": "./scripts/publish-to-dat-web.sh",
     "test-publish": "npm run build && cd dist && hs -c-1"
   },
   "private": true,
@@ -40,6 +41,7 @@
     "concurrently": "^3.5.0",
     "core-js": "^2.4.1",
     "csv-file-creator": "^1.0.7",
+    "dat": "^13.7.0",
     "express-pouchdb": "^2.3.7",
     "gh-markdown-cli": "^0.2.0",
     "hammerjs": "^2.0.8",

--- a/client-v3/package.json
+++ b/client-v3/package.json
@@ -13,7 +13,7 @@
     "precache": "sw-precache --verbose --config=sw-precache-config.js",
     "lite-server": "cd lite-server && node app.js",
     "publish": "npm run build && git clone git@github.com:tangerine-v3-demo/tangerine-v3-demo.github.io .publish-tmp && mv .publish-tmp/.git dist/ && rm -r .publish-tmp && cd dist && git add . && git commit -m \"npm publish\" && git push && cd ..",
-    "publish-to-dat-web": "./scripts/publish-to-dat-web.sh",
+    "publish-to-dat": "./scripts/publish-to-dat-web.sh",
     "test-publish": "npm run build && cd dist && hs -c-1"
   },
   "private": true,

--- a/client-v3/scripts/publish-to-dat-web.sh
+++ b/client-v3/scripts/publish-to-dat-web.sh
@@ -1,0 +1,5 @@
+./node_modules/.bin/angular-pages build
+ng build --aot --prod
+sw-precache --verbose --config=sw-precache-config.js
+cd dist
+../node_modules/.bin/dat share

--- a/client-v3/scripts/publish-to-dat-web.sh
+++ b/client-v3/scripts/publish-to-dat-web.sh
@@ -2,4 +2,9 @@
 ng build --aot --prod
 sw-precache --verbose --config=sw-precache-config.js
 cd dist
+if [ -d ../dat ]; then
+  mv ../dat ./.dat
+fi
+gtimeout 7 ../node_modules/.bin/dat share 
+cp -r .dat ../dat
 ../node_modules/.bin/dat share


### PR DESCRIPTION
Allows you to `npm run publish-to-dat`. It will make sure to persist the dat folder form the first time you `npm run publish-to-dat` so you don't have a new dat url every time. This may be a sensible default, but I could understand an argument for a new dat every time for security purposes.