### PR TITLE
Refactor start.sh and config.defaults.sh to allow configurable ports and tag

### DIFF
--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -1,7 +1,12 @@
+# required in config.sh
 T_HOST_NAME='localhost'
 T_PROTOCOL="http"
 T_USER1="user1"
 T_USER1_PASSWORD="password"
 T_ADMIN="admin"
 T_PASS="password"
+
+# optional
+T_TAG=""
 T_CONTAINER_NAME="tangerine-container"
+T_PORT_MAPPING="-p 80:80 -p 5984:5984"

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Load config.
 source ./config.defaults.sh
 if [ -f "./config.sh" ]; then
   source ./config.sh
@@ -7,14 +8,23 @@ else
   echo "You have no config.sh. Copy config.defaults.sh to config.sh, change the passwords and try again." && exit 1;
 fi
 
-# Allow to specify Tangerine Version as parameter in ./star.sh, other wise use the most recent tag.
-if [ "$1" = "" ]; then
+# Allow to specify Tangerine Version as parameter in ./start.sh, other wise use the most recent tag.
+if [ "$1" = "" ] && [ "$T_TAG" = "" ]; then
   TAG=$(git describe --tags --abbrev=0)
-else
+fi
+echo $T_TAG
+if  [ "$T_TAG" != "" ]; then
+  TAG=$T_TAG
+fi
+if  [ "$1" != "" ]; then
   TAG=$1
 fi
+
+# Pull tag.
 echo "Pulling $TAG"
 docker pull tangerine/tangerine:$TAG
+
+# Check if the container exists, if so, stop and remove it.
 NO_SUCH_CONTAINER=$(docker inspect $T_CONTAINER_NAME | grep "No such object")
 echo $NO_SUCH_CONTAINER
 if [ "$NO_SUCH_CONTAINER" = "" ]; then
@@ -23,20 +33,7 @@ if [ "$NO_SUCH_CONTAINER" = "" ]; then
   echo "Removing $T_CONTAINER_NAME"
   docker rm $T_CONTAINER_NAME > /dev/null 
 fi
+
 echo "Running $T_CONTAINER_NAME at version $TAG"
-docker run -d \
-  --name $T_CONTAINER_NAME \
-  --env "NODE_ENV=production" \
-  --env "T_VERSION=$TANGERINE_VERSION" \
-  --env "T_PROTOCOL=$T_PROTOCOL" \
-  --env "T_ADMIN=$T_ADMIN" \
-  --env "T_PASS=$T_PASS" \
-  --env "T_USER1=$T_USER1" \
-  --env "T_USER1_PASSWORD=$T_USER1_PASSWORD" \
-  --env "T_HOST_NAME=$T_HOST_NAME" \
-  -p 80:80 \
-  --volume $(pwd)/data/couchdb/:/var/lib/couchdb \
-  --volume $(pwd)/data/logs/pm2/:/tangerine-server/logs \
-  --volume $(pwd)/data/logs/couchdb/couchdb.log:/var/log/couchdb/couchdb.log \
-  --volume $(pwd)/data/media_assets/:/tangerine-server/client/media_assets/ \
-  tangerine/tangerine:$TAG
+
+echo "docker run -d --name $T_CONTAINER_NAME   --env \"NODE_ENV=production\"   --env \"T_VERSION=$TANGERINE_VERSION\"   --env \"T_PROTOCOL=$T_PROTOCOL\"   --env \"T_ADMIN=$T_ADMIN\"   --env \"T_PASS=$T_PASS\"   --env \"T_USER1=$T_USER1\"   --env \"T_USER1_PASSWORD=$T_USER1_PASSWORD\"   --env \"T_HOST_NAME=$T_HOST_NAME\"   $T_PORT_MAPPING   --volume $(pwd)/data/couchdb/:/var/lib/couchdb   --volume $(pwd)/data/logs/pm2/:/tangerine-server/logs   --volume $(pwd)/data/logs/couchdb/couchdb.log:/var/log/couchdb/couchdb.log   --volume $(pwd)/data/media_assets/:/tangerine-server/client/media_assets/    tangerine/tangerine:$TAG" | sh


### PR DESCRIPTION
This allows us to create new TSIs in the standard Tangerine way by cloning the code, checking out the version we want, configuring it, and then running start.sh. The difference is we can now set `T_PORTS=""` as opposed to `T_PORTS="-p 80:80 -p 5984:5984`. We can also set `T_TAG="local"` when you want to base a tangerine container on a local build. This is easier to remember I think than the old way of having to do `./start.sh local` every time. The default is `T_TAG=""` which is cool because then it will default to the most recent checked out tag from the git codebase it is being started in.