### PR TITLE
Apply tangerine css variables to core elements

### DIFF
--- a/client/default-assets/custom-styles.css
+++ b/client/default-assets/custom-styles.css
@@ -6,17 +6,17 @@
  * Theme override example:
 
 html {
-  --document-background-color: #FAFAFA !important;
-  --primary-color-dark: #212a3f !important;
-  --primary-text-color-overlay: #FFF !important;
-  --primary-text-color: var(--light-theme-text-color) !important;
-  --primary-color: #3c5b8d !important;
-  --accent-color: #f26f10 !important;
-  --accent-color-dark: #cc5500 !important;
-  --accent-text-color: #FFF !important;
-  --error-color: var(--paper-red-500) !important;
-  --disabled-color: #BBB !important;
-  --paper-tabs-selection-bar-color: #f26f10 !important;
+  --document-background-color: #FAFAFA;
+  --primary-color-dark: #212a3f;
+  --primary-text-color-overlay: #FFF;
+  --primary-text-color: #050505;
+  --primary-color: #3c5b8d;
+  --accent-color: #f26f10;
+  --accent-color-dark: #cc5500;
+  --accent-text-color: #FFF;
+  --error-color: #ff0000;
+  --disabled-color: #BBB;
+  --paper-tabs-selection-bar-color: #f26f10;
 }
 
 */

--- a/client/default-assets/custom-styles.css
+++ b/client/default-assets/custom-styles.css
@@ -1,3 +1,23 @@
 /*
  * Custom Styles
  */
+
+/*
+ * Theme override example:
+
+html {
+  --document-background-color: #FAFAFA !important;
+  --primary-color-dark: #212a3f !important;
+  --primary-text-color-overlay: #FFF !important;
+  --primary-text-color: var(--light-theme-text-color) !important;
+  --primary-color: #3c5b8d !important;
+  --accent-color: #f26f10 !important;
+  --accent-color-dark: #cc5500 !important;
+  --accent-text-color: #FFF !important;
+  --error-color: var(--paper-red-500) !important;
+  --disabled-color: #BBB !important;
+  --paper-tabs-selection-bar-color: #f26f10 !important;
+}
+
+*/
+

--- a/client/src/app/app.component.css
+++ b/client/src/app/app.component.css
@@ -7,8 +7,12 @@ h1 {
   padding-right: 7px;
 }
 
+.hamburger-menu {
+  color: var(--primary-text-color-overlay);
+}
+
 mat-toolbar.mat-tangy-custom-toolbar {
-  background: #212a3f;
+  background: var(--primary-color-dark) !important;
 }
 
 #update-in-progress-inner {

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -20,7 +20,7 @@
   </span>
   <span class="tangy-spacer"></span>
 
-  <paper-icon-button icon="more-vert" *ngIf="showNav" [matMenuTriggerFor]="appMenu"></paper-icon-button>
+  <paper-icon-button icon="more-vert" *ngIf="showNav" [matMenuTriggerFor]="appMenu" class="hamburger-menu"></paper-icon-button>
   <mat-menu #appMenu="matMenu">
     <button *ngIf="window && window.appConfig && !window.appConfig.hideProfile" routerLink="manage-user-profile" mat-menu-item>
       <mat-icon class="material-icons menu-tangy-location-list-icon">create</mat-icon>

--- a/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.css
+++ b/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.css
@@ -2,26 +2,26 @@
     position: fixed;
     top: 0px;
     z-index: 99999;
-    color: white;
+    color: var(--primary-text-color-overlay);
     height: 34px;
     padding-top: 21px;
     margin-right: 80px;
     padding-left: 22px;
-    background: #212a3f;
+    background: var(--primary-color-dark);
     font-size: 1.5em;
 }
 
 .primary iron-icon {
-    color: #FFF !important;
+    color: var(--primary-text-color-overlay) !important;
 }
 
 .secondary {
     background: var(--primary-color);
-    color: var(--primary-text-color);
+    color: var(--primary-text-color-overlay);
     font-size: 1.5em;
     padding: 15px 15px 15px 22px;
 }
 
 .secondary iron-icon {
-    color: var(--primary-text-color) !important;
+    color: var(--primary-text-color-overlay) !important;
 }

--- a/client/src/app/case/components/case-event-schedule/case-event-schedule.component.css
+++ b/client/src/app/case/components/case-event-schedule/case-event-schedule.component.css
@@ -11,7 +11,7 @@ select {
 
 date-carousel {
   --date-carousel-selected-background: var(--accent-color);
-  --date-carousel-table-color: var(--accent-text-color);
+  --date-carousel-table-color: var(--primary-text-color-overlay);
   --date-carousel-selected-color:var(--accent-text-color);
-  --date-carousel-month-color: var(--accent-text-color);
+  --date-carousel-month-color: var(--primary-text-color-overlay);
 }

--- a/client/src/app/case/components/case/case.component.css
+++ b/client/src/app/case/components/case/case.component.css
@@ -1,3 +1,5 @@
+
+
 .confirm-correct-case-prompt {
     width: 100%;
 }
@@ -19,7 +21,7 @@ app-case-breadcrumb {
 
 .subject-header {
     background: var(--primary-color);
-    color: var(--primary-text-color);
+    color: var(--primary-text-color-overlay);
     font-size: 1em;
     padding: 15px;
 }
@@ -33,6 +35,7 @@ app-case-breadcrumb {
 
 .subject-header h1 {
     font-size: 3em;
+    color: var(--primary-text-color-overlay);
 }
 
 .subject-header div[secondary], .subject-header h1 {
@@ -76,18 +79,6 @@ app-case-breadcrumb {
     position: relative;
 }
 
-.new-event button[type="submit"] {
-    background-color: #3c5b8d;
-    border: 1px solid #3c5b8d;
-    box-shadow: 0 2px 2px 0 rgba(60, 91, 141, 0.14), 0 3px 1px -2px rgba(60, 91, 141, 0.2), 0 1px 5px 0 rgba(60, 91, 141, 0.12);
-    padding: 5px 10px;
-    font-size: 14px;
-    vertical-align: middle;
-    color: #fff;
-    text-align: center;
-    line-height: 1.2;
-    border-radius: .25rem;
-}
 
 .dropdown-container {
     position: relative;
@@ -150,16 +141,26 @@ app-case-breadcrumb {
     padding-right: 0;
 }
 */
+.new-event {
+    position: relative;
+}
 .new-event form {
     display: flex;
     margin-right: -15px;
     margin-left: -15px;
 }
-.new-event form > div, .new-event form > button {
+
+.new-event form > div, .new-event form > paper-button {
     flex-basis: 0;
     flex-grow: 1;
     max-width: 33%;
     padding: 0 15px;
+}
+
+.new-event .button {
+    position: absolute;
+    top: 17px;
+    right: 10px;
 }
 
 .text-right {

--- a/client/src/app/case/components/case/case.component.html
+++ b/client/src/app/case/components/case/case.component.html
@@ -41,7 +41,7 @@
             </div>
           </div>
           <div class="text-right">
-            <button type="submit">{{'Create'|translate}}</button>
+            <paper-button (click)="onSubmit()" class="button">{{'Create'|translate}}</paper-button>
           </div>
         </form>
       </div>

--- a/client/src/app/core/search/search.component.css
+++ b/client/src/app/core/search/search.component.css
@@ -22,13 +22,11 @@
 }
 
 #search-bar {
-  background: #3c5b8d;
-  color: var(--accent-text-color);
+  background: var(--primary-color) !important;
+  color: var(--primary-text-color-overlay) !important;
+  --primary-text-color: var(--primary-text-color-overlay) !important;
+  --secondary-text-color: var(--primary-text-color-overlay) !important;
   padding: 0px 15px 5px;
-  --primary-color: #FFF;
-  --primary-text-color: #FFF;
-  --secondary-text-color: #FFF;
-  --default-primary-color: #FFF;
 }
 
 #scan-button {

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -15,15 +15,34 @@ html {
   --document-background-color: #FAFAFA;
   --primary-color-dark: #212a3f;
   --primary-text-color-overlay: #FFF;
-  --primary-text-color: var(--light-theme-text-color);
+  --primary-text-color: #050505;
   --primary-color: #3c5b8d;
   --accent-color: #f26f10;
   --accent-color-dark: #cc5500;
   --accent-text-color: #FFF;
-  --error-color: var(--paper-red-500);
+  --error-color: #ff0000;
   --disabled-color: #BBB;
   --paper-tabs-selection-bar-color: #f26f10;
 }
+
+/* 
+ * Inverted theme for testing.
+
+html {
+  --document-background-color: #050505;
+  --primary-color-dark: #ded5c0;
+  --primary-text-color-overlay: #000;
+  --primary-text-color: #fafafa;
+  --primary-color: #c3a472;
+  --accent-color: #0d90ef;
+  --accent-color-dark: #33aaff;
+  --accent-text-color: #000;
+  --error-color: #00ffff; 
+  --disabled-color: #444444;
+  --paper-tabs-selection-bar-color: #0d90ef;
+}
+
+*/
 
 .container {
   margin:15px;
@@ -50,8 +69,10 @@ paper-button {
   background: var(--accent-color);
   color: var(--accent-text-color);
 }
+
 body {
   background: var(--document-background-color);
+  color: var(--primary-text-color);
   margin: 0px;
   padding: 0px;
   overscroll-behavior: contain;

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -10,12 +10,15 @@
 /* TODO: I'm not sure this is having any affect */
 @import './_tangy-app-variables.scss';
 @import "./tangerine-theme.scss";
+
 html {
   --document-background-color: #FAFAFA;
   --primary-color-dark: #212a3f;
+  --primary-text-color-overlay: #FFF;
   --primary-text-color: var(--light-theme-text-color);
   --primary-color: #3c5b8d;
   --accent-color: #f26f10;
+  --accent-color-dark: #cc5500;
   --accent-text-color: #FFF;
   --error-color: var(--paper-red-500);
   --disabled-color: #BBB;
@@ -29,27 +32,26 @@ html {
 paper-tabs {
   text-transform: uppercase;
   background: var(--primary-color-dark);
-  color: #FFF;
+  color: var(--primary-text-color-overlay);
 }
 paper-tab a:-webkit-any-link {
-  color: #FFF;
+  color: var(--primary-text-color-overlay);
   text-decoration: none;
   height: 42%;
   text-align: center;
 }
 /*
 paper-tab[aria-selected=true] {
-  background: #f26f10;
+  background: var(--accent-color);
   color: #FFF
 }
 */
 paper-button {
   background: var(--accent-color);
   color: var(--accent-text-color);
-  margin-top: 15px;
 }
 body {
-  background: #fafafa;
+  background: var(--document-background-color);
   margin: 0px;
   padding: 0px;
   overscroll-behavior: contain;
@@ -84,6 +86,7 @@ button.tangy-froms-margin-left{
     }
 }
 mat-toolbar{
+    background-color: var(--primary-color-dark) !important;
     position: fixed;
     top: 0;
     right: 0;
@@ -100,7 +103,7 @@ mat-toolbar{
 }
 
 .tangy-foreground-secondary {
-  color: #f26f10;
+  color: var(--accent-color);
 }
 
 .tangy-no-text-decoration{
@@ -132,10 +135,10 @@ mat-toolbar{
 .tangy-location-list-icon{
   padding-right: 5px;
   padding-top:3.5px;
-  color: #f26f10;
+  color: var(--accent-color);
 }
 .menu-tangy-location-list-icon {
-  color: #f26f10;
+  color: var(--accent-color);
   position: relative;
   bottom: 2px;
   padding-right: 3px;
@@ -146,7 +149,7 @@ padding-top:0px;
 }
 
 iron-icon {
-  color: #3c5b8d !important;
+  color: var(--primary-color) !important;
 }
 .material-icons.mat-11 { font-size: 11px; }
 .material-icons.mat-14 { font-size: 14px; }
@@ -173,7 +176,7 @@ iron-icon {
   }
 
 .header .title-text {
-  color: #3c5b8d;
+  color: var(--primary-color);
 }
 
 div.more {
@@ -181,7 +184,7 @@ div.more {
 }
 
 .matmenu_icon {
-  color: #f26f10;
+  color: var(--accent-color);
   font-weight: 700;
 }
 
@@ -197,34 +200,34 @@ div.more {
 }
 
 .mat-focused .mat-form-field-placeholder {
-  color: #3c5b8d !important;
+  color: var(--primary-color) !important;
   font-size: 18px !important;
 }
 .mat-focused .mat-form-field-placeholder span i {
   font-size: 21px;
 }
 .mat-form-field-ripple {
-  background-color: #3c5b8d !important;
+  background-color: var(--primary-color) !important;
 }
 
 .mat-tab-labels {
-  background-color: #3c5b8d;
-  color: #fff;
+  background-color: var(--primary-color);
+  color: var(--primary-text-color-overlay);
   font-weight: 700;
 }
 .mat-tab-label, .mat-tab-link {
-  color: #fff !important;
+  color: var(--primary-text-color-overlay) !important;
   font-weight: 700 !important;
 }
 
 .mat-tab-label-active {
-  background-color: #f26f10;
+  background-color: var(--accent-color) !important;
   opacity: 1.0 !important;
-  color: #fff;
+  color: var(--accent-text-color) !important;
   font-weight: 700;
 }
 .mat-tab-group.mat-primary .mat-ink-bar, .mat-tab-nav-bar.mat-primary .mat-ink-bar {
-  background-color: #ff5a26 !important;
+  background-color: var(--accent-color-dark) !important;
   height: 5px;
 }
 


### PR DESCRIPTION
We have a lot of hardcoded colors in our core modules and `styles.scss`, this applies CSS variables to those colors. It also adds some new CSS variables for use and an example "inverted theme" for testing purposes.

<img width="747" alt="Screen Shot 2019-10-29 at 8 42 27 AM" src="https://user-images.githubusercontent.com/156575/67768275-91026580-fa28-11e9-8aab-564cbff2082a.png">
