### PR TITLE
V3  plane ride fixes

### DIFF
--- a/client/shell/src/app/case-management/form-responses-list/form-responses-list.component.html
+++ b/client/shell/src/app/case-management/form-responses-list/form-responses-list.component.html
@@ -7,7 +7,7 @@
   <ng-container cdkColumnDef="formTitle">
     <mat-header-cell *cdkHeaderCellDef> Form </mat-header-cell>
     <mat-cell *cdkCellDef="let formResponse">
-      <app-tangy-tooltip [tangyToolTipText]="formResponse.form.id" truncateLength="10"></app-tangy-tooltip>
+      <app-tangy-tooltip [tangyToolTipText]="formResponse.formId" truncateLength="10"></app-tangy-tooltip>
     </mat-cell>
   </ng-container>
 

--- a/client/tangy-forms/src/global-styles.js
+++ b/client/tangy-forms/src/global-styles.js
@@ -18,6 +18,7 @@ $_documentContainer.innerHTML = `<custom-style>
       --primary-text-color: var(--light-theme-text-color);
       --primary-color: var(--paper-blue-900);
       --accent-color: #f26f10;
+      --accent-text-color: #FFF;
       --error-color: var(--paper-red-500);
       --disabled-color: #BBB;
       /*
@@ -26,12 +27,11 @@ $_documentContainer.innerHTML = `<custom-style>
       --document-background-color: #93a2b4;
       --primary-text-color: var(--light-theme-text-color);
       --primary-color: #9FADBF;
+      --accent-text-color: #FFF;
       --accent-color: #7edfce;
       --error-color: var(--paper-red-500);
       --disabled-color: #BBB;
        */
-
-    
     }
     h1, h2, h3, h4, h5 {
       @apply --paper-font-common-base;

--- a/client/tangy-forms/src/tangy-form-app/tangy-form-app.js
+++ b/client/tangy-forms/src/tangy-form-app/tangy-form-app.js
@@ -56,7 +56,7 @@ class TangyFormApp extends Element {
         <template is="dom-repeat" items="{{forms}}">
             <paper-card class="form-link" alt="[[item.title]]" heading="[[item.title]]">
                 <div class="card-actions">
-                  <a href="#form=[[item.src]]" on-click="formSelected">
+                  <a href="index.html#form_src=[[item.src]]" on-click="reload">
                     <paper-button class="launch-form">
                       <iron-icon icon="icons:launch">
                     </iron-icon></paper-button>
@@ -179,6 +179,10 @@ class TangyFormApp extends Element {
   onClickNewResponseFab() {
     let params = getHashParams()
     this.loadForm(params.form)
+  }
+
+  reload() {
+    window.location.reload()
   }
 
 }

--- a/client/tangy-forms/src/tangy-form-app/tangy-form-app.js
+++ b/client/tangy-forms/src/tangy-form-app/tangy-form-app.js
@@ -43,11 +43,13 @@ class TangyFormApp extends Element {
         left: 45px;
         top: 8px;
       }
-      #new-response-fab {
+      #new-response-button {
         position: fixed;
+        color: #fff;
         z-index: 999;
-        top: 75px;
-        right: 7px;
+        bottom: 0px;
+        left: 50%;
+        margin-left: -20px;
       }
     </style>
     <div class="tangy-form-app--container">
@@ -67,7 +69,7 @@ class TangyFormApp extends Element {
       </div>
 
       <div id="form-view" hidden="">
-        <paper-fab mini id="new-response-fab" on-click="onClickNewResponseFab" icon="icons:add"></paper-fab>
+        <paper-icon-button mini id="new-response-button" on-click="onClickNewResponseButton" icon="icons:add"></paper-icon-button>
         <div id="form-container"></div>
       </div>
 
@@ -176,9 +178,12 @@ class TangyFormApp extends Element {
     await this.service.saveResponse(newStateDoc)
   }
 
-  onClickNewResponseFab() {
-    let params = getHashParams()
-    this.loadForm(params.form)
+  onClickNewResponseButton() {
+    let confirmation = confirm("Are you sure you want to start a form response?")
+    if (confirmation) {
+      let params = getHashParams()
+      this.loadForm(params.form_src)
+    }
   }
 
   reload() {

--- a/client/tangy-forms/src/tangy-form/tangy-common-styles.js
+++ b/client/tangy-forms/src/tangy-form/tangy-common-styles.js
@@ -24,8 +24,8 @@ $_documentStyleContainer.innerHTML = `
         color: var(--accent-text-color);
         /* fix for the fact that padding is not being taken into account in 
            button position. There is probably a better way to do this. */
-        position: relative;
-        top: 13px;
+        display: inline-flex;
+        min-width: 1em;
       }
       paper-checkbox {
         --paper-checkbox-size: 1.25em;

--- a/client/tangy-forms/src/tangy-form/tangy-common-styles.js
+++ b/client/tangy-forms/src/tangy-form/tangy-common-styles.js
@@ -21,7 +21,11 @@ $_documentStyleContainer.innerHTML = `
       }
       paper-button {
         background: var(--accent-color);
-        color: #FFF;
+        color: var(--accent-text-color);
+        /* fix for the fact that padding is not being taken into account in 
+           button position. There is probably a better way to do this. */
+        position: relative;
+        top: 13px;
       }
       paper-checkbox {
         --paper-checkbox-size: 1.25em;

--- a/client/tangy-forms/src/tangy-form/tangy-element-styles.js
+++ b/client/tangy-forms/src/tangy-form/tangy-element-styles.js
@@ -31,15 +31,20 @@ $_documentStyleContainer.innerHTML = `<dom-module id="tangy-element-styles">
       }
 
       :host([hidden]) {
-        -webkit-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
-        -moz-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
-        -ms-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
-        -o-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        -webkit-transition: 
+          opacity .5s ease-in-out, 
+          max-height .5s ease-in-out,
+          border .5s ease-in-out, 
+          margin .5s ease-in-out, 
+          padding .5s ease-in-out;
         opacity: 0;
         max-height: 0px;
+        border: 0px;
+        margin: 0px;
+        padding: 0px;
       }
 
-      :host([disabled]) {
+      :host([disabled]:not([hidden])) {
         color: var(--disabled-color);
         opacity: .7;
       }

--- a/client/tangy-forms/src/tangy-form/tangy-element-styles.js
+++ b/client/tangy-forms/src/tangy-form/tangy-element-styles.js
@@ -21,8 +21,22 @@ $_documentStyleContainer.innerHTML = `<dom-module id="tangy-element-styles">
         margin: 0 5px 5px 0px;
       }
 
+      :host(:not([hidden])) {
+        -webkit-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        -moz-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        -ms-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        -o-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        opacity: 1;
+        max-height: 3000px;
+      }
+
       :host([hidden]) {
-        display: none;
+        -webkit-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        -moz-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        -ms-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        -o-transition: opacity .5s ease-in-out, max-height .5s ease-in-out;
+        opacity: 0;
+        max-height: 0px;
       }
 
       :host([disabled]) {

--- a/client/tangy-forms/src/tangy-form/tangy-form-response-model.js
+++ b/client/tangy-forms/src/tangy-form/tangy-form-response-model.js
@@ -8,7 +8,7 @@ export class TangyFormResponseModel {
     this.items = []
     this.inputs = []
     // States.
-    complete: false,
+    this.complete = false
     // Focus indexes.
     // @TODO: We can probably get rid of these indexes.
     this.focusIndex = 0


### PR DESCRIPTION
Some usability fixes I made while riding on a plane.

- Bug fix on the shell form list, wrong property name in template.
- An accent-text-color css variable so we don't have to hardcode the text color that overlays accent color.
- New response button integrated into footer as opposed to a floating fab in the top right.
- "Mark response as complete" integrated into the footer and only shows up in place of the next button when there is nothing next and all items are complete.
- Animate the showing and hiding of tangy form elements. Makes for a less jarring experience when skip logic changes something.