### PR TITLE
[#1681] Replacing paper-icon-item with bespoke HTML/CSS. Styling added.

### DIFF
--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.css
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.css
@@ -1,0 +1,34 @@
+.icon-list-item {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	font-family: var(--paper-font-subhead_-_font-family);
+	font-size: var(--paper-font-subhead_-_font-size);
+	font-weight: var(--paper-font-subhead_-_font-weight);
+	line-height: var(--paper-font-subhead_-_line-height);
+	min-height: var(--paper-item-min-height, 48px);
+	padding: 0 16px;
+}
+.icon-list-item > mwc-icon {
+	width: 56px;
+}
+.icon-list-item > div {
+	min-height: var(--paper-item-body-two-line-min-height, 72px);
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	flex: 1;
+	flex-basis: 0.0000000001px;
+}
+.icon-list-item > div > div {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.icon-list-item > div > div + div {
+	font-size: var(--paper-font-body1_-_font-size);
+	font-weight: var(--paper-font-body1_-_font-weight);
+	line-height: var(--paper-font-body1_-_line-height);
+	color: var(--paper-item-body-secondary-color, var(--secondary-text-color));
+}

--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.html
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.html
@@ -1,7 +1,7 @@
-<paper-icon-item>
-  <mwc-icon [innerHTML]="renderedTemplateListItemIcon" slot="item-icon"></mwc-icon> 
-  <paper-item-body two-line>
-    <div [innerHTML]="renderedTemplateListItemPrimary|unsanitizeHtml"></div>
-    <div [innerHTML]="renderedTemplateListItemSecondary|unsanitizeHtml" secondary></div>
-  </paper-item-body>
-</paper-icon-item>
+<div class="icon-list-item">
+	<mwc-icon [innerHTML]="renderedTemplateListItemIcon" slot="item-icon"></mwc-icon>
+	<div>
+		<div [innerHTML]="renderedTemplateListItemPrimary|unsanitizeHtml"></div>
+		<div [innerHTML]="renderedTemplateListItemSecondary|unsanitizeHtml" secondary></div>
+	</div>
+</div>

--- a/client/src/app/case/components/event/event.component.css
+++ b/client/src/app/case/components/event/event.component.css
@@ -31,11 +31,16 @@ paper-card {
     text-align: left;
 }
 
+app-event-form-list-item {
+    display: flex;
+}
+app-event-form-list-item:focus {
+    outline: none;
+    background-color: rgba(0,0,0,0.12);
+}
 .form {
-    background: #FFF;
-    border-color: #CCC;
-    border-style: solid;
-    border-width: 1px 0px 1px 0px;
+    background: #fff;
+    border-top: 1px solid #ccc;
 }
 
 .form.required {
@@ -43,7 +48,7 @@ paper-card {
 }
 
 .form.new-form {
-    border-style: dashed;
+    border: 1px dashed #ccc;
 }
 
 .form.complete {


### PR DESCRIPTION
## Description

---
We need to be able to pass in translation markup but the paper-icon-item has a problem where the extra markup is not clickable/tappable. So here I've replaced the paper-icon-item with our own HTML and attempted to make it look like the paper-icon-item. I also included some other minor styling additions.

- Fixes #1681 