### PR TITLE
When dealing with forms, auto compact and don't keep revs

### DIFF
--- a/client/app/src/app/core/update/update/updates.ts
+++ b/client/app/src/app/core/update/update/updates.ts
@@ -130,5 +130,12 @@ export const updates = [
     script: (userDb) => {
       console.log('Updating to v3.0.0-beta13...')
     }
+  },
+  {
+    requiresViewsUpdate: false,
+    script: async (userDb) => {
+      console.log('Updating to v3.1.0...')
+      await userDb.compact()
+    }
   }
 ]

--- a/client/app/src/app/tangy-forms/tangy-form-service.ts
+++ b/client/app/src/app/tangy-forms/tangy-form-service.ts
@@ -14,7 +14,7 @@ export class TangyFormService {
   constructor(props) {
     this.databaseName = 'tangy-forms'
     Object.assign(this, props)
-    this.db = new PouchDB(this.databaseName)
+    this.db = new PouchDB(this.databaseName, {auto_compaction: true, revs_limit: 1})
   }
 
   async initialize() {


### PR DESCRIPTION
… around because we don't replicate, we don't need this feature taking up disk space.

From my tests, if a form response is saved an average of 30 times, turning on auto_compaction saves 10x disk space. [Here is the script](https://gist.github.com/rjsteinert/3429baff17d6070f19d64df6c1efbd36) I used to test this.  Note the average doc size in the first and second cases. The first case is with auto compaction on, results in an average doc size of 77KB. In the second case with compaction turned off, the average doc size is 750KB. The doc used for testing is on the longer side for forms that we have seen but not astronomically large. Note [this issue](https://github.com/pouchdb/pouchdb/issues/4634#issuecomment-366459711) in the PouchDB issue queue where I talk about how just using `db.compact()` does not reduce the size of the database, though it may in time.
 
![screen shot 2019-01-29 at 11 17 42 am](https://user-images.githubusercontent.com/156575/51931225-45a02580-23ca-11e9-8d2a-79684385944c.png)
