### PR TITLE
PR for Data Collector registers a Participant in a Case #1692

### DIFF
--- a/client/src/app/case/classes/case-definition.class.ts
+++ b/client/src/app/case/classes/case-definition.class.ts
@@ -1,3 +1,4 @@
+import { CaseRole } from './case-role.class';
 import { CaseEventDefinition } from './case-event-definition.class'
 
 class CaseDefinition {
@@ -6,6 +7,7 @@ class CaseDefinition {
   formId:string
   revision:string
   name:string
+  caseRoles:Array<CaseRole>
   description:string
   templateCaseTitle:string 
   templateCaseDescription:string 

--- a/client/src/app/case/classes/case-participant.class.ts
+++ b/client/src/app/case/classes/case-participant.class.ts
@@ -1,0 +1,7 @@
+interface CaseParticipant {
+  id:string
+  caseRoleId:string
+  data:any  
+}
+
+export { CaseParticipant }

--- a/client/src/app/case/classes/case-role.class.ts
+++ b/client/src/app/case/classes/case-role.class.ts
@@ -1,0 +1,6 @@
+
+export interface CaseRole {
+  id:string
+  label:string
+}
+

--- a/client/src/app/case/classes/case-role.class.ts
+++ b/client/src/app/case/classes/case-role.class.ts
@@ -2,5 +2,6 @@
 export interface CaseRole {
   id:string
   label:string
+  templateListItem:string
 }
 

--- a/client/src/app/case/classes/case.class.ts
+++ b/client/src/app/case/classes/case.class.ts
@@ -95,6 +95,7 @@ class Case {
     this.disabledEventDefinitionIds = data.disabledEventDefinitionIds ? data.disabledEventDefinitionIds : []
     this.caseDefinitionId = data.caseDefinitionId
     this.label = data.label
+    this.participants = data.participants
     this.events = data.events.map(caseEventData => <CaseEvent>caseEventData)
   }
   

--- a/client/src/app/case/classes/case.class.ts
+++ b/client/src/app/case/classes/case.class.ts
@@ -2,6 +2,7 @@ import * as UUID from 'uuid/v4'
 import { CaseEvent } from './case-event.class'
 import {TangyFormResponseModel} from 'tangy-form/tangy-form-response-model.js'
 import { TangyFormResponse } from 'src/app/tangy-forms/tangy-form-response.class';
+import { CaseParticipant } from './case-participant.class';
 
 class Case {
   _id:string
@@ -62,7 +63,7 @@ class Case {
   label:string
   status:string
   openedDate:number
-  variables:any = {}
+  participants:Array<CaseParticipant> = []
   disabledEventDefinitionIds: Array<string> = []
   events: Array<CaseEvent> = []
   type:string = 'case'

--- a/client/src/app/case/classes/case.class.ts
+++ b/client/src/app/case/classes/case.class.ts
@@ -95,7 +95,7 @@ class Case {
     this.disabledEventDefinitionIds = data.disabledEventDefinitionIds ? data.disabledEventDefinitionIds : []
     this.caseDefinitionId = data.caseDefinitionId
     this.label = data.label
-    this.participants = data.participants
+    this.participants = data.participants ? data.participants : []
     this.events = data.events.map(caseEventData => <CaseEvent>caseEventData)
   }
   

--- a/client/src/app/case/classes/event-form-definition.class.ts
+++ b/client/src/app/case/classes/event-form-definition.class.ts
@@ -1,13 +1,16 @@
 export class EventFormDefinition {
+
   id:string
   formId:string
   name:string
+  forCaseRole:string
   templateListItem:string
   repeatable: boolean
   required:boolean
   templateListItemIcon:string
   templateListItemPrimary:string
   templateListItemSecondary:string
+
   constructor() {
   }
 }

--- a/client/src/app/case/classes/event-form.class.ts
+++ b/client/src/app/case/classes/event-form.class.ts
@@ -1,5 +1,6 @@
 class EventForm {
   id:string;
+  participantId:string
   complete:boolean = false
   caseId:string; 
   caseEventId:string;

--- a/client/src/app/case/components/event/event.component.css
+++ b/client/src/app/case/components/event/event.component.css
@@ -1,3 +1,7 @@
+h2 {
+    margin: 30px 0px 25px 20px;
+}
+
 .subject-header {
     background: #212a3f;
     color: white;

--- a/client/src/app/case/components/event/event.component.html
+++ b/client/src/app/case/components/event/event.component.html
@@ -2,9 +2,13 @@
   <app-case-breadcrumb *ngIf="caseService && caseService.case && caseService.case._id" [caseId]="caseService.case._id" [caseEventId]="caseEvent.id"></app-case-breadcrumb>
 
   <div class="wrapper">
-    <div class="form-cards" *ngIf="caseService">
+    <div
+      class="form-cards" 
+      *ngFor="let participantInfo of participantInfos"
+    >
+      <h2>{{participantInfo.renderedListItem}}</h2>
       <app-event-form-list-item
-        *ngFor="let eventFormInfo of eventFormsInfo"
+        *ngFor="let eventFormInfo of participantInfo.eventFormInfos"
         [case]="caseService.case"
         [caseDefinition]="caseService.caseDefinition"
         [caseEvent]="caseEvent"

--- a/client/src/app/case/components/event/event.component.ts
+++ b/client/src/app/case/components/event/event.component.ts
@@ -60,6 +60,7 @@ export class EventComponent implements OnInit, AfterContentInit {
         .find(caseDef => caseDef.id === this.caseEvent.caseEventDefinitionId)
       this.participantInfos = this.caseService.case.participants.map(participant => {
         const id = participant.id
+        const data = participant.data
         const role = this.caseService.caseDefinition.caseRoles.find(caseRole => caseRole.id === participant.caseRoleId)
         let renderedListItem:string
         eval(`renderedListItem = \`${role.templateListItem}\``) 

--- a/client/src/app/case/services/case.service.spec.ts
+++ b/client/src/app/case/services/case.service.spec.ts
@@ -1,3 +1,4 @@
+import { CaseRole } from './../classes/case-role.class';
 import { CASE_EVENT_STATUS_COMPLETED, CASE_EVENT_STATUS_IN_PROGRESS } from './../classes/case-event.class';
 import { TestBed } from '@angular/core/testing';
 
@@ -13,6 +14,7 @@ import { CaseEventDefinition } from '../classes/case-event-definition.class';
 import PouchDB from 'pouchdb';
 import { HttpClient } from '@angular/common/http';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
+import { CaseParticipant } from '../classes/case-participant.class';
 
 class MockCaseDefinitionsService {
   async load() {
@@ -22,6 +24,16 @@ class MockCaseDefinitionsService {
         "formId": "caseDefinition1Form",
         "name": "Case Type 1",
         "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        "caseRoles": [
+          <CaseRole>{
+            id: 'role1',
+            label: 'Role 1'
+          },
+          <CaseRole>{
+            id: 'role2',
+            label: 'Role 2'
+          }
+        ],
         "eventDefinitions": <Array<CaseEventDefinition>>[
           {
             "id": "event-definition-screening",
@@ -35,7 +47,16 @@ class MockCaseDefinitionsService {
               <EventFormDefinition>{
                 "id": "event-form-1",
                 "formId": "form1",
+                "forCaseRole": "role1",
                 "name": "Form 1",
+                "required": true,
+                "repeatable": false
+              },
+              <EventFormDefinition>{
+                "id": "event-form-2",
+                "formId": "form2",
+                "forCaseRole": "role2",
+                "name": "Form 2",
                 "required": true,
                 "repeatable": false
               }
@@ -53,6 +74,7 @@ class MockCaseDefinitionsService {
               <EventFormDefinition>{
                 "id": "event-form-1",
                 "formId": "form1",
+                "forCaseRole": "role1",
                 "name": "Form 1",
                 "required": true,
                 "repeatable": false
@@ -60,6 +82,7 @@ class MockCaseDefinitionsService {
               <EventFormDefinition>{
                 "id": "event-form-2",
                 "formId": "form2",
+                "forCaseRole": "role1",
                 "name": "Form 2 (repeatable)",
                 "required": true,
                 "repeatable": true 
@@ -67,6 +90,7 @@ class MockCaseDefinitionsService {
               <EventFormDefinition>{
                 "id": "event-form-3",
                 "formId": "form3",
+                "forCaseRole": "role1",
                 "name": "Form 3",
                 "required": false,
                 "repeatable": false 
@@ -85,6 +109,7 @@ class MockCaseDefinitionsService {
               <EventFormDefinition>{
                 "id": "event-form-1",
                 "formId": "form1",
+                "forCaseRole": "role1",
                 "name": "Form 1",
                 "required": true,
                 "repeatable": false
@@ -103,6 +128,7 @@ class MockCaseDefinitionsService {
               <EventFormDefinition>{
                 "id": "event-form-1",
                 "formId": "form1",
+                "forCaseRole": "role1",
                 "name": "Form 1",
                 "required": true,
                 "repeatable": false
@@ -188,31 +214,31 @@ describe('CaseService', () => {
     expect(service.case.events[0].estimate).toEqual(false)
   })
 
-  it('should create participant', async () => {
+  it('should create participant and create forms for existing events', async () => {
+    const service: CaseService = TestBed.get(CaseService);
+    await service.create('caseDefinition1')
+    await service.createEvent('event-definition-screening', true)
+    expect(service.case.events[0].eventForms.length).toEqual(0)
+    const caseParticipant = await service.createParticipant('role1')
+    expect(service.case.participants[0].id).toEqual(caseParticipant.id)
+    expect(service.case.events[0].eventForms.length).toEqual(1)
+  })
+
+  it('should create CaseEvent and also create corresponding required EventForms for Participants', async() => {
     const service: CaseService = TestBed.get(CaseService);
     await service.create('caseDefinition1')
     const caseParticipant = await service.createParticipant('role1')
+    await service.createEvent('event-definition-screening', true)
     expect(service.case.participants[0].id).toEqual(caseParticipant.id)
- 
-  })
-
-  it('should assign participant to role (and create forms for existing events?)')
-  it('should create CaseEvent and also create corresponding required EventForms for Participants')
-  it('should remove forms for participant upon unassignment')
-  it('should change CaseEvent.status to "complete" when all required forms are completed for roles other than "reviewer".')
-  it('should change CaseEvent.status to "reviewed" after reviewer role completes required forms in Event.')
-
-  it('should create an event with required event forms', async () => {
-    const service: CaseService = TestBed.get(CaseService);
-    await service.create('caseDefinition1')
-    await service.createEvent('event-definition-first-visit', true)
-    expect(service.case.events[0].eventForms.length).toEqual(2)
+    expect(service.case.events[0].eventForms.length).toEqual(1)
   })
 
   it('CaseEvent should have status of comleted when all required forms are completed', async () => {
     const service: CaseService = TestBed.get(CaseService);
     await service.create('caseDefinition1')
-    const caseEvent = await service.createEvent('event-definition-first-visit', true)
+    const caseParticipant = await service.createParticipant('role1')
+    const caseParticipant2 = await service.createParticipant('role2')
+    const caseEvent = await service.createEvent('event-definition-screening', true)
     expect(service.case.events[0].status).toEqual(CASE_EVENT_STATUS_IN_PROGRESS)
     for (let eventForm of service.case.events[0].eventForms) {
       service.markEventFormComplete(caseEvent.id, eventForm.id)

--- a/client/src/app/case/services/case.service.spec.ts
+++ b/client/src/app/case/services/case.service.spec.ts
@@ -188,6 +188,20 @@ describe('CaseService', () => {
     expect(service.case.events[0].estimate).toEqual(false)
   })
 
+  it('should create participant', async () => {
+    const service: CaseService = TestBed.get(CaseService);
+    await service.create('caseDefinition1')
+    const caseParticipant = await service.createParticipant('role1')
+    expect(service.case.participants[0].id).toEqual(caseParticipant.id)
+ 
+  })
+
+  it('should assign participant to role (and create forms for existing events?)')
+  it('should create CaseEvent and also create corresponding required EventForms for Participants')
+  it('should remove forms for participant upon unassignment')
+  it('should change CaseEvent.status to "complete" when all required forms are completed for roles other than "reviewer".')
+  it('should change CaseEvent.status to "reviewed" after reviewer role completes required forms in Event.')
+
   it('should create an event with required event forms', async () => {
     const service: CaseService = TestBed.get(CaseService);
     await service.create('caseDefinition1')

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -239,7 +239,15 @@ class CaseService {
     return caseParticipant
   }
 
+  async setParticipantData(participantId:string, key:string, value:string) {
+    const index = this.case.participants.findIndex(participant => participant.id === participantId)
+    this.case.participants[index].data[key] = value
+    await this.save()
+  }
 
+  getParticipantData(participantId:string, key:string) {
+    return this.case.participants.find(participant => participant.id === participantId).data[key]
+  }
 
   async getQueries (): Promise<Array<Query>> {
     const userDbName = this.userService.getCurrentUser();

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -109,9 +109,11 @@ class CaseService {
       startDate: 0
     }
     this.case.events.push(caseEvent)
-    if (createRequiredEventForms === true) {
-      for (let eventFormDefinition of caseEventDefinition.eventFormDefinitions.filter(eventFormDefinition => eventFormDefinition.required)) {
-        this.startEventForm(caseEvent.id, eventFormDefinition.id)
+    for (const caseParticipant of this.case.participants) {
+      for (const eventFormDefinition of caseEventDefinition.eventFormDefinitions) {
+        if (caseParticipant.caseRoleId === eventFormDefinition.forCaseRole) {
+          this.startEventForm(caseEvent.id, eventFormDefinition.id, caseParticipant.id)
+        }
       }
     }
     return caseEvent
@@ -130,11 +132,12 @@ class CaseService {
     
   }
 
-  startEventForm(caseEventId, eventFormDefinitionId):EventForm {
+  startEventForm(caseEventId, eventFormDefinitionId, participantId = ''):EventForm {
     const eventForm = <EventForm>{
       id: UUID(), 
       complete: false, 
       caseId: this.case._id, 
+      participantId,
       caseEventId, 
       eventFormDefinitionId: eventFormDefinitionId
     }
@@ -148,7 +151,6 @@ class CaseService {
   }
 
   markEventFormComplete(caseEventId:string, eventFormId:string) {
-    //
     let caseEvent = this
       .case
       .events
@@ -157,29 +159,25 @@ class CaseService {
       .caseDefinition
       .eventDefinitions
       .find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
-    //
     caseEvent
       .eventForms
       .find(eventForm => eventForm.id === eventFormId)
       .complete = true
-    //
-    // Test this by opening case type 1, second event, filling out two of the second form, should be evrnt incomplete, then the first form, shoud be event complete
-    //let eventForms = caseEvent.eventForms.filter(eventForm => eventForm.eventFormDefinitionId === eventDefinition.id)
-    let numberOfEventFormsRequired = eventDefinition
-      .eventFormDefinitions
-      .reduce((acc, eventFormDefinition) => eventFormDefinition.required ? acc + 1 : acc, 0)
-    let numberOfUniqueCompleteEventForms = caseEvent
-      .eventForms
-      .reduce((acc, eventForm) => eventForm.complete 
-          ? Array.from(new Set([...acc, eventForm.eventFormDefinitionId])) 
-          : acc
-        , [])
-        .length
+    const allRequiredFormsComplete = caseEvent.eventForms.reduce((allRequiredFormsComplete, eventForm) => {
+      if (allRequiredFormsComplete === false) {
+        return false
+      } else {
+        const eventFormDefinition = eventDefinition
+          .eventFormDefinitions
+          .find(eventFormDefinition => eventFormDefinition.id === eventForm.eventFormDefinitionId )
+        return !eventFormDefinition.required || (eventFormDefinition.required && eventForm.complete) ? true : false
+      }
+    }, true)
     this
       .case
       .events
       .find(caseEvent => caseEvent.id === caseEventId)
-      .status = numberOfEventFormsRequired === numberOfUniqueCompleteEventForms ? CASE_EVENT_STATUS_COMPLETED : CASE_EVENT_STATUS_IN_PROGRESS
+      .status = allRequiredFormsComplete ? CASE_EVENT_STATUS_COMPLETED : CASE_EVENT_STATUS_IN_PROGRESS
     // Check to see if all required Events are complete in Case. If so, mark Case complete.
     let numberOfCaseEventsRequired = this.caseDefinition
       .eventDefinitions
@@ -226,6 +224,17 @@ class CaseService {
       data
     }
     this.case.participants.push(caseParticipant)
+    for (let caseEvent of this.case.events) {
+      const caseEventDefinition = this
+        .caseDefinition
+        .eventDefinitions
+        .find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
+      for (let eventFormDefinition of caseEventDefinition.eventFormDefinitions) {
+        if (eventFormDefinition.forCaseRole === caseRoleId) {
+          this.startEventForm(caseEvent.id, eventFormDefinition.id, caseParticipant.id)
+        }
+      }
+    }
     await this.save()
     return caseParticipant
   }

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -15,6 +15,7 @@ import { UserService } from 'src/app/shared/_services/user.service';
 import { Query } from '../classes/query.class'
 import moment from 'moment/src/moment';
 import { HttpClient } from '@angular/common/http';
+import { CaseParticipant } from '../classes/case-participant.class';
 
 @Injectable({
   providedIn: 'root'
@@ -215,6 +216,21 @@ class CaseService {
       ? this.case.items[0].inputs.find(input => input.name === variableName).value
       : undefined
   }
+
+  async createParticipant(caseRoleId = ''):Promise<CaseParticipant> {
+    const id = UUID()
+    const data = {}
+    const caseParticipant = <CaseParticipant>{
+      id,
+      caseRoleId,
+      data
+    }
+    this.case.participants.push(caseParticipant)
+    await this.save()
+    return caseParticipant
+  }
+
+
 
   async getQueries (): Promise<Array<Query>> {
     const userDbName = this.userService.getCurrentUser();


### PR DESCRIPTION
## Description

<img width="867" alt="Screen Shot 2019-10-17 at 6 38 41 AM" src="https://user-images.githubusercontent.com/156575/67002037-ffe6d280-f0a8-11e9-9252-2e0c9833c676.png">


When working in a Case Event pertaining to a family, we may need to fill out an instance of a form for each child in that family. This PR enables a `caseService.addParticipant(roleId)` API that allows you for example add many children as participants which would then result in a form designated for the child role to be created for every child participant in that case.

- Fixes #1692

## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution
When defining your CaseDefinition, you can now define a list of roles that may be used when enrolling participants in instances of that Case. When defining EventFormDefinition, you can specify `forRole`. Then when an event is created, this data is used to create the required forms for each participant.

## Limitations and Trade-offs
This implements Participants as part of the Case document in the database. So for example, if we wanted to have a Participant in many Cases, this does not enable that. Also because a Participant is not caught up in any form data, we don't have CSV generating for that. This will probably end up being extra CSV data we want to append down the line to each form output.

