### PR TITLE
Move xvfb start command for travis to services section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ cache:
     - $HOME/.yarn-cache
     - client/node_modules
     - server/node_modules
+services:
+  - xvfb
 before_install:
   - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - npm install -g @angular/cli
 install:
   - cd client/ && cp -r default-assets src/assets && npm install && cd ../server && npm install

--- a/client/src/karma.conf.js
+++ b/client/src/karma.conf.js
@@ -3,6 +3,12 @@
 
 module.exports = function (config) {
   config.set({
+    // START Added from https://github.com/jasmine/jasmine/issues/1413#issuecomment-334247097
+    captureTimeout: 210000,
+    browserDisconnectTolerance: 3, 
+    browserDisconnectTimeout : 210000,
+    browserNoActivityTimeout : 210000,
+    // END
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [


### PR DESCRIPTION
All test currently fail with `The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .`.  According to [this blog post](https://benlimmer.com/2019/01/14/travis-ci-xvfb/), moving xvfb from before_scripts to services will fix it.