### PR TITLE
Fix form routing for archived and active forms

### DIFF
--- a/client/src/app/case-management/form-list/form-list.component.html
+++ b/client/src/app/case-management/form-list/form-list.component.html
@@ -5,15 +5,15 @@
         <mat-list-item class="tangy-location-list">
           <span class="tangy-foreground-primary">{{'Select Form Name'|translate}}</span>
         </mat-list-item>
-        <mat-list-item class="tangy-location-list" *ngFor="let form of formList; let formIndex=index">
-          <a class="tangy-foreground-primary" [routerLink]="['/tangy-forms-player/']" [queryParams]={formIndex:formIndex}>
+        <mat-list-item class="tangy-location-list" *ngFor="let form of formList">
+          <a class="tangy-foreground-primary" [routerLink]="['/tangy-forms-player/']" [queryParams]={formId:form.id}>
             <i class="material-icons md-24 tangy-location-list-icon">play_circle_filled</i>
           </a>
           <span [innerHTML]="form.title|unsanitizeHtml"></span>
         </mat-list-item>
       </mat-list>
 
-      <p *ngIf="!formList" class="mat-h3">{{'No Forms Currently Defined'|translate}}</p>
+      <p *ngIf="formList?.length<1" class="mat-h3">{{'No Forms Currently Defined'|translate}}</p>
     </mat-card>
 
   </mat-tab>


### PR DESCRIPTION
## Description

---

When a form is archived, the routing on client breaks at times. This is because we use the `formIndex ` in the `forms.json`.  When a `HTTP` request is made for `forms.json`, it returns all forms, archived and active. This leads to inconsistency when requesting for the underlying form.

- Fixes #1722 

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

In the routing for `formList`, use `formId` instead of `formIndex`


