### PR TITLE
Upgrade to jest 24 and set test runner to jest-circus to fix silently failing tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -76,12 +76,13 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
+    "@nestjs/testing": "^6.0.0",
     "@types/express": "^4.16.0",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",
     "@types/supertest": "^2.0.7",
-    "@nestjs/testing": "^6.0.0",
-    "jest": "^23.6.0",
+    "jest": "^24.9.0",
+    "jest-circus": "^24.9.0",
     "nodemon": "^1.18.9",
     "prettier": "^1.15.3",
     "supertest": "^3.4.1",
@@ -92,6 +93,7 @@
     "typescript": "^3.2.4"
   },
   "jest": {
+    "testRunner": "jest-circus/runner",
     "moduleFileExtensions": [
       "js",
       "json",


### PR DESCRIPTION
In each server test, if the beforeEach fails, it fails silently which leads to a lot of wasted developer time. I reported the issue to nest here (https://github.com/nestjs/nest/issues/1959). When jest gets around to switching their default test runner to jest-circus, this issue will go away. In the meantime, if we upgrade jest and configure it to use, jest-circus, we save ourselves time now. This version of jest is actually the current version that a nestjs project uses, the only difference is the runner.
