### PR TITLE
Fix location list failing due to typo in csv file

### DIFF
--- a/editor/src/app/groups/import-location-list/import-location-list.component.ts
+++ b/editor/src/app/groups/import-location-list/import-location-list.component.ts
@@ -184,8 +184,8 @@ export class ImportLocationListComponent implements OnInit {
     const levels = [...this.locationList.locationsLevels].reverse();
     levels.map((level, index) => {
       this.parsedCSVData.map(item => {
-        const id = item[`${level}_id`];
-        const parentId = item[`${levels[index + 1]}_id`];
+        const id = item[this.mappings[`${level}_id`]];
+        const parentId = item[this.mappings[`${levels[index + 1]}_id`]];
         const parent = index + 1 === levels.length ? 'root' : parentId;
         let value = {
           parent,


### PR DESCRIPTION
## Description

---
* As an editor I should be able to map column names in a `csv`file to the hierarchy of the location list as defined in the `location-list.json`. 
* There is a bug such that the import fails when the column names in the `csv` file do not correspond to the ones in the `location-list.json` e.g through a spelling error.

- Fixes #IssueNumber

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---
* When getting the `id` and `parentId` of an item, we should rely on the name as defined in the `csv` file through the `this.mappings` object.

## Tests

---
* tested with a `csv` file containing typos in column names
