### PR TITLE
V3 integrate couchdb

### DIFF
--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -8,9 +8,10 @@ T_PASS="password"
 T_UPLOAD_USER="uploader"
 T_UPLOAD_PASSWORD="password"
 T_COUCHDB_ENABLE="true"
+T_COUCHDB_LOCAL="true"
 T_COUCHDB_USER_ADMIN_NAME="admin"
 T_COUCHDB_USER_ADMIN_PASS="password"
-T_COUCHDB_ENDPOINT="http://couchdb:5984"
+T_COUCHDB_ENDPOINT="http://admin:password@couchdb:5984"
 T_COUCHDB_CONTAINER_NAME="couchdb"
 
 # optional

--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -8,12 +8,15 @@ T_PASS="password"
 T_UPLOAD_USER="uploader"
 T_UPLOAD_PASSWORD="password"
 T_COUCHDB_ENABLE="true"
+T_COUCHDB_USER_ADMIN_NAME="admin"
+T_COUCHDB_USER_ADMIN_PASS="password"
+T_COUCHDB_ENDPOINT="http://couchdb:5984"
 T_COUCHDB_CONTAINER_NAME="couchdb"
 
 # optional
 T_TAG=""
 T_CONTAINER_NAME="tangerine"
-T_PORT_MAPPING="-p 80:80 -p 5984:5984"
+T_PORT_MAPPING="-p 80:80"
 T_DEV_CONTENT="$(pwd)/client/content/default"
 # Add replication entries in this array to start on server boot in 
 # format of `{"from":"localDbName", "to":"remoteDbUrl", "continuous": true}`

--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -7,6 +7,8 @@ T_ADMIN="admin"
 T_PASS="password"
 T_UPLOAD_USER="uploader"
 T_UPLOAD_PASSWORD="password"
+T_COUCHDB_ENABLE="true"
+T_COUCHDB_CONTAINER_NAME="couchdb"
 
 # optional
 T_TAG=""

--- a/develop.sh
+++ b/develop.sh
@@ -44,7 +44,7 @@ docker build -t tangerine/tangerine:local .
 [ "$(docker ps -a | grep $T_CONTAINER_NAME)" ] && docker rm $T_CONTAINER_NAME 
 
 COUCHDB_OPTIONS=""
-if [ "$T_COUCHDB_ENABLE" = "true" ] && [ "$T_COUCHDB_ENDPOINT" = "http://couchdb:5984" ]; then
+if [ "$T_COUCHDB_ENABLE" = "true" ] && [ "$T_COUCHDB_LOCAL" = "true" ]; then
   if [ ! -d data/couchdb ]; then
     mkdir data/couchdb
   fi
@@ -82,7 +82,7 @@ require_valid_user = true
   COUCHDB_OPTIONS="
     --link $T_COUCHDB_CONTAINER_NAME:couchdb \
     -e T_COUCHDB_ENABLE=$T_COUCHDB_ENABLE \
-    -e T_COUCHDB_ENDPOINT=$T_COUCHDB_ENDPOINT \
+    -e T_COUCHDB_ENDPOINT=\"$T_COUCHDB_ENDPOINT\" \
     -e T_COUCHDB_USER_ADMIN_NAME=$T_COUCHDB_USER_ADMIN_NAME \
     -e T_COUCHDB_USER_ADMIN_PASS=$T_COUCHDB_USER_ADMIN_PASS \
   "

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ const compression = require('compression')
 var DB = {}
 if (process.env.T_COUCHDB_ENABLE === 'true') {
   DB = PouchDB.defaults({
-    prefix: 'http://couchdb:5984'
+    prefix: process.env.T_COUCHDB_ENDPOINT
   });
 } else {
   DB = PouchDB.defaults({

--- a/server/index.js
+++ b/server/index.js
@@ -18,9 +18,16 @@ const PouchDB = require('pouchdb')
 const pako = require('pako')
 const compression = require('compression')
 
-const DB = PouchDB.defaults({
-  prefix: '/tangerine/db/'
-});
+var DB = {}
+if (process.env.T_COUCHDB_ENABLE === 'true') {
+  DB = PouchDB.defaults({
+    prefix: 'http://couchdb:5984'
+  });
+} else {
+  DB = PouchDB.defaults({
+    prefix: '/tangerine/db/'
+  });
+}
 const requestLogger = require('./middlewares/requestLogger');
 let crypto = require('crypto');
 const junk = require('junk');

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -673,6 +673,31 @@
         "merge": "1.2.0"
       }
     },
+    "express-http-proxy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.1.0.tgz",
+      "integrity": "sha1-tTOEKt0VtwIdeNJIyAtTV4p7a6A=",
+      "requires": {
+        "debug": "3.1.0",
+        "es6-promise": "4.2.4",
+        "raw-body": "2.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "cors": "^2.8.4",
     "crypto": "^1.0.1",
     "express": "^4.16.2",
+    "express-http-proxy": "^1.1.0",
     "express-session": "1.15.6",
     "flat": "^4.0.0",
     "fs-extra": "^4.0.3",

--- a/start.sh
+++ b/start.sh
@@ -78,12 +78,45 @@ RUN_OPTIONS="
   --volume $(pwd)/data/client/content/groups:/tangerine/client/content/groups \
 " 
 
-if [ "$T_COUCHDB_ENABLE" = "true"  ]; then
-  docker stop $T_COUCHDB_CONTAINER_NAME
-  docker rm $T_COUCHDB_CONTAINER_NAME
-  docker run -d -v $(pwd)/data/couchdb:/opt/couchdb/data --name $T_COUCHDB_CONTAINER_NAME couchdb
+if [ "$T_COUCHDB_ENABLE" = "true" ] && [ "$T_COUCHDB_ENDPOINT" = "http://couchdb:5984" ]; then
+  if [ ! -d data/couchdb ]; then
+    mkdir data/couchdb
+  fi
+  if [ ! -d data/couchdb/data ]; then
+    mkdir data/couchdb/data
+  fi
+  if [ ! -d data/couchdb/local.d ]; then
+    mkdir data/couchdb/local.d
+  fi
+  if [ ! -f data/couchdb/local.d/local.ini ]; then
+    echo "
+[chttpd]
+bind_address = any
+
+[httpd]
+bind_address = any
+
+[couch_httpd_auth]
+require_valid_user = true
+
+[chttpd]
+require_valid_user = true
+    " > data/couchdb/local.d/local.ini
+  [ "$(docker ps | grep $T_COUCHDB_CONTAINER_NAME)" ] && docker stop $T_COUCHDB_CONTAINER_NAME
+  [ "$(docker ps -a | grep $T_COUCHDB_CONTAINER_NAME)" ] && docker rm $T_COUCHDB_CONTAINER_NAME
+  docker run -d \
+     -e COUCHDB_USER=$T_COUCHDB_USER_ADMIN_NAME \
+     -e COUCHDB_PASSWORD=$T_COUCHDB_USER_ADMIN_PASS \
+     -v $(pwd)/data/couchdb/data:/opt/couchdb/data \
+     -v $(pwd)/data/couchdb/local.d:/opt/couchdb/etc/local.d \
+     --name $T_COUCHDB_CONTAINER_NAME \
+     couchdb
   RUN_OPTIONS="
     --link $T_COUCHDB_CONTAINER_NAME:couchdb \
+    -e T_COUCHDB_ENABLE=$T_COUCHDB_ENABLE \
+    -e T_COUCHDB_ENDPOINT=$T_COUCHDB_ENDPOINT \
+    -e T_COUCHDB_USER_ADMIN_NAME=$T_COUCHDB_USER_ADMIN_NAME \
+    -e T_COUCHDB_USER_ADMIN_PASS=$T_COUCHDB_USER_ADMIN_PASS \
     $RUN_OPTIONS
   "
 fi

--- a/start.sh
+++ b/start.sh
@@ -78,7 +78,7 @@ RUN_OPTIONS="
   --volume $(pwd)/data/client/content/groups:/tangerine/client/content/groups \
 " 
 
-if [ "$T_COUCHDB_ENABLE" = "true" ] && [ "$T_COUCHDB_ENDPOINT" = "http://couchdb:5984" ]; then
+if [ "$T_COUCHDB_ENABLE" = "true" ] && [ "$T_COUCHDB_LOCAL" = "true" ]; then
   if [ ! -d data/couchdb ]; then
     mkdir data/couchdb
   fi

--- a/start.sh
+++ b/start.sh
@@ -81,7 +81,7 @@ RUN_OPTIONS="
 if [ "$T_COUCHDB_ENABLE" = "true"  ]; then
   docker stop $T_COUCHDB_CONTAINER_NAME
   docker rm $T_COUCHDB_CONTAINER_NAME
-  docker run -d --name $T_COUCHDB_CONTAINER_NAME couchdb
+  docker run -d -v $(pwd)/data/couchdb:/opt/couchdb/data --name $T_COUCHDB_CONTAINER_NAME couchdb
   RUN_OPTIONS="
     --link $T_COUCHDB_CONTAINER_NAME:couchdb \
     $RUN_OPTIONS

--- a/start.sh
+++ b/start.sh
@@ -62,6 +62,7 @@ RUN_OPTIONS="
   --name $T_CONTAINER_NAME \
   --env \"NODE_ENV=production\" \
   --env \"T_VERSION=$T_TAG\" \
+  --env \"T_COUCHDB_ENABLE=$T_COUCHDB_ENABLE\" \
   --env \"T_PROTOCOL=$T_PROTOCOL\" \
   --env \"T_ADMIN=$T_ADMIN\" \
   --env \"T_PASS=$T_PASS\" \
@@ -77,9 +78,21 @@ RUN_OPTIONS="
   --volume $(pwd)/data/client/content/groups:/tangerine/client/content/groups \
 " 
 
+if [ "$T_COUCHDB_ENABLE" = "true"  ]; then
+  docker stop $T_COUCHDB_CONTAINER_NAME
+  docker rm $T_COUCHDB_CONTAINER_NAME
+  docker run -d --name $T_COUCHDB_CONTAINER_NAME couchdb
+  RUN_OPTIONS="
+    --link $T_COUCHDB_CONTAINER_NAME:couchdb \
+    $RUN_OPTIONS
+  "
+fi
+
+
 CMD="docker run -d $RUN_OPTIONS tangerine/tangerine:$T_TAG"
 
 echo "Running $T_CONTAINER_NAME at version $T_TAG"
+echo "$CMD"
 eval ${CMD}
 
 echo "Installing missing plugin..."


### PR DESCRIPTION
Adds a config.sh configurable couchdb as the default database. Exposed at the same `/v2/` endpoint of `/db/` but when developing it exposes also on port 5984 because Futon only works when at the root directory, not relative.