### PR TITLE
#1363 disable case event actions

### DIFF
--- a/client/app/src/app/app.component.ts
+++ b/client/app/src/app/app.component.ts
@@ -27,7 +27,8 @@ export class AppComponent implements OnInit {
   updateIsRunning = false;
   @ViewChild(MatSidenav) sidenav: QueryList<MatSidenav>;
   constructor(
-    private windowRef: WindowRef, private userService: UserService,
+    private windowRef: WindowRef,
+    private userService: UserService,
     private authenticationService: AuthenticationService,
     private http: HttpClient,
     private router: Router,

--- a/client/app/src/app/case/classes/case-definition.class.ts
+++ b/client/app/src/app/case/classes/case-definition.class.ts
@@ -7,6 +7,7 @@ class CaseDefinition {
   name:string
   description:string
   eventDefinitions: Array<CaseEventDefinition> = []
+  startFormOnOpen: CaseFormPath
 
   constructor(init:CaseDefinition) {
     Object.assign(this, init);
@@ -20,6 +21,11 @@ class CaseDefinition {
     */
   }
 
+}
+
+class CaseFormPath {
+  eventId:string
+  eventFormId:string
 }
 
 export { CaseDefinition }

--- a/client/app/src/app/case/classes/case.class.ts
+++ b/client/app/src/app/case/classes/case.class.ts
@@ -8,6 +8,7 @@ class Case {
   caseDefinitionId:string
   label:string
   openedDate:number
+  disabledEventDefinitionIds: Array<string> = []
   events: Array<CaseEvent> = []
   collection:string = 'Case'
   constructor(data?:any) {
@@ -20,6 +21,7 @@ class Case {
     this._rev = data._rev
     this.complete = data.complete
     this.openedDate = data.openedDate
+    this.disabledEventDefinitionIds = data.disabledEventDefinitionIds ? data.disabledEventDefinitionIds : []
     this.caseDefinitionId = data.caseDefinitionId
     this.label = data.label
     this.events = data.events.map(caseEventData => new CaseEvent(

--- a/client/app/src/app/case/components/case/case.component.html
+++ b/client/app/src/app/case/components/case/case.component.html
@@ -10,11 +10,12 @@
 
 <div class="wrapper">
   <div class="event-cards" *ngIf="caseService">
+    <div *ngFor="let eventInfo of caseService.eventsInfo">
     <paper-card 
       class="event-card {{eventInfo.required ? 'required' : ''}}" 
       icon="event"
       heading="{{eventInfo.caseEventDefinition.name}}"
-      *ngFor="let eventInfo of caseService.eventsInfo"
+      *ngIf="caseService.case.disabledEventDefinitionIds.indexOf(eventInfo.caseEventDefinition.id) === -1"
     >
       <div class="card-content">
         <span *ngIf="eventInfo.caseEvents.length === 0">
@@ -47,5 +48,6 @@
       </div>
 
     </paper-card>
+    </div>
   </div>
 </div>

--- a/client/app/src/app/case/components/case/case.component.ts
+++ b/client/app/src/app/case/components/case/case.component.ts
@@ -8,13 +8,17 @@ import { CaseService } from '../../services/case.service'
   styleUrls: ['./case.component.css']
 })
 export class CaseComponent implements OnInit, AfterContentInit {
+
   caseService:CaseService;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router
   ) { }
+
   async ngOnInit() {
   }
+
   async ngAfterContentInit() {
     this.route.params.subscribe(async params => {
       const caseService = new CaseService()

--- a/client/app/src/app/case/components/case/case.component.ts
+++ b/client/app/src/app/case/components/case/case.component.ts
@@ -24,7 +24,8 @@ export class CaseComponent implements OnInit, AfterContentInit {
   }
 
   async startEvent(eventDefinitionId) {
-    const caseEvent = await this.caseService.startEvent(eventDefinitionId)
+    const caseEvent = this.caseService.startEvent(eventDefinitionId)
+    await this.caseService.save()
     this.router.navigate(['case', 'event', this.caseService.case._id, caseEvent.id])
   }
 

--- a/client/app/src/app/case/components/event-form/event-form.component.ts
+++ b/client/app/src/app/case/components/event-form/event-form.component.ts
@@ -72,7 +72,8 @@ export class EventFormComponent implements AfterContentInit {
         this.throttledSaveResponse(response)
       })
       this.tangyFormEl.addEventListener('submit', async _ => {
-        await this.caseService.markEventFormComplete(this.caseEvent.id, this.eventForm.id)
+        this.caseService.markEventFormComplete(this.caseEvent.id, this.eventForm.id)
+        await this.caseService.save()
         await this.router.navigate(['case', 'event', this.caseService.case._id, this.caseEvent.id])
       })
       this.loaded = true

--- a/client/app/src/app/case/components/event-form/event-form.component.ts
+++ b/client/app/src/app/case/components/event-form/event-form.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild, ElementRef, AfterContentInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { WindowRef } from '../../../core/window-ref.service';
 import { UserService } from '../../../core/auth/_services/user.service';
 import { CaseService } from '../../services/case.service'
 import { EventForm } from '../../classes/event-form.class';
@@ -29,6 +30,7 @@ export class EventFormComponent implements AfterContentInit {
   @ViewChild('container') container: ElementRef;
   constructor(
     private route: ActivatedRoute,
+    private windowRef: WindowRef,
     private router: Router,
     private userService: UserService
   ) { }
@@ -37,6 +39,7 @@ export class EventFormComponent implements AfterContentInit {
     this.route.params.subscribe(async params => {
       this.caseService = new CaseService()
       await this.caseService.load(params.caseId)
+      this.windowRef.nativeWindow.caseService = this.caseService
       this.caseEvent = this
         .caseService
         .case

--- a/client/app/src/app/case/components/event/event.component.ts
+++ b/client/app/src/app/case/components/event/event.component.ts
@@ -74,7 +74,8 @@ export class EventComponent implements OnInit, AfterContentInit {
 
   async startEventForm(eventFormDefinitionId:string) {
     // Make this function...
-    const eventForm = await this.caseService.startEventForm(this.caseEvent.id, eventFormDefinitionId)
+    const eventForm = this.caseService.startEventForm(this.caseEvent.id, eventFormDefinitionId)
+    await this.caseService.save()
     // Then navigate
     this.router.navigate(['case', 'event', 'form', eventForm.caseId, eventForm.caseEventId, eventForm.id])
   }

--- a/client/app/src/app/case/components/new-case/new-case.component.ts
+++ b/client/app/src/app/case/components/new-case/new-case.component.ts
@@ -28,6 +28,12 @@ export class NewCaseComponent implements OnInit {
   async onCaseDefinitionSelect(caseDefinitionId = '') {
     const caseService = new CaseService()
     await caseService.create(caseDefinitionId)
-    this.router.navigate(['case', caseService.case._id])
+    if (caseService.caseDefinition.startFormOnOpen && caseService.caseDefinition.startFormOnOpen.eventFormId) {
+      const caseEvent = await caseService.startEvent(caseService.caseDefinition.startFormOnOpen.eventId)
+      const eventForm = await caseService.startEventForm(caseEvent.id, caseService.caseDefinition.startFormOnOpen.eventFormId) 
+      this.router.navigate(['case', 'event', 'form', eventForm.caseId, eventForm.caseEventId, eventForm.id])
+    } else {
+      this.router.navigate(['case', caseService.case._id])
+    }
   }
 }

--- a/client/app/src/app/case/components/new-case/new-case.component.ts
+++ b/client/app/src/app/case/components/new-case/new-case.component.ts
@@ -29,8 +29,9 @@ export class NewCaseComponent implements OnInit {
     const caseService = new CaseService()
     await caseService.create(caseDefinitionId)
     if (caseService.caseDefinition.startFormOnOpen && caseService.caseDefinition.startFormOnOpen.eventFormId) {
-      const caseEvent = await caseService.startEvent(caseService.caseDefinition.startFormOnOpen.eventId)
-      const eventForm = await caseService.startEventForm(caseEvent.id, caseService.caseDefinition.startFormOnOpen.eventFormId) 
+      const caseEvent = caseService.startEvent(caseService.caseDefinition.startFormOnOpen.eventId)
+      const eventForm = caseService.startEventForm(caseEvent.id, caseService.caseDefinition.startFormOnOpen.eventFormId) 
+      await caseService.save()
       this.router.navigate(['case', 'event', 'form', eventForm.caseId, eventForm.caseEventId, eventForm.id])
     } else {
       this.router.navigate(['case', caseService.case._id])

--- a/client/app/src/app/case/services/case.service.ts
+++ b/client/app/src/app/case/services/case.service.ts
@@ -73,7 +73,7 @@ class CaseService {
     await this.setCase(await this.db.get(this.case._id))
   }
 
-  async startEvent(eventDefinitionId:string):Promise<CaseEvent> {
+  startEvent(eventDefinitionId:string):CaseEvent {
     const caseEvent = new CaseEvent(
       UUID(),
       false,
@@ -83,11 +83,10 @@ class CaseService {
       Date.now()
     )
     this.case.events.push(caseEvent)
-    await this.save()
     return caseEvent
   }
 
-  async startEventForm(caseEventId, eventFormId):Promise<EventForm> {
+  startEventForm(caseEventId, eventFormId):EventForm {
     const eventForm = new EventForm(UUID(), false, this.case._id, caseEventId, eventFormId)
     this
       .case
@@ -95,11 +94,10 @@ class CaseService {
       .find(caseEvent => caseEvent.id === caseEventId)
       .eventForms
       .push(eventForm)
-    await this.save()
     return eventForm
   }
-  
-  async markEventFormComplete(caseEventId:string, eventFormId:string) {
+
+  markEventFormComplete(caseEventId:string, eventFormId:string) {
     //
     let caseEvent = this
       .case
@@ -146,8 +144,6 @@ class CaseService {
     this
       .case
       .complete = numberOfCaseEventsRequired === numberOfUniqueCompleteCaseEvents ? true : false
-    await this.save()
-
     
   }
 

--- a/client/app/src/app/case/services/case.service.ts
+++ b/client/app/src/app/case/services/case.service.ts
@@ -147,6 +147,12 @@ class CaseService {
     
   }
 
+  disableEventDefinition(eventDefinitionId) {
+    if (this.case.disabledEventDefinitionIds.indexOf(eventDefinitionId) === -1) {
+      this.case.disabledEventDefinitionIds.push(eventDefinitionId)
+    }
+  }
+
 }
 
 export { CaseService }


### PR DESCRIPTION
Related to #1363 

This allows you to access the caseService from your form and also to disable types of events. Here is an example of disabling a number of Event Definitions given the fact that the form submitted without consent given.
```
<tangy-form id="form1" title="Form 1" on-submit="
  if (!getValue('consent')) {
    caseService.disableEventDefinition('event-definition-first-visit')
    caseService.disableEventDefinition('event-definition-repeatable-event')
    caseService.disableEventDefinition('event-definition-not-required-event')
  }
  ">
  <tangy-form-item id="item1" title="Item 1">
    <tangy-input name="first_name" label="First Name" type="text" required></tangy-input>
    <tangy-input name="middle_name" label="Middle Name" type="text" required></tangy-input>
    <tangy-input name="last_name" label="Last Name" type="text" required></tangy-input>
  </tangy-form-item>
  <tangy-form-item id="item2" title="Item 2">
    <tangy-checkbox name="consent" label="I consent to this study"></tangy-checkbox>
  </tangy-form-item>
</tangy-form>
```