### PR TITLE
Styling New Case screen

### DIFF
--- a/client/src/app/core/new-form-response/new-form-response.component.css
+++ b/client/src/app/core/new-form-response/new-form-response.component.css
@@ -9,6 +9,58 @@ paper-card {
   width: 100%;
 }
 
+paper-button {
+  margin-top: 0px;
+}
+
 .card-header {
   margin: 15px;
+}
+
+.icon-list-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-family: var(--paper-font-subhead_-_font-family);
+  font-size: var(--paper-font-subhead_-_font-size);
+  font-weight: var(--paper-font-subhead_-_font-weight);
+  line-height: var(--paper-font-subhead_-_line-height);
+  min-height: var(--paper-item-min-height, 48px);
+  padding: 0 16px;
+  border-bottom: gray dashed 1px;
+}
+.icon-list-item > mwc-icon {
+  width: 56px;
+}
+.icon-list-item > div {
+  min-height: var(--paper-item-body-two-line-min-height, 72px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1 auto;
+  flex-basis: 0.0000000001px;
+}
+.icon-list-item > div > div {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.icon-list-item > div > div + div {
+  font-size: var(--paper-font-body1_-_font-size);
+  font-weight: var(--paper-font-body1_-_font-weight);
+  line-height: var(--paper-font-body1_-_line-height);
+  color: var(--paper-item-body-secondary-color, var(--secondary-text-color));
+}
+
+.icon-list-item:hover {
+  background-color: lightgray;
+}
+.icon-list-item.create-new:hover {
+  background-color: transparent;
+}
+
+mwc-icon {
+  color: var(--primary-color);
+  font-size: 36px;
 }

--- a/client/src/app/core/new-form-response/new-form-response.component.html
+++ b/client/src/app/core/new-form-response/new-form-response.component.html
@@ -1,12 +1,27 @@
-
 <div class="wrapper">
   <div class="form-info-cards">
-    <paper-card class="form-info-card" *ngFor="let formInfo of formsInfo">
+    <!-- <paper-card class="form-info-card" *ngFor="let formInfo of formsInfo">
       <h2 class="card-header" [innerHTML]="formInfo.title | unsanitizeHtml"></h2>
       <div class="card-content" [innerHTML]="formInfo.description | unsanitizeHtml"></div>
       <div class="card-actions">
         <paper-button (click)="onFormInfoSelect(formInfo.id)">{{'start'|translate}}</paper-button>
       </div>
-    </paper-card>
+    </paper-card> -->
+    <div class="icon-list-item create-new">
+      <mwc-icon slot="item-icon">add</mwc-icon>
+      <div>
+        <div>{{"Create New Case"|translate}}</div>
+        <div secondary>{{"Select the appropriate case type from the options listed below"|translate}}</div>
+      </div>
+    </div>
+    <div class="icon-list-item" *ngFor="let formInfo of formsInfo">
+      <mwc-icon slot="item-icon">{{formInfo.caseIcon}}</mwc-icon>
+      <div>
+        <div [innerHTML]="formInfo.title | unsanitizeHtml"></div>
+        <div [innerHTML]="formInfo.description | unsanitizeHtml" secondary></div>
+
+      </div>
+      <paper-button (click)="onFormInfoSelect(formInfo.id)">{{'Create'|translate}}</paper-button>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Description

---
Style new case screen to correspond to #1689 

- Fixes #1689 

## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution

---
- Add CSS classes and change HTML.
- Add a new property `caseIcon` in HTML. This is to be set in the `forms.json` for the corresponding form entry.


## Screenshots/Videos

---
* [Link to video](http://recordit.co/Zsc8YIJjTc.gif)

![image](https://user-images.githubusercontent.com/6088118/67000610-d21d8000-f0e0-11e9-949e-d481439013a8.png)


## Tests

---

[How you tested (or have not tested) this PR and what where those steps.]

## Notices, Regressions, Breaking Changes

---

* to show a custom icon, add `caseIcon` property to `forms.json` entry of the item. The value should be the icon name.
* The icon set is [here](https://material.io/resources/icons). 

