### PR TITLE
Add build numbers to releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install global node dependencies
-RUN npm install -g nodemon dat
+RUN npm install -g nodemon dat uuid
 
 # T_USER1 is the username of the first user you will log in as. It is also the super user that has all permissions. 
 ENV T_USER1 user1

--- a/client/src/app/core/about/about.service.spec.ts
+++ b/client/src/app/core/about/about.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AboutService } from './about.service';
+
+describe('AboutService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: AboutService = TestBed.get(AboutService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/client/src/app/core/about/about.service.ts
+++ b/client/src/app/core/about/about.service.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AboutService {
+
+  constructor(
+    private http:HttpClient
+  ) { }
+
+  getBuildNumber():Promise<string> {
+    return this.http.get('./assets/tangerine-build-id', {responseType: 'text'}).toPromise()
+  }
+
+}

--- a/client/src/app/core/about/about/about.component.html
+++ b/client/src/app/core/about/about/about.component.html
@@ -18,4 +18,7 @@
   <p> 
     For questions about Tangerine, contact <a href="mailto:support@tangerinehelp.zendesk.com">support@tangerinehelp.zendesk.com</a>.  
   </p>
+  <p>
+    Build ID: {{buildId}}
+  </p>
 </div>

--- a/client/src/app/core/about/about/about.component.ts
+++ b/client/src/app/core/about/about/about.component.ts
@@ -1,3 +1,4 @@
+import { AboutService } from './../about.service';
 import { Component, OnInit } from '@angular/core';
 
 @Component({
@@ -7,9 +8,15 @@ import { Component, OnInit } from '@angular/core';
 })
 export class AboutComponent implements OnInit {
 
-  constructor() { }
+  buildId:string
 
-  ngOnInit() {
+  constructor(
+    private aboutService:AboutService
+
+  ) { }
+
+  async ngOnInit() {
+    this.buildId = await this.aboutService.getBuildNumber()
   }
 
 }

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -50,7 +50,7 @@ cp -r $CONTENT_PATH $RELEASE_DIRECTORY/www/shell/assets
 cp /tangerine/logo.svg $RELEASE_DIRECTORY/www/
 
 # Stash the Build ID in the release.
-echo $BUILD_ID > $RELEASE_DIRECTORY/www/.tangerine-build-id 
+echo $BUILD_ID > $RELEASE_DIRECTORY/www/shell/assets/tangerine-build-id 
 
 cd $RELEASE_DIRECTORY
 

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -11,6 +11,7 @@ STATUS_FILE="/tangerine/client/releases/$RELEASE_TYPE/apks/$GROUP.json"
 URL="$T_PROTOCOL://$T_HOST_NAME/releases/$RELEASE_TYPE/apks/$GROUP/www"
 CHCP_URL="$T_PROTOCOL://$T_HOST_NAME/releases/$RELEASE_TYPE/apks/$GROUP/www/chcp.json"
 DATE=`date '+%Y-%m-%d %H:%M:%S'`
+BUILD_ID=`uuid`
 
 echo "RELEASE APK script started $DATE"
 
@@ -48,6 +49,9 @@ rm -rf $RELEASE_DIRECTORY/www/shell/assets
 cp -r $CONTENT_PATH $RELEASE_DIRECTORY/www/shell/assets
 cp /tangerine/logo.svg $RELEASE_DIRECTORY/www/
 
+# Stash the Build ID in the release.
+echo $BUILD_ID > $RELEASE_DIRECTORY/www/.tangerine-build-id 
+
 cd $RELEASE_DIRECTORY
 
 # replace the URL property in config.xml
@@ -67,8 +71,5 @@ cordova build --no-telemetry android
 cp $RELEASE_DIRECTORY/platforms/android/app/build/outputs/apk/debug/app-debug.apk $RELEASE_DIRECTORY/$GROUP.apk
 
 echo '{"processing":false}' > $STATUS_FILE
-echo "Released apk for $GROUP at $RELEASE_DIRECTORY on $DATE"
-
-
-
-
+echo 
+echo "Released apk for $GROUP at $RELEASE_DIRECTORY on $DATE with Build ID of $BUILD_ID"

--- a/server/src/scripts/release-pwa.sh
+++ b/server/src/scripts/release-pwa.sh
@@ -49,6 +49,7 @@ mv .pwa-temporary/release-uuid .pwa-temporary/$UUID
 # Install content into PWA.
 rm -r .pwa-temporary/$UUID/app/assets
 cp -r $CONTENT_PATH .pwa-temporary/$UUID/app/assets
+echo $BUILD_ID > .pwa-temporary/$UUID/app/assets/tangerine-build-id
 
 # Add logo.
 cp .pwa-temporary/logo.svg .pwa-temporary/$UUID/
@@ -61,5 +62,4 @@ echo $UUID > .pwa-temporary/release-uuid.txt
 
 rm -r $RELEASE_DIRECTORY
 mv .pwa-temporary $RELEASE_DIRECTORY
-echo $BUILD_ID > $RELEASE_DIRECTORY/app/.tangerine-build-id
 echo "Release with UUID of $UUID to $RELEASE_DIRECTORY with Build ID of $BUILD_ID"

--- a/server/src/scripts/release-pwa.sh
+++ b/server/src/scripts/release-pwa.sh
@@ -4,6 +4,7 @@ GROUP="$1"
 CONTENT_PATH="$2"
 RELEASE_TYPE="$3"
 RELEASE_DIRECTORY="/tangerine/client/releases/$RELEASE_TYPE/pwas/$GROUP"
+BUILD_ID=`uuid`
 
 echo "RELEASE_DIRECTORY: $RELEASE_DIRECTORY"
 
@@ -60,4 +61,5 @@ echo $UUID > .pwa-temporary/release-uuid.txt
 
 rm -r $RELEASE_DIRECTORY
 mv .pwa-temporary $RELEASE_DIRECTORY
-echo "Release with UUID of $UUID to $RELEASE_DIRECTORY"
+echo $BUILD_ID > $RELEASE_DIRECTORY/app/.tangerine-build-id
+echo "Release with UUID of $UUID to $RELEASE_DIRECTORY with Build ID of $BUILD_ID"


### PR DESCRIPTION
After releasing an APK/PWA from the server and upgrading from client, all clients on the same release will see the same build number on their about page.

![image](https://user-images.githubusercontent.com/156575/67595533-e42c9d80-f734-11e9-93dc-b05b0182adc6.png)
