### PR TITLE
Add a TangyFormService class and database views

### DIFF
--- a/client/content/form-1/form.html
+++ b/client/content/form-1/form.html
@@ -1,15 +1,14 @@
-<tangy-form hide-closed-items linear-mode  id="form-1" on-item-change="
+<tangy-form linear-mode hide-closed-items id="form-1" on-change="
   console.log('item changed')
   console.log(tangyForm)
   console.log(response)
   console.log(items)
-  if (items[0].response['extra_items']) items[1].disabled = false 
-  if (!items[0].response['extra_items']) items[1].disabled = true
+  item_2.disabled = (response.extra_items) ? false : true
 ">
-  <tangy-form-item src="item-1.html" id="item-1" title="Design Your Pizza"></tangy-form-item>
-  <tangy-form-item src="item-2.html" id="item-2" title="Extra Items" disabled></tangy-form-item>
-  <tangy-form-item src="item-3.html" id="item-3" title="A quick word survey"></tangy-form-item>
-  <tangy-form-item src="item-4.html" id="item-4" title="GPS"></tangy-form-item>
-  <tangy-form-item src="item-5.html" id="item-5" title="Location"></tangy-form-item>
+  <tangy-form-item src="item-1.html" id="item_1" title="Design Your Pizza"></tangy-form-item>
+  <tangy-form-item src="item-2.html" id="item_2" title="Extra Items" disabled></tangy-form-item>
+  <tangy-form-item src="item-3.html" id="item_3" title="A quick word survey"></tangy-form-item>
+  <tangy-form-item src="item-4.html" id="item_4" title="GPS"></tangy-form-item>
+  <tangy-form-item src="item-5.html" id="item_5" title="Location"></tangy-form-item>
 </tangy-form>
 

--- a/client/content/form-1/item-2.html
+++ b/client/content/form-1/item-2.html
@@ -1,7 +1,7 @@
 <form>
   <label>Extra items:</label> <br>
-  <paper-checkbox name="cheesy-sticks">cheesy sticks</paper-checkbox><br>
-  <paper-checkbox name="gummy-bears">gummy bears</paper-checkbox><br>
-  <paper-checkbox name="ice-cream">ice cream</paper-checkbox><br>
+  <tangy-checkbox name="cheesy-sticks" value="">cheesy sticks</tangy-checkbox><br>
+  <tangy-checkbox name="gummy-bears" value="">gummy bears</tangy-checkbox><br>
+  <tangy-checkbox name="ice-cream" value="">ice cream</tangy-checkbox><br>
 </form>
 

--- a/client/content/form-1/item-4.html
+++ b/client/content/form-1/item-4.html
@@ -1,6 +1,6 @@
 <form id="form" onchange="">
   <tangy-gps>
-    <input class="latitude" name="latitude" type="hidden">
-    <input class="longitude" name="longitude" type="hidden">
+    <input class="latitude" name="latitude" type="hidden" value="">
+    <input class="longitude" name="longitude" type="hidden" value="">
   </tangy-gps>
 </form>

--- a/client/content/form-1/item-5.html
+++ b/client/content/form-1/item-5.html
@@ -1,4 +1,4 @@
 <form id="form" onchange="">
-  <tangy-location namespace="pizza-delivery-location">
+  <tangy-location name="pizza-delivery-location" value="">
   </tangy-location>
 </form>

--- a/client/content/form-2/form.html
+++ b/client/content/form-2/form.html
@@ -1,15 +1,14 @@
-<tangy-form  id="form-2" on-item-change="
+<tangy-form  id="form-2" on-change="
   console.log('item changed')
   console.log(tangyForm)
   console.log(response)
   console.log(items)
-  if (items[0].response['extra_items']) items[1].disabled = false 
-  if (!items[0].response['extra_items']) items[1].disabled = true
+  item_2.disabled = (response.extra_items) ? false : true
 ">
-  <tangy-form-item src="item-1.html" id="item-1" title="Design Your Pizza"></tangy-form-item>
-  <tangy-form-item src="item-2.html" id="item-2" title="Extra Items" disabled></tangy-form-item>
-  <tangy-form-item src="item-3.html" id="item-3" title="A quick word survey"></tangy-form-item>
-  <tangy-form-item src="item-4.html" id="item-4" title="GPS"></tangy-form-item>
-  <tangy-form-item src="item-5.html" id="item-5" title="Location"></tangy-form-item>
+  <tangy-form-item src="item-1.html" id="item_1" title="Design Your Pizza"></tangy-form-item>
+  <tangy-form-item src="item-2.html" id="item_2" title="Extra Items" disabled></tangy-form-item>
+  <tangy-form-item src="item-3.html" id="item_3" title="A quick word survey"></tangy-form-item>
+  <tangy-form-item src="item-4.html" id="item_4" title="GPS"></tangy-form-item>
+  <tangy-form-item src="item-5.html" id="item_5" title="Location"></tangy-form-item>
 </tangy-form>
 

--- a/client/content/form-2/item-2.html
+++ b/client/content/form-2/item-2.html
@@ -1,7 +1,8 @@
 <form>
   <label>Extra items:</label> <br>
-  <paper-checkbox name="cheesy-sticks">cheesy sticks</paper-checkbox><br>
-  <paper-checkbox name="gummy-bears">gummy bears</paper-checkbox><br>
-  <paper-checkbox name="ice-cream">ice cream</paper-checkbox><br>
+  <tangy-checkbox name="cheesy-sticks" value="">cheesy sticks</tangy-checkbox><br>
+  <tangy-checkbox name="gummy-bears" value="">gummy bears</tangy-checkbox><br>
+  <tangy-checkbox name="ice-cream" value="">ice cream</tangy-checkbox><br>
 </form>
-
+  
+  

--- a/client/content/form-2/item-3.html
+++ b/client/content/form-2/item-3.html
@@ -3,7 +3,7 @@
     <h3> Subtask 5: Oral Reading Passage</h3>
     <p><strong>Here is a short story. I want you to read it aloud, quickly but carefully. When you finish, I will ask you some questions about what you have read. When I say &ldquo;Begin,&rdquo; read the story as best as you can. If you come to a word you do not know, go on to the next word. Put your finger on the first word. </strong></p><p><strong>Ready? Begin.</strong> &nbsp;</p><p>&nbsp;</p>
 
-    <tangy-timed id="oral_read" duration=60>
+    <tangy-timed name="oral_read" value="" duration=60>
         <table>
             <tr>
                 <td> <tangy-toggle-button  id="Salma1" name="Salma1"   /> Salma</tangy-toggle-button> </td>

--- a/client/content/form-2/item-4.html
+++ b/client/content/form-2/item-4.html
@@ -1,6 +1,6 @@
 <form id="form" onchange="">
   <tangy-gps>
-    <input class="latitude" name="latitude" type="hidden">
-    <input class="longitude" name="longitude" type="hidden">
+    <input class="latitude" name="latitude" type="hidden" value="">
+    <input class="longitude" name="longitude" type="hidden" value="">
   </tangy-gps>
 </form>

--- a/client/content/form-2/item-5.html
+++ b/client/content/form-2/item-5.html
@@ -1,4 +1,4 @@
 <form id="form" onchange="">
-  <tangy-location namespace="pizza-delivery-location">
+  <tangy-location name="pizza-delivery-location" value="">
   </tangy-location>
 </form>

--- a/client/content/user-profile/item-1.html
+++ b/client/content/user-profile/item-1.html
@@ -57,8 +57,10 @@
   </paper-input>
   <tangy-location required save-children show-levels="county,subcounty,zone" name="location" value=""></tangy-location>
   <h2>Gender</h2>
-  <option name="gender" value="female">Female</option>
-  <option name="gender" value="male">Male</option>
+  <tangy-radio-buttons name="gender" value="">
+    <option value="female">Female</option>
+    <option value="male">Male</option>
+  </tangy-radio-buttons>
   <paper-input 
     error-message="A valid email address is required." 
     type="email" 

--- a/client/tangy-forms/src/tangy-form/tangy-form-model.js
+++ b/client/tangy-forms/src/tangy-form/tangy-form-model.js
@@ -1,0 +1,9 @@
+class TangyFormModel {
+  constructor(props) {
+    this._id = '' 
+    this.collection = 'TangyForm'
+    this.formId
+    this.responseId = ''
+    Object.assign(this, props)
+  }
+}

--- a/client/tangy-forms/src/tangy-form/tangy-form-response-model.js
+++ b/client/tangy-forms/src/tangy-form/tangy-form-response-model.js
@@ -9,6 +9,7 @@ class TangyFormResponseModel {
     this.variables = {}
     this.log = []
     this.items = {}
+    this.uploadDatetime = ''
     Object.assign(this, props)
   }
 }

--- a/client/tangy-forms/src/tangy-form/tangy-form-service.js
+++ b/client/tangy-forms/src/tangy-form/tangy-form-service.js
@@ -1,0 +1,103 @@
+class TangyFormService {
+
+  constructor(props) {
+    this.databaseName = 'tangy-forms'
+    Object.assign(this, props)
+  }
+
+  async initialize() {
+    this.db = new PouchDB(this.databaseName)
+    try {
+      let designDoc = await this.db.get('_design/tangy-form')
+      if (designDoc.version !== tangyFormDesignDoc.version) {
+        updatedDesignDoc = Object.assign({}, designDoc, tangyFormDesignDoc)
+        await this.db.put(updatedDesignDoc)
+      }
+    } catch (e) {
+      this.loadDesignDoc()
+    }
+  }
+
+  async loadDesignDoc() {
+    await this.db.put(tangyFormDesignDoc)
+  }
+
+  async getForm(formId) {
+    let results = await this.db.query('tangy-form/formByFormId', {key: formId, include_docs: true})
+    if (results.rows.length == 0) {
+        return false
+    } else {
+        return results.rows[0].doc
+    }
+  }
+
+  async saveForm(formDoc) {
+    let r
+    if (!formDoc._id) {
+      r = await this.db.post(formDoc)
+    }
+    else {
+      r = await this.db.put(formDoc)
+    }
+    return await this.db.get(r.id)
+  }
+
+  // Would be nice if this was queue based so if two saves get called at the same time, the differentials are sequentials updated
+  // into the database. Using a getter and setter for property fields, this would be one way to queue.
+  async saveResponse(responseDoc) {
+    let r
+    if (!responseDoc._id) {
+      r = await this.db.post(responseDoc)
+    }
+    else {
+      r = await this.db.put(responseDoc)
+    }
+    return await this.db.get(r.id)
+
+  }
+
+  async getResponse(responseId) {
+    try {
+        let doc = await this.db.get(responseId)
+        return doc
+    } catch (e) {
+        return false
+    }
+  }
+
+  async getResponsesByFormId(formId) {
+    return this.db.query('tangy-form/responseByFormId', {key: formId, include_docs: true})
+  }
+  
+}
+
+var tangyFormDesignDoc = {
+    _id: '_design/tangy-form',
+    version: '2',
+    views: {
+      formByFormId: {
+        map: function(doc) {
+          if (doc.collection !== 'TangyForm') return
+          emit(`${doc.formId}`, true)
+        }.toString()
+      },
+      responseByFormId: {
+        map: function(doc) {
+          if (doc.collection !== 'TangyFormResponse') return
+          emit(`${doc.formId}`, true)
+        }.toString()
+      },
+      responseByFormIdAndStartDatetime: {
+        map: function(doc) {
+          if (doc.collection !== 'TangyFormResponse') return
+          emit(`${doc.formId}-${doc.startDatetime}`, true)
+        }.toString()
+      },
+      responseByUploadDatetime: {
+        map: function(doc) {
+          if (doc.collection !== 'TangyFormResponse') return
+          emit(doc.uploadDatetime, true)
+        }.toString()
+      }
+    }
+  }

--- a/client/tangy-forms/src/tangy-form/tangy-form.html
+++ b/client/tangy-forms/src/tangy-form/tangy-form.html
@@ -1,5 +1,7 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
+<script src="tangy-form-model.js"></script>
 <script src="tangy-form-response-model.js"></script>
+<script src="tangy-form-service.js"></script>
 <link rel="import" href="tangy-form-item.html">
 <link rel="import" href="../tangy-timed/tangy-timed.html">
 <link rel="import" href="../tangy-gps/tangy-gps.html">
@@ -230,41 +232,53 @@
       }
 
       async connectedCallback() {
+
+        // @TODO Change this.id to this.form_id. It's more obvious.
         super.connectedCallback();
-        // Use a PouchDB to store responses.
-        this.db = new PouchDB(this.database)
+
         // Stash initial state of innerHTML for use when starting a new response 
         // after a prior response was worked on.
         this._formDefinition = this.innerHTML
-        // If now responseId provided, try to get it from a current tangy form response doc.
-        if (!this.responseId) {
-          // Get the current response, else catch and create new response.
-          let currentTangyFormResponse
-          try {
-            currentTangyFormResponse = await this.db.get(`current_tangy_form_response_${this.id}`);
-          } catch (e) {
-            let tangyFormResponse = new TangyFormResponseModel({
-              formId: this.id
-            })
-            let dbResponse = await this.db.post(tangyFormResponse)
-            tangyFormResponse = await this.db.get(dbResponse.id)
-            dbResponse = await this.db.put({
-              _id: `current_tangy_form_response_${this.id}`,
-              responseId: tangyFormResponse._id
-            })
-            currentTangyFormResponse = await this.db.get(`current_tangy_form_response_${this.id}`);
-          }
-          this.response = await this.db.get(currentTangyFormResponse.responseId)
-        } else {
-          // Try to get the response with responseId provided, otherwise create it.
-          try {
-            this.response = await this.db.get(this.responseId)
-          } catch (e) {
-            let response = new TangyFormResponseModel({_id: this.responseId})
-            await this.db.put(response)
-            this.response = await this.db.get(response._id)
-          }
+
+        // @TODO Rename database to databaseName.
+        this.service = new TangyFormService({databaseName: this.database})
+        await this.service.initialize()
+
+        // Get our formDoc.
+        this.formDoc = await this.service.getForm(this.id)
+
+        // No formDoc? Create one. 
+        if (!this.formDoc) {
+          this.formDoc = new TangyFormModel({formId: this.id})
+          this.formDoc = await this.service.saveForm(this.formDoc)
         }
+
+        // Determine our current response ID.
+        if (!this.responseId && this.formDoc.responseId) {
+          this.responseId = this.formDoc.responseId
+        }
+
+        // No response ID? Create one.
+        if (!this.responseId) {
+          this.response = new TangyFormResponseModel({_id: this.responseId, formId: this.id})
+          this.response = await this.service.saveResponse(this.response)
+          // Now we definitely have a response ID.
+          this.responseId = this.response._id
+        }
+
+        // Get our current response.
+        this.response = await this.service.getResponse(this.responseId)
+
+        // No response by this ID? Create it.
+        if (!this.response) {
+          this.response = new TangyFormResponseModel({_id: this.responseId, formId: this.id})
+          this.response = await this.service.saveResponse(this.response)
+        }
+
+        // Save this response as our current response.
+        this.formDoc.responseId = this.response._id
+        this.formDoc = await this.service.saveForm(this.formDoc)
+
         // Render the form.
         this.render()
       }
@@ -277,14 +291,10 @@
         // Load response data into items.
         let items = [].slice.call(this.querySelectorAll('tangy-form-item'))
         for (let item of items) {
-          if (this.response.items.hasOwnProperty(item.id)) {
-            item.response = this.response.items[item.id] 
-          } else {
-            this.response.items[item.id] = {}
-          }
+          item.response = this.response
         }
         // Listen for Item Change events, save to response.
-        this.addEventListener('tangy-form-item-variables-change', this.onItemVariablesChange)
+        this.addEventListener('change', this.onInputChange)
         // If hideClosedItems, hide other items when one opens.
         if (this.hideClosedItems) {
           this.addEventListener('tangy-form-item-open-change', (event) => {
@@ -311,10 +321,17 @@
         }
       }
 
-      async onItemVariablesChange(event) {
-        this.response.items[event.srcElement.id] = event.srcElement.response
-        await this.db.post(this.response)
-        this.response = await this.db.get(this.response._id)
+      async onInputChange(event) {
+        let input = event.srcElement
+        this.response[input.name] = input.value
+        this.response.log.push({
+          event: 'change',
+          package: {
+            name: input.name,
+            value: input.value 
+          }
+        })
+        this.response = this.service.saveResponse(this.response) 
         // onItemChange logic.
         let tangyForm = this
         let response = this.response
@@ -333,8 +350,7 @@
         let item = this.querySelector(`#${itemId}`)
         // Save our new focus item ID.
         this.response.focusItemId = item.id 
-        await this.db.put(this.response)
-        this.response = await this.db.get(this.response._id);
+        this.response = this.service.saveResponse(this.response)
         // Open item.
         if(!item.open) item.open = true
         // Update the nav.
@@ -400,54 +416,24 @@
       }
 
       async newResponse() {
-        let currentTangyFormResponse
-        try {
-          currentTangyFormResponse = await this.db.get(`current_tangy_form_response_${this.id}`);
-        }
-        catch (e) {
-          await this.db.post({
-            _id: `current_tangy_form_response_${this.id}`
-          })
-          currentTangyFormResponse = await this.db.get(`current_tangy_form_response_${this.id}`);
-        }
-        // Create the new response.
-        let tangyFormResponse = new TangyFormResponseModel({
-          formId: this.id
-        })
-        this.response = await this.db.get((await this.db.post(tangyFormResponse)).id)
-        currentTangyFormResponse.responseId = this.response._id 
-        await this.db.put(currentTangyFormResponse)
+        this.response = this.service.saveResponse(new TangyFormResponse({formId: this.formId}))
         this.render()
       }
 
       async resumeResponse(event) {
-        let currentTarget = event.currentTarget
-        let currentTangyFormResponse = await this.db.get(`current_tangy_form_response_${this.id}`);
-        currentTangyFormResponse.responseId = currentTarget.dataResponseId
-        await this.db.put(currentTangyFormResponse)
-        this.response = this.db.get(currentTangyFormResponse.responseId)
+        let resumeResponseId = event.currentTarget.dataResponseId
+        this.response = await this.service.getResponse(resumeResponseId)
+        this.formDoc = await this.service.getForm(this.id)
+        this.formDoc.responseId = this.response._id
+        this.formDoc = await this.service.saveForm(this.formDoc)
         this.render()
       }
 
       async showResponses() {
         this.$['tangy-form-questions'].hidden = true 
         this.$['tangy-form-responses'].hidden = false 
-        let currentResponse = await this.db.get(`current_tangy_form_response_${this.id}`);
-        // @TODO Query for form response docs with `doc.form_id` equal to `this.form_id`.
-        let allDocs = (await this.db.allDocs({include_docs: true})).rows.map((row) => { return row.doc})
-        allDocs.sort(function (a, b) {
-          return b.startUnixtime - a.startUnixtime;
-        });
-        this.responses = allDocs.filter((doc) => {
-          if (doc.collection === 'TangyFormResponse' && doc.formId == this.id) {
-            if (doc._id == currentResponse.responseId) {
-              doc.isCurrentTangyFormResponse = true
-            } else {
-              doc.isCurrentTangyFormResponse = false
-            }
-            return doc
-          }
-        }) 
+        // @TODO Paginate and mark current response.
+        this.responses = await this.service.getResponsesByFormId(this.id) 
       }
 
     }

--- a/client/tangy-forms/src/tangy-form/tangy-form.html
+++ b/client/tangy-forms/src/tangy-form/tangy-form.html
@@ -200,7 +200,7 @@
             type: String,
             value: 'tangy-form'
           },
-          onItemChange: {
+          onChange: {
             type: String,
             value: '' 
           },
@@ -294,7 +294,7 @@
           item.response = this.response
         }
         // Listen for Item Change events, save to response.
-        this.addEventListener('change', this.onInputChange)
+        this.addEventListener('change', (event) => this.onInputChange(event.target) )
         // If hideClosedItems, hide other items when one opens.
         if (this.hideClosedItems) {
           this.addEventListener('tangy-form-item-open-change', (event) => {
@@ -319,10 +319,10 @@
           let firstItem = this.querySelector('tangy-form-item')
           this.focusOnItem(firstItem.id)
         }
+        this.evalOnChange()
       }
 
-      async onInputChange(event) {
-        let input = event.srcElement
+      async onInputChange(input) {
         this.response[input.name] = input.value
         this.response.log.push({
           event: 'change',
@@ -331,12 +331,16 @@
             value: input.value 
           }
         })
-        this.response = this.service.saveResponse(this.response) 
+        this.response = await this.service.saveResponse(this.response) 
+        this.evalOnChange()
+      }
+
+      evalOnChange() {
         // onItemChange logic.
         let tangyForm = this
         let response = this.response
         let items = [].slice.call(this.querySelectorAll('tangy-form-item'))
-        eval(this.onItemChange)// .bind(this)
+        eval(this.onChange)// .bind(this)
       }
 
       async focusOnItem(itemId) {
@@ -350,7 +354,7 @@
         let item = this.querySelector(`#${itemId}`)
         // Save our new focus item ID.
         this.response.focusItemId = item.id 
-        this.response = this.service.saveResponse(this.response)
+        this.response = await this.service.saveResponse(this.response)
         // Open item.
         if(!item.open) item.open = true
         // Update the nav.
@@ -416,7 +420,7 @@
       }
 
       async newResponse() {
-        this.response = this.service.saveResponse(new TangyFormResponse({formId: this.formId}))
+        this.response = await this.service.saveResponse(new TangyFormResponse({formId: this.formId}))
         this.render()
       }
 


### PR DESCRIPTION
Related:
- Assessor reviews/resumes past results on device #488
- Quickly add and update views in client v3 #432

Changes:
- DId away with the `current_tangy_form_response_{formId}` document idea in favor of creating a TangyForm document that has a `responseId` property.  TangyFormModel has it's own class as well as getter and setters in the TangyFormService.
- TangyFormService.initialize() makes sure that current version of the TangyFormDesignDoc is in the database being used. If not, then it loads it up.
- TangyForm component code is now much simpler as it uses an instance of TangyFormService to do database operations. It's still a little confusing though on connectedCallback because we are handling a lot of different ways in which it might be used but it should be easier to follow now.
- Heading in a direction of making tangy-form-item more of a simple lazy loader, pushing work up to tangy-form.