### PR TITLE
Change variable names capture items at n seconds

### DIFF
--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -142,9 +142,9 @@ const generateFlatResponse = async function (formResponse, locationList) {
         flatFormResponse[`${formID}.${item.id}.${input.name}.time_remaining`] = input.timeRemaining
         flatFormResponse[`${formID}.${item.id}.${input.name}.gridAutoStopped`] = input.gridAutoStopped
         flatFormResponse[`${formID}.${item.id}.${input.name}.autoStop`] = input.autoStop
-        flatFormResponse[`${formID}.${item.id}.${input.name}.GRID_VAR_item_at_time`]
+        flatFormResponse[`${formID}.${item.id}.${input.name}.item_at_time`]
           = input.gridVarItemAtTime ? input.gridVarItemAtTime : ''
-        flatFormResponse[`${formID}.${item.id}.${input.name}.GRID_VAR_time_intermediate_captured`]
+        flatFormResponse[`${formID}.${item.id}.${input.name}.time_intermediate_captured`]
           = input.gridVarTimeIntermediateCaptured ? input.gridVarTimeIntermediateCaptured : ''
         // Calculate Items Per Minute.
         let numberOfItemsAttempted = input.value.findIndex(el => el.highlighted ? true : false) + 1


### PR DESCRIPTION
## Description

---
* The variable naming should be consistent with expected CSV output.
- Fixes #1586 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---
* Change `GRID_VAR_time_intermediate_captured` and `GRID_VAR_item_at_time` to `time_intermediate_captured` and `item_at_time`


