### PR TITLE
Re-order form listing

### DIFF
--- a/editor/src/app/groups/group-details/group-details.component.css
+++ b/editor/src/app/groups/group-details/group-details.component.css
@@ -47,3 +47,25 @@ mat-list-item {
 mat-select {
   visibility: hidden;
 }
+.mat-option {
+  width: 150px;
+}
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+    0 3px 5px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+.tangy-spacer-drag {
+  width: 60%;
+}
+.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+.drag-list.cdk-drop-list-dragging .drag-item:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/editor/src/app/groups/group-details/group-details.component.html
+++ b/editor/src/app/groups/group-details/group-details.component.html
@@ -30,35 +30,78 @@
           </div>
 
           <h2 class="tangy-foreground-secondary">{{'Active Forms'|translate}}</h2>
-          <mat-list>
-            <mat-list-item *ngFor="let form of activeForms; let index=index">
+          <mat-list class="drag-list" cdkDropList (cdkDropListDropped)="dropActive($event)">
+
+
+            <mat-list-item class="drag-item" *ngFor="let form of activeForms; let index=index" cdkDrag
+              [cdkDragDisabled]="!isGroupAdminUser">
+              <mat-list class="tangy-full-width" *cdkDragPreview>
+                <mat-list-item>
+                  <span>{{index+1}}</span>
+                  <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+                  <span>{{form.title}}</span>
+                  <span class="tangy-spacer-drag"></span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">add</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">edit</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">print</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">flip_to_front</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">delete</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">archive</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
+                    </a>
+                  </span>
+                </mat-list-item>
+              </mat-list>
               <span>{{index+1}}</span>
               <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
               <span class="tangy-spacer">{{form.title}}</span>
 
-              <span><a mat-icon-button [routerLink]="['/tangy-form-player']" [queryParams]="{formId: form.id, groupName: groupName}">
-                <i class="material-icons mat-32 tangy-location-list-icon">add</i>
-              </a>
-            </span>
-            <span ><a mat-icon-button [routerLink]="isGroupAdminUser?'/tangy-form-editor/'+groupName+'/'+form.id:'/groups/'+groupName">
-                <i [class.disabled-button]="!isGroupAdminUser" class="material-icons mat-32 tangy-location-list-icon">edit</i>
-              </a>
-            </span>
-            <span>
-						  <mat-select #test>
-								<mat-option>
-											<a mat-icon-button target="_new" [href]="form.printUrl">{{'Print Content'|translate}}</a>
-										</mat-option>
-										<mat-option>
-											<a mat-icon-button target="_new" [href]="groupUrl+'#/groups/'+groupId+'/printFormAsTable/'+form.id">{{'Print Metadata'|translate}}</a>
-										</mat-option>
-									</mat-select>
-								</span>
-						<span>
-							<a mat-icon-button (click)="test.open()">
-								<i class="material-icons mat-32 tangy-location-list-icon">print</i>
-							</a> 
-						</span>
+              <span><a mat-icon-button [routerLink]="['/tangy-form-player']"
+                  [queryParams]="{formId: form.id, groupName: groupName}">
+                  <i class="material-icons mat-32 tangy-location-list-icon">add</i>
+                </a>
+              </span>
+              <span><a mat-icon-button
+                  [routerLink]="isGroupAdminUser?'/tangy-form-editor/'+groupName+'/'+form.id:'/groups/'+groupName">
+                  <i [class.disabled-button]="!isGroupAdminUser"
+                    class="material-icons mat-32 tangy-location-list-icon">edit</i>
+                </a>
+              </span>
+              <span>
+                <mat-select #test>
+                  <mat-option>
+                    <a mat-icon-button target="_new" [href]="form.printUrl">{{'Print Content'|translate}}</a>
+                  </mat-option>
+                  <mat-option>
+                    <a mat-icon-button target="_new"
+                      [href]="groupUrl+'#/groups/'+groupId+'/printFormAsTable/'+form.id">{{'Print Metadata'|translate}}</a>
+                  </mat-option>
+                </mat-select>
+              </span>
+              <span>
+                <a mat-icon-button (click)="test.open()">
+                  <i class="material-icons mat-32 tangy-location-list-icon">print</i>
+                </a>
+              </span>
 
               <span>
                 <a mat-icon-button (click)="onCopyFormClick(form.id)">
@@ -90,8 +133,45 @@
             </mat-list-item>
           </mat-list>
           <h2 class="tangy-foreground-secondary">{{'Archived Forms'|translate}}</h2>
-          <mat-list>
-            <mat-list-item *ngFor="let form of archivedForms; let index=index">
+          <mat-list class="drag-list" cdkDropList (cdkDropListDropped)="dropArchived($event)">
+            <mat-list-item class="drag-item" *ngFor="let form of archivedForms; let index=index" cdkDrag
+              [cdkDragDisabled]="!isGroupAdminUser">
+              <mat-list class="tangy-full-width" *cdkDragPreview>
+                <mat-list-item>
+                  <span>{{index+1}}</span>
+                  <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+                  <span>{{form.title}}</span>
+                  <span class="tangy-spacer-drag"></span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">add</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">edit</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">print</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">flip_to_front</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">delete</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">archive</i>
+                    </a>
+                  </span>
+                  <span><a mat-icon-button>
+                      <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
+                    </a>
+                  </span>
+                </mat-list-item>
+              </mat-list>
               <span>{{index+1}}</span>
               <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
               <span class="tangy-spacer">{{form.title}}</span>
@@ -168,77 +248,77 @@
           <paper-card heading="
             Android Installation
           ">
-						<div class="card-content">
-							<p>
-								Use this for offline deployments or those with many forms and assets.
-							</p>
-							<mat-list>
-								<mat-list-item class="tangy-location-list">
-									<span class="tangy-foreground-secondary">
-										<a [routerLink]="['/group/release-apk',groupName,'qa']">
-											<iron-icon icon="assignment-late"></iron-icon> {{'Test Release'|translate}}
-										</a>
-									</span>
-								</mat-list-item>
-								<mat-list-item class="tangy-location-list">
-									<span class="tangy-foreground-secondary">
-										<a [routerLink]="['/group/release-apk',groupName,'prod']">
-											<iron-icon icon="assignment-turned-in"></iron-icon> {{'Live Release'|translate}}
-										</a>
-									</span>
-								</mat-list-item>
-							</mat-list>
-						</div>
-					</paper-card>
-				</td>
-				<td>
-					<paper-card heading="
+            <div class="card-content">
+              <p>
+                Use this for offline deployments or those with many forms and assets.
+              </p>
+              <mat-list>
+                <mat-list-item class="tangy-location-list">
+                  <span class="tangy-foreground-secondary">
+                    <a [routerLink]="['/group/release-apk',groupName,'qa']">
+                      <iron-icon icon="assignment-late"></iron-icon> {{'Test Release'|translate}}
+                    </a>
+                  </span>
+                </mat-list-item>
+                <mat-list-item class="tangy-location-list">
+                  <span class="tangy-foreground-secondary">
+                    <a [routerLink]="['/group/release-apk',groupName,'prod']">
+                      <iron-icon icon="assignment-turned-in"></iron-icon> {{'Live Release'|translate}}
+                    </a>
+                  </span>
+                </mat-list-item>
+              </mat-list>
+            </div>
+          </paper-card>
+        </td>
+        <td>
+          <paper-card heading="
             Web Browser Installation
           ">
-						<div class="card-content">
-							<p>
-								Use this for smaller deployments where tablets have solid internet connectivity.
-							</p>
-							<mat-list>
-								<mat-list-item class="tangy-location-list">
-									<span class="tangy-foreground-secondary">
-										<a [routerLink]="['/group/release-pwa',groupName,'qa']">
-											<iron-icon icon="assignment-late"></iron-icon> {{'Test Release'|translate}}
-										</a>
-									</span>
-								</mat-list-item>
-								<mat-list-item class="tangy-location-list">
-									<span class="tangy-foreground-secondary">
-										<a [routerLink]="['/group/release-pwa',groupName,'prod']">
-											<iron-icon icon="assignment-turned-in"></iron-icon> {{'Live Release'|translate}}
-										</a>
-									</span>
-								</mat-list-item>
-							</mat-list>
-						</div>
-					</paper-card>
-				</td>
-			</tr>
-		</table>
-	</mat-tab>
+            <div class="card-content">
+              <p>
+                Use this for smaller deployments where tablets have solid internet connectivity.
+              </p>
+              <mat-list>
+                <mat-list-item class="tangy-location-list">
+                  <span class="tangy-foreground-secondary">
+                    <a [routerLink]="['/group/release-pwa',groupName,'qa']">
+                      <iron-icon icon="assignment-late"></iron-icon> {{'Test Release'|translate}}
+                    </a>
+                  </span>
+                </mat-list-item>
+                <mat-list-item class="tangy-location-list">
+                  <span class="tangy-foreground-secondary">
+                    <a [routerLink]="['/group/release-pwa',groupName,'prod']">
+                      <iron-icon icon="assignment-turned-in"></iron-icon> {{'Live Release'|translate}}
+                    </a>
+                  </span>
+                </mat-list-item>
+              </mat-list>
+            </div>
+          </paper-card>
+        </td>
+      </tr>
+    </table>
+  </mat-tab>
 
-	<mat-tab *ngIf="isGroupAdminUser" label="Manage Location List Levels">
-		<app-manage-location-list-levels></app-manage-location-list-levels>
-	</mat-tab>
+  <mat-tab *ngIf="isGroupAdminUser" label="Manage Location List Levels">
+    <app-manage-location-list-levels></app-manage-location-list-levels>
+  </mat-tab>
 
-	<mat-tab *ngIf="isGroupAdminUser" label="Manage Location List Content">
-		<app-location-list-editor></app-location-list-editor>
-	</mat-tab>
-	<mat-tab *ngIf="isGroupAdminUser&&enabledModules.indexOf('case')>-1" label="{{'Case Management Editor'|translate}}">
-		<app-case-management-editor></app-case-management-editor>
-	</mat-tab>
+  <mat-tab *ngIf="isGroupAdminUser" label="Manage Location List Content">
+    <app-location-list-editor></app-location-list-editor>
+  </mat-tab>
+  <mat-tab *ngIf="isGroupAdminUser&&enabledModules.indexOf('case')>-1" label="{{'Case Management Editor'|translate}}">
+    <app-case-management-editor></app-case-management-editor>
+  </mat-tab>
 
-	<mat-tab *ngIf="isGroupAdminUser" label="{{'Manage Users'|translate}}">
-		<app-list-users class="tangy-full-width"></app-list-users>
-	</mat-tab>
+  <mat-tab *ngIf="isGroupAdminUser" label="{{'Manage Users'|translate}}">
+    <app-list-users class="tangy-full-width"></app-list-users>
+  </mat-tab>
 
-	<mat-tab *ngIf="isGroupAdminUser" label="{{'Media Library'|translate}}">
-		<app-group-media></app-group-media>
-	</mat-tab>
+  <mat-tab *ngIf="isGroupAdminUser" label="{{'Media Library'|translate}}">
+    <app-group-media></app-group-media>
+  </mat-tab>
 
 </mat-tab-group>

--- a/editor/src/app/groups/groups.module.ts
+++ b/editor/src/app/groups/groups.module.ts
@@ -5,6 +5,7 @@ import {
   MatAutocompleteModule, MatSelectModule, MatChipsModule, MatGridListModule
 } from '@angular/material';
 import { MatTreeModule } from '@angular/material/tree';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { GroupComponent } from './group/group.component';
 import { GroupsRoutingModule } from './groups-routing.module';
 import { GroupsComponent } from './groups.component';
@@ -46,6 +47,7 @@ import { CopyFormComponent } from './copy-form/copy-form.component';
     CommonModule,
     MatGridListModule,
     FormsModule,
+    DragDropModule,
     ReactiveFormsModule,
     MatInputModule,
     MatAutocompleteModule,


### PR DESCRIPTION

## Description

---
* An admin user should be able to change the order in which forms are listed in the `Tangerine Editor`. Pre-dating this PR, this is only possible through editing the underlying `forms.json` manually.
* Non admin users should not be able to change the order of forms.

- Fixes #1523 

## Type of Change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---
* Implement a drag and drop feature, thus enabling an administrative user to change the order of forms. Makes use of `Angular's cdk` for the draggable interface.
* When a users drags and drops an item into a valid `drop` container, the user is asked to confirm the action. If `true`, the forms are re-ordered and the changes are persisted to the underlying `forms.json` file on disk.

* Since forms of type `user-profile` and `reports` are not in a groups `forms.json` but added dynamically, the two form types are always index `0` and `1` respectively. As such when any of them is dragged and dropped, there is no change to the underlying `forms.json` and thus users are not asked to confirm the action, as no change will be made. Also, dropping an item into index `0` or `1` does not make any changes to the `forms.json` for the reason that the first two indices are always `user-profile` and reports.

* The drag and drop is disabled for non administrative users. There is no draggable element(s) in the list when a user is not an administrative user.

* When persisting to `forms.json` after a re-order, the `printUrl` property is deleted as it is not in the `forms.json` but added on the fly to each of the entries from the result of querying for the contents of `forms.json`

* We add an item preview that mimics the item being dragged. This is through creating another `list-item` when dragging that corresponds to the one being dragged to give the user an illusory effect of the `list-item` being moved.


## Limitations and Trade-offs

* The challenge would be when dragging and dropping over very long lists of forms

## Screenshots/Videos

---
* [Video of and administrative user changing order of forms](http://recordit.co/j7wWQEbgqj)

## Tests

---
* User testing on the browser

## TODOS/enhancements

---
* It would be great to make `user-profile` and `reports` non-draggable as dragging and dropping them to another place on the list does not change the order in which they appear.
