### PR TITLE
Auto calculate descendant count when saving location list

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -33,7 +33,7 @@
     "material-design-icons-iconfont": "^3.0.3",
     "redux": "^4.0.1",
     "rxjs": "~6.3.3",
-    "tangy-form": "^3.3.1",
+    "tangy-form": "^3.3.2",
     "tangy-form-editor": "^5.0.0",
     "tslib": "^1.9.0",
     "underscore": "^1.9.1",

--- a/editor/package.json
+++ b/editor/package.json
@@ -33,7 +33,7 @@
     "material-design-icons-iconfont": "^3.0.3",
     "redux": "^4.0.1",
     "rxjs": "~6.3.3",
-    "tangy-form": "^3.3.0",
+    "tangy-form": "^3.3.1",
     "tangy-form-editor": "^5.0.0",
     "tslib": "^1.9.0",
     "underscore": "^1.9.1",

--- a/editor/src/app/groups/location-list-editor/location-list-editor.component.html
+++ b/editor/src/app/groups/location-list-editor/location-list-editor.component.html
@@ -2,7 +2,9 @@
   <mat-card-title class="tangy-foreground-secondary">
     {{'Manage Locations'|translate}}
   </mat-card-title>
+
   <mat-card-content>
+
     <div class="tangy-full-width">
       <div>
         <mat-chip-list>
@@ -27,7 +29,9 @@
         {{breadcrumbs[breadcrumbs.length-1]['label']}}
 
         to another {{locationsLevels[breadcrumbs.length-3]}}</span>
-
+      <div *ngIf="isLoading">
+        <app-tangy-loading></app-tangy-loading>
+      </div>
       <div *ngIf="showLocationForm">
         <form name="newLocationItemForm" class="tangy-full-width" novalidate #newLocationItemForm="ngForm">
           <mat-form-field class="tangy-full-width">
@@ -35,8 +39,8 @@
           </mat-form-field>
           <div *ngIf="levelHasMetadata">
             <mat-form-field class="tangy-full-width" *ngFor="let item of locationList.metadata[locationsLevels[breadcrumbs.length-1]]">
-              <input [name]="item.variableName" matInput [type]="item.type" [(ngModel)]="form[item.variableName]" placeholder="{{item.label}}"
-                [required]="item.requiredField">
+              <input [name]="item.variableName" matInput [type]="item.type" [(ngModel)]="form[item.variableName]"
+                placeholder="{{item.label}}" [required]="item.requiredField">
             </mat-form-field>
           </div>
           <button [hidden]="isItemMarkedForUpdate" type="button" [disabled]="newLocationItemForm.invalid"

--- a/editor/src/app/groups/location-list-editor/location-list-editor.component.ts
+++ b/editor/src/app/groups/location-list-editor/location-list-editor.component.ts
@@ -30,6 +30,7 @@ export class LocationListEditorComponent implements OnInit {
   moveLocationParentLevelId;
   canMoveItem = false;
   isItemMarkedForUpdate = false;
+  isLoading = false;
   form: any = { label: '', id: '' };
   @ViewChild('container') container: ElementRef;
   constructor(
@@ -177,10 +178,13 @@ export class LocationListEditorComponent implements OnInit {
   }
   async saveLocationListToDisk() {
     try {
+      this.isLoading = true;
       const payload = { filePath: this.locationListFileName, groupId: this.groupName, fileContents: JSON.stringify(this.locationList) };
       await this.http.post(`/editor/file/save`, payload).toPromise();
+      this.isLoading = false;
       this.errorHandler.handleError(`Successfully saved Location list for Group: ${this.groupName}`);
     } catch (error) {
+      this.isLoading = false;
       this.errorHandler.handleError('Error Saving Location Lits File to disk');
     }
   }

--- a/editor/src/app/groups/location-list-editor/location-list-editor.component.ts
+++ b/editor/src/app/groups/location-list-editor/location-list-editor.component.ts
@@ -167,8 +167,9 @@ export class LocationListEditorComponent implements OnInit {
     this.parentItemsForMoveLocation = null;
   }
   async saveLocationListToDisk() {
+    const locationListWithDescendants = Loc.calculateDescendentCounts(this.locationList);
     try {
-      const payload = { filePath: this.locationListFileName, groupId: this.groupName, fileContents: JSON.stringify(this.locationList) };
+      const payload = { filePath: this.locationListFileName, groupId: this.groupName, fileContents: JSON.stringify(locationListWithDescendants) };
       await this.http.post(`/editor/file/save`, payload).toPromise();
       this.errorHandler.handleError(`Successfully saved Location list for Group: ${this.groupName}`);
     } catch (error) {

--- a/editor/src/app/groups/location-list-editor/location-list-editor.component.ts
+++ b/editor/src/app/groups/location-list-editor/location-list-editor.component.ts
@@ -173,7 +173,7 @@ export class LocationListEditorComponent implements OnInit {
     // Check if the item being added or moved is at the last level of the hierarchy. 
     // The descendentsCount needs update ony when the last level has a new item or an item is moved
     if (this.locationsLevelsLength === this.breadcrumbs.length) {
-      this.locationList = Loc.calculateDescendentCounts(this.locationList);
+      this.locationList = Loc.calculateDescendantCounts(this.locationList);
     }
   }
   async saveLocationListToDisk() {

--- a/editor/src/app/shared/_components/tangy-loading/tangy-loading.component.html
+++ b/editor/src/app/shared/_components/tangy-loading/tangy-loading.component.html
@@ -1,0 +1,133 @@
+<!-- Generated using loading.io -->
+<div>
+  <div class="lds-css ng-scope">
+    <div class="lds-spinner" style="100%;height:100%">
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
+    <style type="text/css">
+      @keyframes lds-spinner {
+        0% {
+          opacity: 1;
+        }
+
+        100% {
+          opacity: 0;
+        }
+      }
+
+      @-webkit-keyframes lds-spinner {
+        0% {
+          opacity: 1;
+        }
+
+        100% {
+          opacity: 0;
+        }
+      }
+
+      .lds-spinner {
+        position: relative;
+      }
+
+      .lds-spinner div {
+        left: 95px;
+        top: 57px;
+        position: absolute;
+        -webkit-animation: lds-spinner linear 1s infinite;
+        animation: lds-spinner linear 1s infinite;
+        background: #f05125;
+        width: 10px;
+        height: 22px;
+        border-radius: 196%;
+        -webkit-transform-origin: 5px 43px;
+        transform-origin: 5px 43px;
+      }
+
+      .lds-spinner div:nth-child(1) {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+        -webkit-animation-delay: -0.9s;
+        animation-delay: -0.9s;
+      }
+
+      .lds-spinner div:nth-child(2) {
+        -webkit-transform: rotate(36deg);
+        transform: rotate(36deg);
+        -webkit-animation-delay: -0.8s;
+        animation-delay: -0.8s;
+      }
+
+      .lds-spinner div:nth-child(3) {
+        -webkit-transform: rotate(72deg);
+        transform: rotate(72deg);
+        -webkit-animation-delay: -0.7s;
+        animation-delay: -0.7s;
+      }
+
+      .lds-spinner div:nth-child(4) {
+        -webkit-transform: rotate(108deg);
+        transform: rotate(108deg);
+        -webkit-animation-delay: -0.6s;
+        animation-delay: -0.6s;
+      }
+
+      .lds-spinner div:nth-child(5) {
+        -webkit-transform: rotate(144deg);
+        transform: rotate(144deg);
+        -webkit-animation-delay: -0.5s;
+        animation-delay: -0.5s;
+      }
+
+      .lds-spinner div:nth-child(6) {
+        -webkit-transform: rotate(180deg);
+        transform: rotate(180deg);
+        -webkit-animation-delay: -0.4s;
+        animation-delay: -0.4s;
+      }
+
+      .lds-spinner div:nth-child(7) {
+        -webkit-transform: rotate(216deg);
+        transform: rotate(216deg);
+        -webkit-animation-delay: -0.3s;
+        animation-delay: -0.3s;
+      }
+
+      .lds-spinner div:nth-child(8) {
+        -webkit-transform: rotate(252deg);
+        transform: rotate(252deg);
+        -webkit-animation-delay: -0.2s;
+        animation-delay: -0.2s;
+      }
+
+      .lds-spinner div:nth-child(9) {
+        -webkit-transform: rotate(288deg);
+        transform: rotate(288deg);
+        -webkit-animation-delay: -0.1s;
+        animation-delay: -0.1s;
+      }
+
+      .lds-spinner div:nth-child(10) {
+        -webkit-transform: rotate(324deg);
+        transform: rotate(324deg);
+        -webkit-animation-delay: 0s;
+        animation-delay: 0s;
+      }
+
+      .lds-spinner {
+        width: 89px !important;
+        height: 89px !important;
+        -webkit-transform: translate(-44.5px, -44.5px) scale(0.445) translate(44.5px, 44.5px);
+        transform: translate(-44.5px, -44.5px) scale(0.445) translate(44.5px, 44.5px);
+      }
+    </style>
+  </div>
+</div>

--- a/editor/src/app/shared/_components/tangy-loading/tangy-loading.component.spec.ts
+++ b/editor/src/app/shared/_components/tangy-loading/tangy-loading.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TangyLoadingComponent } from './tangy-loading.component';
+
+describe('TangyLoadingComponent', () => {
+  let component: TangyLoadingComponent;
+  let fixture: ComponentFixture<TangyLoadingComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TangyLoadingComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TangyLoadingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/editor/src/app/shared/_components/tangy-loading/tangy-loading.component.ts
+++ b/editor/src/app/shared/_components/tangy-loading/tangy-loading.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-tangy-loading',
+  templateUrl: './tangy-loading.component.html',
+  styleUrls: ['./tangy-loading.component.css']
+})
+export class TangyLoadingComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/editor/src/app/shared/shared.module.ts
+++ b/editor/src/app/shared/shared.module.ts
@@ -2,13 +2,15 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatSnackBarModule } from '@angular/material';
 import { TranslateModule } from '@ngx-translate/core';
-import {AppConfigService} from "../shared/_services/app-config.service";
+import { AppConfigService } from "../shared/_services/app-config.service";
+import { TangyLoadingComponent } from './_components/tangy-loading/tangy-loading.component';
 
 @NgModule({
   imports: [
     CommonModule
   ],
   providers: [AppConfigService],
-  exports: [TranslateModule, MatSnackBarModule]
+  exports: [TranslateModule, MatSnackBarModule, TangyLoadingComponent],
+  declarations: [TangyLoadingComponent]
 })
 export class SharedModule { }

--- a/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -6,7 +6,6 @@ import {MatTabChangeEvent} from "@angular/material";
 import { UserService } from '../../core/auth/_services/user.service';
 import { WindowRef } from '../../core/window-ref.service';
 import { TangyFormService } from '../tangy-form-service';
-import 'tangy-form/tangy-form.js';
 const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true), milliseconds))
 
 


### PR DESCRIPTION
* Fix for #1259 
## Feature Description
* When saving a location list in editor, we'd like to attach updated descendant counts. The descendant count of an item is the count of all the items at the last level of the hierarchy.

## Approach
* Pass in the location list to the [Loc.calculateDescendentCounts](https://github.com/Tangerine-Community/tangy-form/blob/master/util/loc.js#L107) when saving the location list. 
* The [Loc.calculateDescendentCounts](https://github.com/Tangerine-Community/tangy-form/blob/master/util/loc.js#L107) is only utilized when a new location item has been created, edited or moved. It is not called however when creating/updating location hierarchies or metadata items. This is because the count descendant count would only change when a location item is created or moved.
## Limitations/Trade-offs
* The [Loc.calculateDescendentCounts](https://github.com/Tangerine-Community/tangy-form/blob/master/util/loc.js#L107) walks through the entire tree adding descendant counts at each level for each of the location items and may thus lead to performance degradation on deeply nested location lists with many location items
* A proposed enhancement is to only call [Loc.calculateDescendentCounts](https://github.com/Tangerine-Community/tangy-form/blob/master/util/loc.js#L107) when the items at the last level change i.e. moved or created. This is because *only* the creation, deletion or moving of items at the last level of the hierarchy should trigger an update to `descendantCount`
* Another enhancement would be to set `descendantCount` to `0(zero)` when a new location item is added