### PR TITLE
Add an elastic_search module that sends data to elastic search on reportingOutputs hook

### DIFF
--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -34,8 +34,6 @@ T_CENTRALLY_MANAGED_USER_PROFILE="false"
 # Add replication entries in this array to start on server boot in 
 # format of `{"from":"localDbName", "to":"remoteDbUrl", "continuous": true}`
 T_REPLICATE="[]"
-# To enable the Class dashboard, set to "['csv','class']"
-T_MODULES="['csv']"
 # To populate categories in Class:
 #T_CATEGORIES="['one','two','three','four']"
 # This will set the default direction of text flow on new groups.
@@ -46,6 +44,14 @@ T_LEGACY="false"
 T_DEV_CONTENT="$(pwd)/client/content/default"
 # Override the docker image version of Tangerine to use. Note you must also check out that version in git.
 T_TAG=""
+
+#
+# Modules
+#
+
+# To enable the Class dashboard, set to "['csv','class']"
+T_MODULES="['csv']"
+T_MODULE_ELASTIC_SEARCH_URL="http://localhost:9200"
 
 # @TODO Deprecated? 
 T_SYNC_SERVER="localhost:5984"

--- a/develop.sh
+++ b/develop.sh
@@ -8,6 +8,9 @@ fi
 if [ ! -d data/csv ]; then
   mkdir data/csv
 fi
+if [ ! -d data/transformers ]; then
+  mkdir data/transformers
+fi
 if [ ! -d data/client ]; then
   mkdir data/client
 fi
@@ -142,6 +145,7 @@ CMD="docker run -it --name $T_CONTAINER_NAME \
   --volume $(pwd)/data/db:/tangerine/db/ \
   --volume $(pwd)/data/groups:/tangerine/groups/ \
   --volume $(pwd)/data/csv:/csv/ \
+  --volume $(pwd)/data/transformers:/transformers/ \
   --volume $(pwd)/data/worker-state.json:/worker-state.json \
   --volume $(pwd)/data/paid-worker-state.json:/paid-worker-state.json \
   --volume $(pwd)/data/client/releases:/tangerine/client/releases/ \

--- a/server/src/modules/elastic_search/index.js
+++ b/server/src/modules/elastic_search/index.js
@@ -1,0 +1,61 @@
+const log = require('tangy-log').log
+const clog = require('tangy-log').clog
+const http = require('axios')
+import fs, { access } from 'fs';
+import {promisify} from 'util';
+const stat = promisify(fs.stat)
+
+
+module.exports = {
+  hooks: {
+    reportingOutputs: function(data) {
+      return new Promise(async (resolve, reject) => {
+          const {flatResponse, doc, sourceDb} = data
+          await ensureIndex(sourceDb.name);
+          if (await access('/transformers/elastic_search.js') === fs.constants.F_OK) {
+            const transformer = require('/transformers/elastic_search.js')
+            await indexFlattenedFormResponse(await transformer(flatResponse, doc, sourceDb.name), sourceDb.name, doc);
+          } else {
+            await indexFlattenedFormResponse(flatResponse, sourceDb.name, doc);
+          }
+          resolve(data)
+      })
+    }
+  }
+}
+
+function ensureIndex(groupName) {
+  return new Promise((resolve, reject) => {
+    http.get(`http://elasticsearch:9200/${groupName}`)
+      .then(_ => resolve(true))
+      .catch(err => {
+        http.put(`http://elasticsearch:9200/${groupName}`)
+          .then(_ => resolve(true))
+          .catch(err => reject(err))
+      })
+  })
+}
+
+function indexFlattenedFormResponse(doc, groupName, originalDoc) {
+  return new Promise((resolve, reject) => {
+    let safeDoc = Object.assign({}, doc.processedResult)
+    let indexDoc = {}
+    for (let prop in safeDoc) {
+      // elasticsearch gets confused about periods, replace them with underscores.
+      let indexProp = prop.replace(/\./g, '_')
+      if (typeof safeDoc[prop] === 'boolean') {
+        indexDoc[indexProp] = (safeDoc[prop]) ? 'true' : 'false'
+      }
+      else if (!safeDoc[prop]) {
+        indexDoc[indexProp] = ''
+      } else {
+        indexDoc[indexProp] = safeDoc[prop]
+      }
+    }
+    http.put(`${process.env.T_MODULE_ELASTIC_SEARCH_URL}/${groupName}/_doc/${doc._id}`, indexDoc)
+      .then(_ => resolve(true))
+      .catch(err => {
+        reject(err)
+      })
+  })
+}

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,9 @@ fi
 if [ ! -d data/csv ]; then
   mkdir data/csv
 fi
+if [ ! -d data/transformers ]; then
+  mkdir data/transformers
+fi
 if [ ! -d data/client ]; then
   mkdir data/client
 fi
@@ -103,6 +106,7 @@ RUN_OPTIONS="
   --volume $(pwd)/data/paid-worker-state.json:/paid-worker-state.json \
   --volume $(pwd)/data/client/releases:/tangerine/client/releases/ \
   --volume $(pwd)/data/csv:/csv/ \
+  --volume $(pwd)/data/transformers:/transformers/ \
   --volume $(pwd)/data/db:/tangerine/db/ \
   --volume $(pwd)/data/groups:/tangerine/groups/ \
   --volume $(pwd)/data/client/content/groups:/tangerine/client/content/groups \


### PR DESCRIPTION
... and uses a custom transformer option

Enable sending reporting data to elastic search by adding `elastic_search` to the list of enabled modules in `config.sh`. Configure it to send data to elastic search by setting the `T_MODULE_ELASTIC_SEARCH_URL` variable in `config.sh`. It will create indexes and upload by group.  You can also add on a site by site basis your own custom transformer for the data headed to elastic search by putting a Node.js module as a single function at `./data/transformers/elastic_search.js`.