### PR TITLE
Remove periods from new form IDs

### DIFF
--- a/editor/src/app/groups/group-details/group-details.component.ts
+++ b/editor/src/app/groups/group-details/group-details.component.ts
@@ -44,7 +44,7 @@ export class GroupDetailsComponent implements OnInit {
   }
 
   generateFormId() {
-    return 'form-' + Math.random()
+    return 'form-' + this.UUID()
   }
 
   generateUuid() {


### PR DESCRIPTION
Related to #1516 "formIDs that have a period in them throw off the data parsing in logstash". Instead of `Math.random()`, use a UUID.