### PR TITLE
Fix metadata print screen options

### DIFF
--- a/editor/src/app/groups/print-form-as-table/print-form-as-table.component.html
+++ b/editor/src/app/groups/print-form-as-table/print-form-as-table.component.html
@@ -1,60 +1,64 @@
 <style>
   .tangy-main-container {
-    left : 0px;
-    position:relative !important
+    left: 0px;
+    position: relative !important
   }
-  mat-toolbar, mat-tab-header {
-    display:none !important;
+
+  mat-toolbar,
+  mat-tab-header {
+    display: none !important;
   }
 </style>
 <div class="tangy-content tangy-full-width">
-	<mat-card>
-	<mat-card-title>
-    <div #container></div>
-    {{'Group'|translate}}: {{groupDetails.label}}<br>
-    {{'Group ID'}}: {{groupDetails.id}}<br>
-		{{'Form'|translate}}: {{meta.form.title}}
-  </mat-card-title>
-  <br><br><br>
-	<div>
-		<div *ngFor="let section of meta.items;let index= index">
-      <p>Section {{index+1}}</p>
-      <p>ID: {{section.id}}</p>
-			<table class="tangy-full-width">
-				<th>Variable Name</th>
-				<th>Prompt</th>
-				<th>Type</th>
-				<th>Hint Text</th>
-        <th>Options</th>
-        <th>Required</th>
-        <th>Disabled</th>
-        <th>Hidden</th>
-        <th></th>
-				<tr *ngFor="let input of section.inputs">
-					<td>{{input.name}}</td>
-					<td>{{input.label}}</td>
-					<td>
-            {{input.tagName==='TANGY-SELECT'?'single':''}}
-            {{input.tagName==='TANGY-RADIO-BUTTONS'?'single':''}}
-            {{input.tagName==='TANGY-CHECKBOX'?'single':''}}
-            {{input.tagName==='TANGY-CHECKBOXES'?'multiple':''}}
-            {{input.type}}
-          </td>
-          <td>{{input.hintText}}</td>
-          <td>
-            <span *ngFor="let option of input.value; let i=index">
-              {{i+1}} {{option.name}} {{option.value}},
-            </span>
-          </td>
-          <td>{{input.required}}</td>
-          <td>{{input.disabled}}</td>
-          <td>{{input.hidden}}</td>
-				</tr>
+  <mat-card>
+    <mat-card-title>
+      <div #container></div>
+      {{'Group'|translate}}: {{groupDetails?.label}}<br>
+      {{'Group ID'}}: {{groupDetails?.id}}<br>
+      {{'Form'|translate}}: {{meta?.form.title}}
+    </mat-card-title>
+    <br><br><br>
+    <div>
+      <div *ngFor="let section of meta?.items;let index= index">
+        <p>Section {{index+1}}</p>
+        <p>ID: {{section.id}}</p>
+        <table class="tangy-full-width">
+          <th>Variable Name</th>
+          <th>Prompt</th>
+          <th>Type</th>
+          <th>Hint Text</th>
+          <th>Options</th>
+          <th>Required</th>
+          <th>Disabled</th>
+          <th>Hidden</th>
+          <th></th>
+          <tr *ngFor="let input of section.inputs">
+            <td>{{input.name}}</td>
+            <td>{{input.label}}</td>
+            <td>
+              {{input.tagName==='TANGY-SELECT'?'single':''}}
+              {{input.tagName==='TANGY-RADIO-BUTTONS'?'single':''}}
+              {{input.tagName==='TANGY-CHECKBOX'?'single':''}}
+              {{input.tagName==='TANGY-CHECKBOXES'?'multiple':''}}
+              {{input.type}}
+            </td>
+            <td>{{input.hintText}}</td>
+            <td>
+              <span *ngIf="input.value.length>1">
+                <span *ngFor="let option of input.value">
+                  {{option.value}} {{'"'+option.label+'" '}}
+                </span>
+              </span>
+            </td>
+            <td>{{input.required}}</td>
+            <td>{{input.disabled}}</td>
+            <td>{{input.hidden}}</td>
+          </tr>
         </table>
         <br>
         <hr>
         <br><br>
-		</div>
-	</div>
-	</mat-card>
+      </div>
+    </div>
+  </mat-card>
 </div>

--- a/editor/src/app/groups/print-form-as-table/print-form-as-table.component.html
+++ b/editor/src/app/groups/print-form-as-table/print-form-as-table.component.html
@@ -45,8 +45,8 @@
             <td>{{input.hintText}}</td>
             <td>
               <span *ngIf="input.value.length>1">
-                <span *ngFor="let option of input.value">
-                  {{option.value}} {{'"'+option.label+'" '}}
+                <span *ngFor="let option of input.value; let index=index">
+                  {{option.value}} {{'"'+option.label+'"'}}{{index+1===input.value.length?'':' ,'}}
                 </span>
               </span>
             </td>


### PR DESCRIPTION
## Description

---

* In the print form as table view, the radio buttons and check boxes are rendered as  `index` value, index value` instead of `value "option", value "option"`
The rendered output should be similar to the one of v2 in this regard.
* There are places where `*ngFor` attempts to iterate over items which are as yet undefined as `AJAX` calls haven't completed yet leading to console errors.

- Fixes #1670 and #1671 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

* Change the template bindings so as to be in the form `value "option", value "option"` for radios and check-boxes.
* Only do an `*ngFor` iteration if the `AJAX` call has completed. This is effected using the syntax `<div *ngFor="let item of myVar?.attr"></div>` which only evaluates the `attr` property if `myVar` is defined. [Link](https://stackoverflow.com/questions/36583503/ngfor-object-attribute-undefined)



## Screenshots/Videos

---
![image](https://user-images.githubusercontent.com/6088118/66477439-cc9cb600-eaa0-11e9-9496-b00e9de5e944.png)
## Tests

---
* Comparing the outputs of the the Table to the expected output as in V2
* Checking for console errors for  attempting to iterate over `undefined` items
