### PR TITLE
Add PR Template to enhance documentation and help documentation writers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+## Description
+
+---
+
+[What is the business, user experience or technical problem? What is the motivation or context? Any Dependencies required for the change? e.g `tangy-forms` version etc]
+[List the issues fixed and any other relevant issues]
+
+- Fixes #IssueNumber
+
+## Type of Change
+
+[Please delete irrelevant options]
+
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
+
+## Proposed Solution
+
+---
+
+[Please give a description of the solution proposed in the PR]
+
+## Limitations and Trade-offs
+
+[Optional. What are the limitations of the proposed solution? What are the potential edge cases that one should be aware of? What are some of the tradeoffs? What are some of the approaches considered and not used? Why were they not used? ]
+
+## Screenshots/Videos
+
+---
+
+[Optional. Post screenshots or videos to explain this change visually.]
+
+## Tests
+
+---
+
+[How you tested (or have not tested) this PR and what where those steps.]
+
+## Notices, Regressions, Breaking Changes
+
+---
+
+[Optional. Impacts to developers, project or structure that is required to be communicated.]
+
+## TODOS/enhancements
+
+---
+
+[Optional. List out the remaining tasks that would complete this pull request.]
+
+- [Develop more tests for this PR.]
+- [Follow up on something else.]


### PR DESCRIPTION
* The  conversation about how to get developer notes into the documentation was helpful. The challenge for PR reviewers and documentation creators is knowing what has changed in the code base, how things work and any relevant dependencies. 

* Even for developers, at times we need communication around how dependencies have changed etc. 

* In order to help us have a more streamlined documentation process, I have added a PR template to help in collecting and storing these and other vital info regarding the work done in PRs.

* What are some improvements we could make in the PR creation process?