### PR TITLE
Add support for using replication when downloading user info on registration

### DIFF
--- a/client/app/src/app/user-profile/import-user-profile/import-user-profile.component.ts
+++ b/client/app/src/app/user-profile/import-user-profile/import-user-profile.component.ts
@@ -30,8 +30,12 @@ export class ImportUserProfileComponent implements AfterContentInit {
     const db = new PouchDB(userDbName)
     const userId = this.userIdInput.nativeElement.value
     this.docs = await this.http.get(`${this.appConfig.serverUrl}api/${this.appConfig.groupName}/responsesByUserProfileId/${userId}`).toPromise()
-    this.docs.forEach(doc => delete doc._rev)
-    await db.bulkDocs(this.docs);
+    if (this.appConfig.syncProtocol === 'replication') {
+      await PouchDB.replicate(this.appConfig.dbUrl, db, {doc_ids: this.docs.map(doc => doc._id)})
+    } else {
+      this.docs.forEach(doc => delete doc._rev)
+      await db.bulkDocs(this.docs);
+    }
     this.router.navigate([`/${this.appConfig.homeUrl}`] );
   }
 


### PR DESCRIPTION
When sync mode in client is using replication to push docs up, I can see how that might create strange conflicts when your profile/etc. docs came from the server on registration. This is because when those docs are downloaded, it's __not__ done via a couchdb replication, they are downloaded and placed in the pouchdb as new docs but with the same IDs. When Pouch tries to push replicate to Couch, there will be a mismatch between revision ID histories for the same IDs which may cause it to bail in some way. If this is the case, then the original download of docs needs to be a pull replication of only that user's docs. 

This PR shows how that would work in theory. If this is a good idea, we'll need to 1) create a new read/write CouchDB user for a group database when it's created and 2) combine those credentials into a full path dbUrl property for that group's app-config.json. We'll also need to figure out how to communicate that this security model is riskier than other models we had in the past. In v2 we distributed a write only credentials to every person who got the app, in this paradigm we'd be distributing a read and write credentials to every person who got the app.