### PR TITLE
Add TangyModules and example Class module

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ const PouchSession = require("session-pouchdb-store")
 const bodyParser = require('body-parser');
 const path = require('path')
 const app = express()
+var tangyModules = require('./src/modules/index.js')()
 const fs = require('fs-extra')
 const fsc = require('fs')
 const readFile = util.promisify(fsc.readFile);
@@ -433,6 +434,7 @@ app.post('/editor/group/new', isAuthenticated, async function (req, res) {
     }
   }
   let groupName = req.body.groupName
+  await tangyModules.hook('onCreateGroup', groupName)
   // Copy the content directory for the new group.
   await exec(`cp -r /tangerine/client/app/src/assets  /tangerine/client/content/groups/${groupName}`)
   await insertGroupViews(groupName, DB)

--- a/server/src/modules/class/index.js
+++ b/server/src/modules/class/index.js
@@ -1,0 +1,16 @@
+const DB = require('../../db.js')
+const log = require('tangy-log').log
+const clog = require('tangy-log').clog
+
+module.exports = {
+  hooks: {
+    onCreateGroup: function(groupName) {
+      return new Promise((resolve, reject) => {
+        setTimeout(_ => {
+          clog(`Class Module is hooking into onCreateGroup for group ${groupName}`)
+          resolve()
+        }, 1000)
+      })
+    }
+  }
+}

--- a/server/src/modules/index.js
+++ b/server/src/modules/index.js
@@ -1,0 +1,20 @@
+class TangyModules {
+
+  constructor() {
+    let enabledModules = JSON.parse(process.env.T_MODULES.replace(/\'/g,`"`))
+    this.modules = enabledModules.map(moduleName => require(`/tangerine/server/src/modules/${moduleName}/index.js`)) 
+  }
+
+  async hook(hookName, data) {
+    for (let module of this.modules) {
+      if(module.hasOwnProperty('hooks') && module.hooks.hasOwnProperty(hookName)) {
+        data = await module.hooks[hookName](data)
+      }
+    }
+  }
+
+}
+
+module.exports = function() {
+  return new TangyModules()
+}


### PR DESCRIPTION
Here is a possible direction for Tangerine Modules that would allow module to hook into code in the core of the server as opposed to having to place the code for those modules behind conditionals sprinkled around the codebase.