### PR TITLE
Added new date types and setters

### DIFF
--- a/client/src/app/case-management/_services/case-management.service.spec.ts
+++ b/client/src/app/case-management/_services/case-management.service.spec.ts
@@ -33,7 +33,6 @@ describe('CaseManagementService', () => {
 //        RouterModule,
 //        AuthModule,
 //        HttpClientModule,
-        
         CaseManagementModule,
         SharedModule
       ]

--- a/client/src/app/case/classes/case-event.class.ts
+++ b/client/src/app/case/classes/case-event.class.ts
@@ -11,8 +11,12 @@ class CaseEvent {
   status = CASE_EVENT_STATUS_IN_PROGRESS 
   eventForms:Array<EventForm> = []
   estimate = true
-  dateStart:number
-  dateEnd:number
+  estimatedDay:number
+  scheduledDay:number
+  windowStartDay:number
+  windowEndDay:number
+  occurredOnDay:number
+
   name:string
   constructor() {
 

--- a/client/src/app/case/classes/case-event.class.ts
+++ b/client/src/app/case/classes/case-event.class.ts
@@ -5,19 +5,19 @@ export const CASE_EVENT_STATUS_COMPLETED = 'completed'
 export const CASE_EVENT_STATUS_REVIEWED = 'reviewed' 
 
 class CaseEvent {
-  id?:string
-  caseId:string
+  id?: string
+  caseId: string
   caseEventDefinitionId:string
-  status = CASE_EVENT_STATUS_IN_PROGRESS 
-  eventForms:Array<EventForm> = []
+  status = CASE_EVENT_STATUS_IN_PROGRESS
+  eventForms: Array<EventForm> = []
   estimate = true
-  estimatedDay:number
-  scheduledDay:number
-  windowStartDay:number
-  windowEndDay:number
-  occurredOnDay:number
+  estimatedDay: string
+  scheduledDay: string
+  windowStartDay: string
+  windowEndDay: string
+  occurredOnDay: string
 
-  name:string
+  name: string
   constructor() {
 
   }

--- a/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.spec.ts
+++ b/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.spec.ts
@@ -43,7 +43,8 @@ class MockUserService {
   }
 }
 
-const REFERENCE_TIME = 1558715176000
+const REFERENCE_TIME = '2019-08-13'
+const REFERENCE_TIME_2 = '2019-12-31'
 
 class MockCasesService {
   
@@ -147,7 +148,7 @@ class MockCasesService {
         occurredOnDay: REFERENCE_TIME,
         estimatedDay: REFERENCE_TIME,
         windowStartDay: REFERENCE_TIME,
-        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60),
+        windowEndDay: REFERENCE_TIME_2,
         caseDefinition,
         caseInstance: {
           caseDefinitionId: 'c1',
@@ -165,7 +166,7 @@ class MockCasesService {
               'occurredOnDay': REFERENCE_TIME,
               'estimatedDay': REFERENCE_TIME,
               'windowStartDay': REFERENCE_TIME,
-              'windowEndDay': REFERENCE_TIME + (1000 * 60 * 60),
+              'windowEndDay': REFERENCE_TIME_2,
               'eventForms': [
                 {
                   'id': 'fb64d705-ee99-4a27-bbad-8349a0e8767d',
@@ -191,7 +192,7 @@ class MockCasesService {
       }
 ]}
 }
-describe("CaseEventScheduleListComponent", () => {
+describe('CaseEventScheduleListComponent', () => {
   let component: CaseEventScheduleListComponent;
   let fixture: ComponentFixture<CaseEventScheduleListComponent>;
 

--- a/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.spec.ts
+++ b/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.spec.ts
@@ -49,88 +49,90 @@ class MockCasesService {
   
   async getEventsByDate(username: string, dateStart, dateEnd, excludeEstimates = false): Promise<Array<CaseEventInfo>> {
     const caseDefinition= {
-      "id": "c1",
-      "formId": "mother-manifest-3a453b",
-      "name": "Pregnant Woman",
-      "description": "Select this case type to screen, consent and enroll a pregnant womans.",
-      "templateCaseTitle": "${getVariable('participant_id') ? `${getVariable('firstname')} ${getVariable('surname')}` : '...'}",
-      "templateCaseDescription": "${getVariable('participant_id') ? `<b>Participant ID</b>: ${getVariable('participant_id')} <b>Village</b>: ${getVariable('village')} <b>Head of household</b>: ${getVariable('headofhouse')}` : '...'}",
-      "templateScheduleListItemIcon": "${caseEventInfo.complete ? 'event_available' : 'event_note'}",
-      "templateScheduleListItemPrimary": "<span>${caseEventDefinition.name}</span>",
-      "templateScheduleListItemSecondary": "<span>${caseInstance.label}</span>",
+      'id': 'c1',
+      'formId': 'mother-manifest-3a453b',
+      'name': 'Pregnant Woman',
+      'description': 'Select this case type to screen, consent and enroll a pregnant womans.',
+      'templateCaseTitle': '${getVariable("participant_id") ? `${getVariable("firstname")} ${getVariable("surname")}` : "..."}',
+      'templateCaseDescription':
+      '${getVariable("participant_id") ? `<b>Participant ID</b>: ${getVariable("participant_id")} <b>Village</b>: ${getVariable("village")} <b>Head of household</b>: ${getVariable("headofhouse")}` : "..."}',
+      'templateScheduleListItemIcon': '${caseEventInfo.complete ? "event_available" : "event_note"}',
+      'templateScheduleListItemPrimary': '<span>${caseEventDefinition.name}</span>',
+      'templateScheduleListItemSecondary': '<span>${caseInstance.label}</span>',
     
-      "templateCaseEventListItemIcon": "${caseEventInfo.complete ? 'event_available' : 'event_note'}",
-      "templateCaseEventListItemPrimary": "<span>${caseEventDefinition.name}</span>",
-      "templateCaseEventListItemSecondary": "${TRANSLATE('Scheduled')}: ${formatDate(caseEventInfo.dateStart,'dddd, MMMM Do YYYY, h:mm:ss a')}",
-      "templateEventFormListItemIcon": "",
-      "templateEventFormListItemPrimary": "<span>${eventFormDefinition.name}</span>",
-      "templateEventFormListItemSecondary": "Workflow: ${getValue('workflow_state')} Status: ${!eventForm.complete ? 'Incomplete' : 'Complete'}",
-      "startFormOnOpen": {
-        "eventId": "c1",
-        "eventFormId": "event-form-definition-ece26e"
+      'templateCaseEventListItemIcon': '${caseEventInfo.complete ? "event_available" : "event_note"}',
+      'templateCaseEventListItemPrimary': '<span>${caseEventDefinition.name}</span>',
+      'templateCaseEventListItemSecondary':
+        '${TRANSLATE("Scheduled")}: ${formatDate(caseEventInfo.dateStart,"dddd, MMMM Do YYYY, h:mm:ss a")}',
+      'templateEventFormListItemIcon': '',
+      'templateEventFormListItemPrimary': '<span>${eventFormDefinition.name}</span>',
+      'templateEventFormListItemSecondary': 
+      'Workflow: ${getValue("workflow_state")} Status: ${!eventForm.complete ? "Incomplete" : "Complete"}',
+      'startFormOnOpen': {
+        'eventId': 'c1',
+        'eventFormId': 'event-form-definition-ece26e'
       },
-      "eventDefinitions": [
+      'eventDefinitions': [
         {
-          "id": "c1",
-          "name": "ANC-Enrollment",
-          "description": "",
-          "repeatable": false,
-          "estimatedTimeFromCaseOpening": 0,
-          "estimatedTimeWindow": 0,
-          "required": true,
-          "eventFormDefinitions": [
+          'id': 'c1',
+          'name': 'ANC-Enrollment',
+          'description': '',
+          'repeatable': false,
+          'estimatedTimeFromCaseOpening': 0,
+          'estimatedTimeWindow': 0,
+          'required': true,
+          'eventFormDefinitions': [
             {
-              "id": "event-form-definition-ece26e",
-              "formId": "s0-participant-information-f254b9",
-              "name": "S01 - Screening and Enrollment",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-ece26e',
+              'formId': 's0-participant-information-f254b9',
+              'name': 'S01 - Screening and Enrollment',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-574497",
-              "formId": "s02-drug-administration-99380a",
-              "name": "S02 - AZ dosing",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-574497',
+              'formId': 's02-drug-administration-99380a',
+              'name': 'S02 - AZ dosing',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-c94289",
-              "formId": "s03-demographic-characteristics-c09a84",
-              "name": "S03 - Demographic information",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-c94289',
+              'formId': 's03-demographic-characteristics-c09a84',
+              'name': 'S03 - Demographic information',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-a5301b",
-              "formId": "s04-current-pregnancy-record-and-pregnancy-history-9858d6",
-              "name": "S04 - Maternal Clinical history",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-a5301b',
+              'formId': 's04-current-pregnancy-record-and-pregnancy-history-9858d6',
+              'name': 'S04 - Maternal Clinical history',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-c58ef3",
-              "formId": "s05-maternal-physical-exam-1c983b",
-              "name": "S05 - Physical Exam",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-c58ef3',
+              'formId': 's05-maternal-physical-exam-1c983b',
+              'name': 'S05 - Physical Exam',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-z830kj",
-              "formId": "s06-current-anc-visit-68fc78",
-              "name": "S06 - Current ANC visit",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-z830kj',
+              'formId': 's06-current-anc-visit-68fc78',
+              'name': 'S06 - Current ANC visit',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-z452kj",
-              "formId": "s07-visit-information-82328c",
-              "name": "S07 - Visit Close Out",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-z452kj',
+              'formId': 's07-visit-information-82328c',
+              'name': 'S07 - Visit Close Out',
+              'required': true,
+              'repeatable': false
             }
           ]
         },
-        
       ]
     }
     return [
@@ -141,51 +143,55 @@ class MockCasesService {
         status: CASE_EVENT_STATUS_IN_PROGRESS,
         eventForms: [],
         estimate: false,
-        dateStart: REFERENCE_TIME,
-        dateEnd: REFERENCE_TIME + (1000 * 60 * 60),
+        scheduledDay: REFERENCE_TIME,
+        occurredOnDay: REFERENCE_TIME,
+        estimatedDay: REFERENCE_TIME,
+        windowStartDay: REFERENCE_TIME,
+        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60),
         caseDefinition,
         caseInstance: {
           caseDefinitionId: 'c1',
           type: 'case',
           label: 'Pregnant Woman',
           collection: 'TangyFormResponse',
-          events:<any> [
+          events: <any> [
             {
-              "id": "0ff22322-7734-4cc1-957d-dd25416a9413",
-              "caseId": "ff621529-d26b-42cc-a9a1-254179e75622",
-              "status": "in-progress",
-              "name": "ANC-Enrollment",
-              "estimate": true,
-              "caseEventDefinitionId": "c1",
-              "dateStart": REFERENCE_TIME,
-              "dateEnd": REFERENCE_TIME + (1000 * 60 * 60),
-              "eventForms": [
+              'id': '0ff22322-7734-4cc1-957d-dd25416a9413',
+              'caseId': 'ff621529-d26b-42cc-a9a1-254179e75622',
+              'status': 'in-progress',
+              'name': 'ANC-Enrollment',
+              'estimate': true,
+              'scheduledDay': REFERENCE_TIME,
+              'occurredOnDay': REFERENCE_TIME,
+              'estimatedDay': REFERENCE_TIME,
+              'windowStartDay': REFERENCE_TIME,
+              'windowEndDay': REFERENCE_TIME + (1000 * 60 * 60),
+              'eventForms': [
                 {
-                  "id": "fb64d705-ee99-4a27-bbad-8349a0e8767d",
-                  "complete": false,
-                  "caseId": "ff621529-d26b-42cc-a9a1-254179e75622",
-                  "caseEventId": "0ff22322-7734-4cc1-957d-dd25416a9413",
-                  "eventFormDefinitionId": "event-form-definition-ece26e",
-                  "formResponseId": "487517f7-0bec-4363-b22c-0c20090fe284"
+                  'id': 'fb64d705-ee99-4a27-bbad-8349a0e8767d',
+                  'complete': false,
+                  'caseId': 'ff621529-d26b-42cc-a9a1-254179e75622',
+                  'caseEventId': '0ff22322-7734-4cc1-957d-dd25416a9413',
+                  'eventFormDefinitionId': 'event-form-definition-ece26e',
+                  'formResponseId': '487517f7-0bec-4363-b22c-0c20090fe284'
                 },
                 {
-                  "id": "83c502a2-8c82-4ed8-ad05-e8263cd56a0b",
-                  "complete": false,
-                  "caseId": "ff621529-d26b-42cc-a9a1-254179e75622",
-                  "caseEventId": "0ff22322-7734-4cc1-957d-dd25416a9413",
-                  "eventFormDefinitionId": "event-form-definition-574497",
-                  "formResponseId": "3cd53c20-d213-4e8b-bf90-c7091bf95ad6"
+                  'id': '83c502a2-8c82-4ed8-ad05-e8263cd56a0b',
+                  'complete': false,
+                  'caseId': 'ff621529-d26b-42cc-a9a1-254179e75622',
+                  'caseEventId': '0ff22322-7734-4cc1-957d-dd25416a9413',
+                  'eventFormDefinitionId': 'event-form-definition-574497',
+                  'formResponseId': '3cd53c20-d213-4e8b-bf90-c7091bf95ad6'
                 },
-                
               ],
-              "startDate": 0
+              'startDate': 0
             }
           ]
         }
       }
 ]}
 }
-describe('CaseEventScheduleListComponent', () => {
+describe("CaseEventScheduleListComponent", () => {
   let component: CaseEventScheduleListComponent;
   let fixture: ComponentFixture<CaseEventScheduleListComponent>;
 
@@ -214,8 +220,7 @@ describe('CaseEventScheduleListComponent', () => {
         }
 
       ],
-      declarations: [ 
-
+      declarations: [
         UnsanitizeHtmlPipe,
         CaseEventScheduleListComponent ]
     })
@@ -229,28 +234,28 @@ describe('CaseEventScheduleListComponent', () => {
   });
 
   /*
-  it('should create', () => {
+  it("should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show day view', (done) => {
+  it("should show day view', (done) => {
     expect(component).toBeTruthy();
     component.didSearch$.subscribe((value) => {
       fixture.detectChanges();
-      expect(fixture.nativeElement.querySelectorAll('.event-info').length).toEqual(1)
+      expect(fixture.nativeElement.querySelectorAll(".event-info").length).toEqual(1)
       done()
     })
     component.date = REFERENCE_TIME
   });
 
-  it('should show week view', (done) => {
+  it("should show week view', (done) => {
     expect(component).toBeTruthy();
     let i = 0
     component.didSearch$.subscribe((value) => {
       i++
       if (i === 2) {
         fixture.detectChanges()
-        expect(fixture.nativeElement.querySelectorAll('.event-info').length).toEqual(1)
+        expect(fixture.nativeElement.querySelectorAll(".event-info").length).toEqual(1)
         expect(component.eventsInfo.length).toEqual(1)
         done()
       }

--- a/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.ts
+++ b/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.ts
@@ -101,7 +101,7 @@ export class CaseEventScheduleListComponent implements OnInit {
     let daysOfWeekSeen = []
     this.eventsInfo = events.map( event => {
       const eventInfo = <EventInfo>{}
-      const searchDate = event.occurredOnDay|| event.scheduledDay || event.estimatedDay
+      const searchDate = event.occurredOnDay || event.scheduledDay || event.estimatedDay || event.windowStartDay
       const date = new Date(searchDate)
       if (daysOfWeekSeen.indexOf(date.getDate()) === -1) {
         daysOfWeekSeen.push(date.getDate())

--- a/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.ts
+++ b/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.ts
@@ -101,8 +101,9 @@ export class CaseEventScheduleListComponent implements OnInit {
     let daysOfWeekSeen = []
     this.eventsInfo = events.map( event => {
       const eventInfo = <EventInfo>{}
-      const date = new Date(event.dateStart)
-      if (daysOfWeekSeen.indexOf(date.getDate()) == -1) {
+      const searchDate = event.occurredOnDay|| event.scheduledDay || event.estimatedDay
+      const date = new Date(searchDate)
+      if (daysOfWeekSeen.indexOf(date.getDate()) === -1) {
         daysOfWeekSeen.push(date.getDate())
         eventInfo.newDateLabel = moment(date).format('ddd')
         eventInfo.newDateNumber = this._mode === CASE_EVENT_SCHEDULE_LIST_MODE_WEEKLY 

--- a/client/src/app/case/components/case-event-schedule/case-event-schedule.component.spec.ts
+++ b/client/src/app/case/components/case-event-schedule/case-event-schedule.component.spec.ts
@@ -45,7 +45,8 @@ class MockUserService {
   }
 }
 
-const REFERENCE_TIME = 1558715176000
+const REFERENCE_TIME = '2019-08-13'
+const REFERENCE_TIME_2 = '2019-12-31'
 
 class MockCasesService {
 
@@ -61,8 +62,8 @@ class MockCasesService {
         scheduledDay: REFERENCE_TIME,
         occurredOnDay: REFERENCE_TIME,
         estimatedDay: REFERENCE_TIME,
-        windowStartDay: REFERENCE_TIME + (1000 * 60 * 60 * 24 * 2) ,
-        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60 * 24 * 2) + (1000 * 60 * 60)
+        windowStartDay: REFERENCE_TIME ,
+        windowEndDay: REFERENCE_TIME_2
       },
       <CaseEvent>{
         id: 'e2',
@@ -74,8 +75,8 @@ class MockCasesService {
         scheduledDay: REFERENCE_TIME,
         occurredOnDay: REFERENCE_TIME,
         estimatedDay: REFERENCE_TIME,
-        windowStartDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) ,
-        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) + (1000 * 60 * 60)
+        windowStartDay: REFERENCE_TIME ,
+        windowEndDay: REFERENCE_TIME_2
       },
       <CaseEvent>{
         id: 'e3',
@@ -87,8 +88,8 @@ class MockCasesService {
         scheduledDay: REFERENCE_TIME,
         occurredOnDay: REFERENCE_TIME,
         estimatedDay: REFERENCE_TIME,
-        windowStartDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) ,
-        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) + (1000 * 60 * 60)
+        windowStartDay: REFERENCE_TIME ,
+        windowEndDay: REFERENCE_TIME_2
       }
     ]
   }

--- a/client/src/app/case/components/case-event-schedule/case-event-schedule.component.spec.ts
+++ b/client/src/app/case/components/case-event-schedule/case-event-schedule.component.spec.ts
@@ -58,8 +58,11 @@ class MockCasesService {
         status: CASE_EVENT_STATUS_IN_PROGRESS,
         eventForms: [],
         estimate: false,
-        dateStart: REFERENCE_TIME,
-        dateEnd: REFERENCE_TIME + (1000*60*60)
+        scheduledDay: REFERENCE_TIME,
+        occurredOnDay: REFERENCE_TIME,
+        estimatedDay: REFERENCE_TIME,
+        windowStartDay: REFERENCE_TIME + (1000 * 60 * 60 * 24 * 2) ,
+        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60 * 24 * 2) + (1000 * 60 * 60)
       },
       <CaseEvent>{
         id: 'e2',
@@ -68,8 +71,11 @@ class MockCasesService {
         status: CASE_EVENT_STATUS_IN_PROGRESS,
         eventForms: [],
         estimate: false,
-        dateStart: REFERENCE_TIME,
-        dateEnd: REFERENCE_TIME + (1000*60*60)
+        scheduledDay: REFERENCE_TIME,
+        occurredOnDay: REFERENCE_TIME,
+        estimatedDay: REFERENCE_TIME,
+        windowStartDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) ,
+        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) + (1000 * 60 * 60)
       },
       <CaseEvent>{
         id: 'e3',
@@ -78,8 +84,11 @@ class MockCasesService {
         status: CASE_EVENT_STATUS_IN_PROGRESS,
         eventForms: [],
         estimate: false,
-        dateStart: REFERENCE_TIME + (1000*60*60*24),
-        dateEnd: REFERENCE_TIME + (1000*60*60*24) + (1000*60*60)
+        scheduledDay: REFERENCE_TIME,
+        occurredOnDay: REFERENCE_TIME,
+        estimatedDay: REFERENCE_TIME,
+        windowStartDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) ,
+        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60 * 24) + (1000 * 60 * 60)
       }
     ]
   }

--- a/client/src/app/case/components/case/case.component.html
+++ b/client/src/app/case/components/case/case.component.html
@@ -34,12 +34,7 @@
               <option *ngFor="let eventInfo of creatableCaseEventsInfo" [value]="eventInfo.caseEventDefinition.id">
                 {{eventInfo.caseEventDefinition.name}}</option>
             </select>
-          </div>
-          <div>
-            <div class="dropdown-container">
-              <input type="date" name="event-date" [(ngModel)]="inputSelectedDate">
-            </div>
-          </div>
+          </div>         
           <div class="text-right">
             <paper-button (click)="onSubmit()" class="button">{{'Create'|translate}}</paper-button>
           </div>

--- a/client/src/app/case/components/case/case.component.ts
+++ b/client/src/app/case/components/case/case.component.ts
@@ -84,7 +84,6 @@ export class CaseComponent implements AfterContentInit {
   async onSubmit() {
     const newDate = moment(this.inputSelectedDate, 'YYYY-MM-DD').unix()*1000
     const caseEvent = this.caseService.createEvent(this.selectedNewEventType, true)
-    await this.caseService.scheduleEvent(caseEvent.id, newDate, newDate)
     await this.caseService.save()
     this.calculateTemplateData()
   }

--- a/client/src/app/case/services/case.service.spec.ts
+++ b/client/src/app/case/services/case.service.spec.ts
@@ -207,7 +207,7 @@ describe('CaseService', () => {
     await service.createEvent('event-definition-first-visit')
     const timeInMs = new Date().getTime()
     const dateString = new Date(timeInMs)
-    const date = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    const date = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
     await service.setEventOccurredOn(service.case.events[0].id, timeInMs)
     expect(service.case.events[0].occurredOnDay).toEqual(date)
   })
@@ -217,7 +217,7 @@ describe('CaseService', () => {
     await service.createEvent('event-definition-first-visit')
     const timeInMs = new Date().getTime()
     const dateString = new Date(timeInMs)
-    const date = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    const date = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
     await service.setEventEstimatedDay(service.case.events[0].id, timeInMs)
     expect(service.case.events[0].estimatedDay).toEqual(date)
   })
@@ -227,7 +227,7 @@ describe('CaseService', () => {
     await service.createEvent('event-definition-first-visit')
     const timeInMs = new Date().getTime()
     const dateString = new Date(timeInMs)
-    const date = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    const date = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
     await service.setEventScheduledDay(service.case.events[0].id, timeInMs)
     expect(service.case.events[0].scheduledDay).toEqual(date)
   })
@@ -239,8 +239,8 @@ describe('CaseService', () => {
     const windowEndDayTimeInMs = new Date().getTime()
     const windowStartDateString = new Date(windowStartDayTimeInMs)
     const windowEndDateString = new Date(windowEndDayTimeInMs)
-    const windowStartDay = `${windowStartDateString.getFullYear}-${windowStartDateString.getMonth}-${windowStartDateString.getDate}`
-    const windowEndDay = `${windowEndDateString.getFullYear}-${windowEndDateString.getMonth}-${windowEndDateString.getDate}`
+    const windowStartDay = `${windowStartDateString.getFullYear()}-${windowStartDateString.getMonth()}-${windowStartDateString.getDate()}`
+    const windowEndDay = `${windowEndDateString.getFullYear()}-${windowEndDateString.getMonth()}-${windowEndDateString.getDate()}`
     await service.setEventWindow(service.case.events[0].id, windowStartDayTimeInMs, windowEndDayTimeInMs)
     expect(service.case.events[0].windowStartDay).toEqual(windowStartDay)
     expect(service.case.events[0].windowEndDay).toEqual(windowEndDay)

--- a/client/src/app/case/services/case.service.spec.ts
+++ b/client/src/app/case/services/case.service.spec.ts
@@ -205,30 +205,45 @@ describe('CaseService', () => {
     const service: CaseService = TestBed.get(CaseService)
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
-    await service.setEventOccurredOn(service.case.events[0].id, 12345678)
-    expect(service.case.events[0].occurredOnDay).toEqual(12345678)
+    const timeInMs = new Date().getTime()
+    const dateString = new Date(timeInMs)
+    const date = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    await service.setEventOccurredOn(service.case.events[0].id, timeInMs)
+    expect(service.case.events[0].occurredOnDay).toEqual(date)
   })
   it('should set an event EstimatedDay date', async () => {
     const service: CaseService = TestBed.get(CaseService)
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
-    await service.setEventEstimatedDay(service.case.events[0].id, 12345678)
-    expect(service.case.events[0].estimatedDay).toEqual(12345678)
+    const timeInMs = new Date().getTime()
+    const dateString = new Date(timeInMs)
+    const date = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    await service.setEventEstimatedDay(service.case.events[0].id, timeInMs)
+    expect(service.case.events[0].estimatedDay).toEqual(date)
   })
   it('should set an event ScheduledDay date', async () => {
     const service: CaseService = TestBed.get(CaseService)
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
-    await service.setEventScheduledDay(service.case.events[0].id, 12345678)
-    expect(service.case.events[0].scheduledDay).toEqual(12345678)
+    const timeInMs = new Date().getTime()
+    const dateString = new Date(timeInMs)
+    const date = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    await service.setEventScheduledDay(service.case.events[0].id, timeInMs)
+    expect(service.case.events[0].scheduledDay).toEqual(date)
   })
   it('should set an event Window period', async () => {
     const service: CaseService = TestBed.get(CaseService)
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
-    await service.setEventWindow(service.case.events[0].id, 12345678, 123456787)
-    expect(service.case.events[0].windowStartDay).toEqual(12345678)
-    expect(service.case.events[0].windowEndDay).toEqual(123456787)
+    const windowStartDayTimeInMs = new Date().getTime()
+    const windowEndDayTimeInMs = new Date().getTime()
+    const windowStartDateString = new Date(windowStartDayTimeInMs)
+    const windowEndDateString = new Date(windowEndDayTimeInMs)
+    const windowStartDay = `${windowStartDateString.getFullYear}-${windowStartDateString.getMonth}-${windowStartDateString.getDate}`
+    const windowEndDay = `${windowEndDateString.getFullYear}-${windowEndDateString.getMonth}-${windowEndDateString.getDate}`
+    await service.setEventWindow(service.case.events[0].id, windowStartDayTimeInMs, windowEndDayTimeInMs)
+    expect(service.case.events[0].windowStartDay).toEqual(windowStartDay)
+    expect(service.case.events[0].windowEndDay).toEqual(windowEndDay)
   })
 
   it('should create participant and create forms for existing events', async () => {

--- a/client/src/app/case/services/case.service.spec.ts
+++ b/client/src/app/case/services/case.service.spec.ts
@@ -19,11 +19,11 @@ class MockCaseDefinitionsService {
   async load() {
     return <Array<CaseDefinition>>[
       {
-        "id": "caseDefinition1",
-        "formId": "caseDefinition1Form",
-        "name": "Case Type 1",
-        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-        "caseRoles": [
+        'id': 'caseDefinition1',
+        'formId': 'caseDefinition1Form',
+        'name': 'Case Type 1',
+        'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+        'caseRoles': [
           <CaseRole>{
             id: 'role1',
             label: 'Role 1'
@@ -33,104 +33,104 @@ class MockCaseDefinitionsService {
             label: 'Role 2'
           }
         ],
-        "eventDefinitions": <Array<CaseEventDefinition>>[
+        'eventDefinitions': <Array<CaseEventDefinition>>[
           {
-            "id": "event-definition-screening",
-            "name": "Screening",
-            "description": "A screening.",
-            "repeatable": false,
-            "required": true,
-            "estimatedTimeFromCaseOpening": 0,
-            "estimatedTimeWindow": 0,
-            "eventFormDefinitions": [
+            'id': 'event-definition-screening',
+            'name': 'Screening',
+            'description': 'A screening.',
+            'repeatable': false,
+            'required': true,
+            'estimatedTimeFromCaseOpening': 0,
+            'estimatedTimeWindow': 0,
+            'eventFormDefinitions': [
               <EventFormDefinition>{
-                "id": "event-form-1",
-                "formId": "form1",
-                "forCaseRole": "role1",
-                "name": "Form 1",
-                "required": true,
-                "repeatable": false
+                'id': 'event-form-1',
+                'formId': 'form1',
+                'forCaseRole': 'role1',
+                'name': 'Form 1',
+                'required': true,
+                'repeatable': false
               },
               <EventFormDefinition>{
-                "id": "event-form-2",
-                "formId": "form2",
-                "forCaseRole": "role2",
-                "name": "Form 2",
-                "required": true,
-                "repeatable": false
+                'id': 'event-form-2',
+                'formId': 'form2',
+                'forCaseRole': 'role2',
+                'name': 'Form 2',
+                'required': true,
+                'repeatable': false
               }
             ]
           },
           {
-            "id": "event-definition-first-visit",
-            "name": "First visit",
-            "description": "The first visit",
-            "repeatable": false,
-            "required": true,
-            "estimatedTimeFromCaseOpening": 15552000000,
-            "estimatedTimeWindow": 2592000000,
-            "eventFormDefinitions": [
+            'id': 'event-definition-first-visit',
+            'name': 'First visit',
+            'description': 'The first visit',
+            'repeatable': false,
+            'required': true,
+            'estimatedTimeFromCaseOpening': 15552000000,
+            'estimatedTimeWindow': 2592000000,
+            'eventFormDefinitions': [
               <EventFormDefinition>{
-                "id": "event-form-1",
-                "formId": "form1",
-                "forCaseRole": "role1",
-                "name": "Form 1",
-                "required": true,
-                "repeatable": false
+                'id': 'event-form-1',
+                'formId': 'form1',
+                'forCaseRole': 'role1',
+                'name': 'Form 1',
+                'required': true,
+                'repeatable': false
               },
               <EventFormDefinition>{
-                "id": "event-form-2",
-                "formId": "form2",
-                "forCaseRole": "role1",
-                "name": "Form 2 (repeatable)",
-                "required": true,
-                "repeatable": true 
+                'id': 'event-form-2',
+                'formId': 'form2',
+                'forCaseRole': 'role1',
+                'name': 'Form 2 (repeatable)',
+                'required': true,
+                'repeatable': true 
               },
               <EventFormDefinition>{
-                "id": "event-form-3",
-                "formId": "form3",
-                "forCaseRole": "role1",
-                "name": "Form 3",
-                "required": false,
-                "repeatable": false 
+                'id': 'event-form-3',
+                'formId': 'form3',
+                'forCaseRole': 'role1',
+                'name': 'Form 3',
+                'required': false,
+                'repeatable': false 
               }
             ]
           },
           {
-            "id": "event-definition-repeatable-event",
-            "name": "A Repeatable Event",
-            "description": "A repeatable event.",
-            "repeatable": true,
-            "required": true,
-            "estimatedTimeFromCaseOpening": 0,
-            "estimatedTimeWindow": 0,
-            "eventFormDefinitions": [
+            'id': 'event-definition-repeatable-event',
+            'name': 'A Repeatable Event',
+            'description': 'A repeatable event.',
+            'repeatable': true,
+            'required': true,
+            'estimatedTimeFromCaseOpening': 0,
+            'estimatedTimeWindow': 0,
+            'eventFormDefinitions': [
               <EventFormDefinition>{
-                "id": "event-form-1",
-                "formId": "form1",
-                "forCaseRole": "role1",
-                "name": "Form 1",
-                "required": true,
-                "repeatable": false
+                'id': 'event-form-1',
+                'formId': 'form1',
+                'forCaseRole': 'role1',
+                'name': 'Form 1',
+                'required': true,
+                'repeatable': false
               }
             ]
           },
           {
-            "id": "event-definition-not-required-event",
-            "name": "A Event that is not require",
-            "description": "An event that is not required.",
-            "repeatable": true,
-            "required": false,
-            "estimatedTimeFromCaseOpening": 0,
-            "estimatedTimeWindow": 0,
-            "eventFormDefinitions": [
+            'id': 'event-definition-not-required-event',
+            'name': 'A Event that is not require',
+            'description': 'An event that is not required.',
+            'repeatable': true,
+            'required': false,
+            'estimatedTimeFromCaseOpening': 0,
+            'estimatedTimeWindow': 0,
+            'eventFormDefinitions': [
               <EventFormDefinition>{
-                "id": "event-form-1",
-                "formId": "form1",
-                "forCaseRole": "role1",
-                "name": "Form 1",
-                "required": true,
-                "repeatable": false
+                'id': 'event-form-1',
+                'formId': 'form1',
+                'forCaseRole': 'role1',
+                'name': 'Form 1',
+                'required': true,
+                'repeatable': false
               }
             ]
           }
@@ -143,9 +143,9 @@ class MockCaseDefinitionsService {
 class MockTangyFormService {
   async getFormMarkup(formId) {
     return `
-      <tangy-form id="caseDefinition1Form">
-        <tangy-form-item id="item1">
-          <tangy-input name="input1"></tangy-input>
+      <tangy-form id='caseDefinition1Form'>
+        <tangy-form-item id='item1'>
+          <tangy-input name='input1'></tangy-input>
         </tangy-form>
       </tangy-form>
     `
@@ -173,8 +173,8 @@ describe('CaseService', () => {
       ],
       providers: [
         { 
-          provide: CaseDefinitionsService, 
-          useClass: MockCaseDefinitionsService      
+          provide: CaseDefinitionsService,
+          useClass: MockCaseDefinitionsService
         },
         {
           provide: TangyFormService,
@@ -201,18 +201,38 @@ describe('CaseService', () => {
     expect(service.case._id).toBeTruthy()
   })
 
-  it('should schedule an event', async () => {
-    const service: CaseService = TestBed.get(CaseService);
+  it('should set an event ocurred on date', async () => {
+    const service: CaseService = TestBed.get(CaseService)
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
-    await service.scheduleEvent(service.case.events[0].id, 12345678)
-    expect(service.case.events[0].dateStart).toEqual(12345678)
-    expect(service.case.events[0].dateEnd).toEqual(12345678)
-    expect(service.case.events[0].estimate).toEqual(false)
+    await service.setEventOccurredOn(service.case.events[0].id, 12345678)
+    expect(service.case.events[0].occurredOnDay).toEqual(12345678)
+  })
+  it('should set an event EstimatedDay date', async () => {
+    const service: CaseService = TestBed.get(CaseService)
+    await service.create('caseDefinition1')
+    await service.createEvent('event-definition-first-visit')
+    await service.setEventEstimatedDay(service.case.events[0].id, 12345678)
+    expect(service.case.events[0].estimatedDay).toEqual(12345678)
+  })
+  it('should set an event ScheduledDay date', async () => {
+    const service: CaseService = TestBed.get(CaseService)
+    await service.create('caseDefinition1')
+    await service.createEvent('event-definition-first-visit')
+    await service.setEventScheduledDay(service.case.events[0].id, 12345678)
+    expect(service.case.events[0].scheduledDay).toEqual(12345678)
+  })
+  it('should set an event Window period', async () => {
+    const service: CaseService = TestBed.get(CaseService)
+    await service.create('caseDefinition1')
+    await service.createEvent('event-definition-first-visit')
+    await service.setEventWindow(service.case.events[0].id, 12345678, 123456787)
+    expect(service.case.events[0].windowStartDay).toEqual(12345678)
+    expect(service.case.events[0].windowEndDay).toEqual(123456787)
   })
 
   it('should create participant and create forms for existing events', async () => {
-    const service: CaseService = TestBed.get(CaseService);
+    const service: CaseService = TestBed.get(CaseService)
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-screening', true)
     expect(service.case.events[0].eventForms.length).toEqual(0)
@@ -237,7 +257,7 @@ describe('CaseService', () => {
     const caseParticipant2 = await service.createParticipant('role2')
     const caseEvent = await service.createEvent('event-definition-screening', true)
     expect(service.case.events[0].status).toEqual(CASE_EVENT_STATUS_IN_PROGRESS)
-    for (let eventForm of service.case.events[0].eventForms) {
+    for (const eventForm of service.case.events[0].eventForms) {
       service.markEventFormComplete(caseEvent.id, eventForm.id)
     }
     expect(service.case.events[0].status).toEqual(CASE_EVENT_STATUS_COMPLETED)

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -145,7 +145,7 @@ class CaseService {
 
   async setEventEstimatedDay(eventId, timeInMs: number) {
     const dateString = new Date(timeInMs)
-    const estimatedDay = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    const estimatedDay = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
       ? { ...event, ...{ estimatedDay} }
@@ -154,7 +154,7 @@ class CaseService {
   }
   async setEventScheduledDay(eventId, timeInMs: number) {
     const dateString = new Date(timeInMs)
-    const scheduledDay = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
+    const scheduledDay = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
       ? { ...event, ...{ scheduledDay} }
@@ -164,8 +164,8 @@ class CaseService {
   async setEventWindow(eventId: string, windowStartDayTimeInMs: number, windowEndDayTimeInMs: number) {
     const windowStartDateString = new Date(windowStartDayTimeInMs)
     const windowEndDateString = new Date(windowEndDayTimeInMs)
-    const windowStartDay = `${windowStartDateString.getFullYear}-${windowStartDateString.getMonth}-${windowStartDateString.getDate}`
-    const windowEndDay = `${windowEndDateString.getFullYear}-${windowEndDateString.getMonth}-${windowEndDateString.getDate}`
+    const windowStartDay = `${windowStartDateString.getFullYear()}-${windowStartDateString.getMonth()}-${windowStartDateString.getDate()}`
+    const windowEndDay = `${windowEndDateString.getFullYear()}-${windowEndDateString.getMonth()}-${windowEndDateString.getDate()}`
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
       ? { ...event, ...{ windowStartDay, windowEndDay} }
@@ -174,8 +174,8 @@ class CaseService {
   }
   async setEventOccurredOn(eventId, timeInMs: number) {
     const dateString = new Date(timeInMs)
-    const occurredOnDay = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
-    this.case.events = this.case.events.map(event => {
+    const occurredOnDay = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
+    return this.case.events = this.case.events.map(event => {
       return event.id === eventId
       ? { ...event, ...{ occurredOnDay} }
       : event

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -143,28 +143,38 @@ class CaseService {
   //   })
   // }
 
-  async setEventEstimatedDay(eventId, estimatedDay:number){
+  async setEventEstimatedDay(eventId, timeInMs: number) {
+    const dateString = new Date(timeInMs)
+    const estimatedDay = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
       ? { ...event, ...{ estimatedDay} }
       : event
     })
   }
-  async setEventScheduledDay(eventId, scheduledDay: number) {
+  async setEventScheduledDay(eventId, timeInMs: number) {
+    const dateString = new Date(timeInMs)
+    const scheduledDay = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
       ? { ...event, ...{ scheduledDay} }
       : event
     })
   }
-  async setEventWindow(eventId: string, windowStartDay: number, windowEndDay: number) {
+  async setEventWindow(eventId: string, windowStartDayTimeInMs: number, windowEndDayTimeInMs: number) {
+    const windowStartDateString = new Date(windowStartDayTimeInMs)
+    const windowEndDateString = new Date(windowEndDayTimeInMs)
+    const windowStartDay = `${windowStartDateString.getFullYear}-${windowStartDateString.getMonth}-${windowStartDateString.getDate}`
+    const windowEndDay = `${windowEndDateString.getFullYear}-${windowEndDateString.getMonth}-${windowEndDateString.getDate}`
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
-      ? { ...event, ...{ windowStartDay, windowEndDay: windowEndDay ? windowEndDay : windowStartDay} }
+      ? { ...event, ...{ windowStartDay, windowEndDay} }
       : event
     })
   }
-  async setEventOccurredOn(eventId, occurredOnDay: number) {
+  async setEventOccurredOn(eventId, timeInMs: number) {
+    const dateString = new Date(timeInMs)
+    const occurredOnDay = `${dateString.getFullYear}-${dateString.getMonth}-${dateString.getDate}`
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
       ? { ...event, ...{ occurredOnDay} }

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -112,8 +112,11 @@ class CaseService {
       name: caseEventDefinition.name,
       estimate: true,
       caseEventDefinitionId: eventDefinitionId,
-      dateStart: Date.now() + caseEventDefinition.estimatedTimeFromCaseOpening - (caseEventDefinition.estimatedTimeWindow/2),
-      dateEnd: Date.now() + caseEventDefinition.estimatedTimeFromCaseOpening + (caseEventDefinition.estimatedTimeWindow/2),
+      windowEndDay: undefined,
+      windowStartDay: undefined,
+      estimatedDay: undefined,
+      occurredOnDay: undefined,
+      scheduledDay: undefined,
       eventForms: [],
       startDate: 0
     }
@@ -132,15 +135,42 @@ class CaseService {
     // ??
   }
 
-  async scheduleEvent(eventId, dateStart:number, dateEnd?:number) {
+  // async scheduleEvent(eventId, dateStart:number, dateEnd?:number) {
+  //   this.case.events = this.case.events.map(event => {
+  //     return event.id === eventId 
+  //     ? { ...event, ...{ dateStart, dateEnd: dateEnd ? dateEnd : dateStart, estimate: false} }
+  //     : event
+  //   })
+  // }
+
+  async setEventEstimatedDay(eventId, estimatedDay:number){
     this.case.events = this.case.events.map(event => {
-      return event.id === eventId 
-      ? { ...event, ...{ dateStart, dateEnd: dateEnd ? dateEnd : dateStart, estimate: false} }
+      return event.id === eventId
+      ? { ...event, ...{ estimatedDay} }
       : event
     })
-    
   }
-
+  async setEventScheduledDay(eventId, scheduledDay: number) {
+    this.case.events = this.case.events.map(event => {
+      return event.id === eventId
+      ? { ...event, ...{ scheduledDay} }
+      : event
+    })
+  }
+  async setEventWindow(eventId: string, windowStartDay: number, windowEndDay: number) {
+    this.case.events = this.case.events.map(event => {
+      return event.id === eventId
+      ? { ...event, ...{ windowStartDay, windowEndDay: windowEndDay ? windowEndDay : windowStartDay} }
+      : event
+    })
+  }
+  async setEventOccurredOn(eventId, occurredOnDay: number) {
+    this.case.events = this.case.events.map(event => {
+      return event.id === eventId
+      ? { ...event, ...{ occurredOnDay} }
+      : event
+    })
+  }
   startEventForm(caseEventId, eventFormDefinitionId, participantId = ''):EventForm {
     const eventForm = <EventForm>{
       id: UUID(), 
@@ -284,7 +314,6 @@ class CaseService {
     if (caseEvent === undefined) {
         const newDate = moment(new Date(), 'YYYY-MM-DD').unix() * 1000;
         caseEvent = this.createEvent(this.queryCaseEventDefinitionId);
-        await this.scheduleEvent(caseEvent.id, newDate, newDate);
         await this.save();
       } else {
         caseEvent = this.case.events

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -101,7 +101,7 @@ class CaseService {
     await this.setCase(await this.db.get(this.case._id))
   }
 
-  createEvent(eventDefinitionId:string, createRequiredEventForms = false):CaseEvent {
+  createEvent(eventDefinitionId:string, createRequiredEventForms = false): CaseEvent {
     const caseEventDefinition = this.caseDefinition
       .eventDefinitions
       .find(eventDefinition => eventDefinition.id === eventDefinitionId)

--- a/client/src/app/case/services/cases.service.spec.ts
+++ b/client/src/app/case/services/cases.service.spec.ts
@@ -83,7 +83,8 @@ class MockUserService {
   }
 }
 
-const REFERENCE_TIME = 1558715176000
+const REFERENCE_TIME = '2019-08-13'
+const REFERENCE_TIME_2 = '2019-12-31'
 
 class MockCasesService {
   
@@ -184,7 +185,7 @@ class MockCasesService {
         occurredOnDay: REFERENCE_TIME,
         estimatedDay: REFERENCE_TIME,
         windowStartDay: REFERENCE_TIME,
-        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60),
+        windowEndDay: REFERENCE_TIME_2,
         caseDefinition,
         caseInstance: {
           caseDefinitionId: 'c1',
@@ -203,7 +204,7 @@ class MockCasesService {
               'occurredOnDay': REFERENCE_TIME,
               'estimatedDay': REFERENCE_TIME,
               'windowStartDay': REFERENCE_TIME,
-              'windowEndDay': REFERENCE_TIME + (1000 * 60 * 60),
+              'windowEndDay': REFERENCE_TIME_2,
               'eventForms': [
                 {
                   'id': 'fb64d705-ee99-4a27-bbad-8349a0e8767d',

--- a/client/src/app/case/services/cases.service.spec.ts
+++ b/client/src/app/case/services/cases.service.spec.ts
@@ -89,88 +89,87 @@ class MockCasesService {
   
   async getEventsByDate(username: string, dateStart, dateEnd, excludeEstimates = false): Promise<Array<CaseEventInfo>> {
     const caseDefinition= {
-      "id": "c1",
-      "formId": "mother-manifest-3a453b",
-      "name": "Pregnant Woman",
-      "description": "Select this case type to screen, consent and enroll a pregnant womans.",
-      "templateCaseTitle": "${getVariable('participant_id') ? `${getVariable('firstname')} ${getVariable('surname')}` : '...'}",
-      "templateCaseDescription": "${getVariable('participant_id') ? `<b>Participant ID</b>: ${getVariable('participant_id')} <b>Village</b>: ${getVariable('village')} <b>Head of household</b>: ${getVariable('headofhouse')}` : '...'}",
-      "templateScheduleListItemIcon": "${caseEventInfo.complete ? 'event_available' : 'event_note'}",
-      "templateScheduleListItemPrimary": "<span>${caseEventDefinition.name}</span>",
-      "templateScheduleListItemSecondary": "<span>${caseInstance.label}</span>",
+      'id': 'c1',
+      'formId': 'mother-manifest-3a453b',
+      'name': 'Pregnant Woman',
+      'description': 'Select this case type to screen, consent and enroll a pregnant womans.',
+      'templateCaseTitle': '${getVariable("participant_id") ? `${getVariable("firstname")} ${getVariable("surname")}` : "..."}',
+      'templateCaseDescription': '${getVariable("participant_id") ? `<b>Participant ID</b>: ${getVariable("participant_id")} <b>Village</b>: ${getVariable("village")} <b>Head of household</b>: ${getVariable("headofhouse")}` : "..."}',
+      'templateScheduleListItemIcon': '${caseEventInfo.complete ? "event_available" : "event_note"}',
+      'templateScheduleListItemPrimary': '<span>${caseEventDefinition.name}</span>',
+      'templateScheduleListItemSecondary': '<span>${caseInstance.label}</span>',
     
-      "templateCaseEventListItemIcon": "${caseEventInfo.complete ? 'event_available' : 'event_note'}",
-      "templateCaseEventListItemPrimary": "<span>${caseEventDefinition.name}</span>",
-      "templateCaseEventListItemSecondary": "${TRANSLATE('Scheduled')}: ${formatDate(caseEventInfo.dateStart,'dddd, MMMM Do YYYY, h:mm:ss a')}",
-      "templateEventFormListItemIcon": "",
-      "templateEventFormListItemPrimary": "<span>${eventFormDefinition.name}</span>",
-      "templateEventFormListItemSecondary": "Workflow: ${getValue('workflow_state')} Status: ${!eventForm.complete ? 'Incomplete' : 'Complete'}",
-      "startFormOnOpen": {
-        "eventId": "c1",
-        "eventFormId": "event-form-definition-ece26e"
+      'templateCaseEventListItemIcon': '${caseEventInfo.complete ? "event_available" : "event_note"}',
+      'templateCaseEventListItemPrimary': '<span>${caseEventDefinition.name}</span>',
+      'templateCaseEventListItemSecondary': '${TRANSLATE("Scheduled")}: ${formatDate(caseEventInfo.dateStart,"dddd, MMMM Do YYYY, h:mm:ss a")}',
+      'templateEventFormListItemIcon': '',
+      'templateEventFormListItemPrimary': '<span>${eventFormDefinition.name}</span>',
+      'templateEventFormListItemSecondary': 'Workflow: ${getValue("workflow_state")} Status: ${!eventForm.complete ? "Incomplete" : "Complete"}',
+      'startFormOnOpen': {
+        'eventId': 'c1',
+        'eventFormId': 'event-form-definition-ece26e'
       },
-      "eventDefinitions": [
+      'eventDefinitions': [
         {
-          "id": "c1",
-          "name": "ANC-Enrollment",
-          "description": "",
-          "repeatable": false,
-          "estimatedTimeFromCaseOpening": 0,
-          "estimatedTimeWindow": 0,
-          "required": true,
-          "eventFormDefinitions": [
+          'id': 'c1',
+          'name': 'ANC-Enrollment',
+          'description': '',
+          'repeatable': false,
+          'estimatedTimeFromCaseOpening': 0,
+          'estimatedTimeWindow': 0,
+          'required': true,
+          'eventFormDefinitions': [
             {
-              "id": "event-form-definition-ece26e",
-              "formId": "s0-participant-information-f254b9",
-              "name": "S01 - Screening and Enrollment",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-ece26e',
+              'formId': 's0-participant-information-f254b9',
+              'name': 'S01 - Screening and Enrollment',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-574497",
-              "formId": "s02-drug-administration-99380a",
-              "name": "S02 - AZ dosing",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-574497',
+              'formId': 's02-drug-administration-99380a',
+              'name': 'S02 - AZ dosing',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-c94289",
-              "formId": "s03-demographic-characteristics-c09a84",
-              "name": "S03 - Demographic information",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-c94289',
+              'formId': 's03-demographic-characteristics-c09a84',
+              'name': 'S03 - Demographic information',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-a5301b",
-              "formId": "s04-current-pregnancy-record-and-pregnancy-history-9858d6",
-              "name": "S04 - Maternal Clinical history",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-a5301b',
+              'formId': 's04-current-pregnancy-record-and-pregnancy-history-9858d6',
+              'name': 'S04 - Maternal Clinical history',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-c58ef3",
-              "formId": "s05-maternal-physical-exam-1c983b",
-              "name": "S05 - Physical Exam",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-c58ef3',
+              'formId': 's05-maternal-physical-exam-1c983b',
+              'name': 'S05 - Physical Exam',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-z830kj",
-              "formId": "s06-current-anc-visit-68fc78",
-              "name": "S06 - Current ANC visit",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-z830kj',
+              'formId': 's06-current-anc-visit-68fc78',
+              'name': 'S06 - Current ANC visit',
+              'required': true,
+              'repeatable': false
             },
             {
-              "id": "event-form-definition-z452kj",
-              "formId": "s07-visit-information-82328c",
-              "name": "S07 - Visit Close Out",
-              "required": true,
-              "repeatable": false
+              'id': 'event-form-definition-z452kj',
+              'formId': 's07-visit-information-82328c',
+              'name': 'S07 - Visit Close Out',
+              'required': true,
+              'repeatable': false
             }
           ]
         },
-        
       ]
     }
     return [
@@ -181,8 +180,11 @@ class MockCasesService {
         status: CASE_EVENT_STATUS_IN_PROGRESS,
         eventForms: [],
         estimate: false,
-        dateStart: REFERENCE_TIME,
-        dateEnd: REFERENCE_TIME + (1000 * 60 * 60),
+        scheduledDay: REFERENCE_TIME,
+        occurredOnDay: REFERENCE_TIME,
+        estimatedDay: REFERENCE_TIME,
+        windowStartDay: REFERENCE_TIME,
+        windowEndDay: REFERENCE_TIME + (1000 * 60 * 60),
         caseDefinition,
         caseInstance: {
           caseDefinitionId: 'c1',
@@ -191,34 +193,36 @@ class MockCasesService {
           collection: 'TangyFormResponse',
           events:<any> [
             {
-              "id": "0ff22322-7734-4cc1-957d-dd25416a9413",
-              "caseId": "ff621529-d26b-42cc-a9a1-254179e75622",
-              "status": "in-progress",
-              "name": "ANC-Enrollment",
-              "estimate": true,
-              "caseEventDefinitionId": "c1",
-              "dateStart": REFERENCE_TIME,
-              "dateEnd": REFERENCE_TIME + (1000 * 60 * 60),
-              "eventForms": [
+              'id': '0ff22322-7734-4cc1-957d-dd25416a9413',
+              'caseId': 'ff621529-d26b-42cc-a9a1-254179e75622',
+              'status': 'in-progress',
+              'name': 'ANC-Enrollment',
+              'estimate': true,
+              'caseEventDefinitionId': 'c1',
+              'scheduledDay': REFERENCE_TIME,
+              'occurredOnDay': REFERENCE_TIME,
+              'estimatedDay': REFERENCE_TIME,
+              'windowStartDay': REFERENCE_TIME,
+              'windowEndDay': REFERENCE_TIME + (1000 * 60 * 60),
+              'eventForms': [
                 {
-                  "id": "fb64d705-ee99-4a27-bbad-8349a0e8767d",
-                  "complete": false,
-                  "caseId": "ff621529-d26b-42cc-a9a1-254179e75622",
-                  "caseEventId": "0ff22322-7734-4cc1-957d-dd25416a9413",
-                  "eventFormDefinitionId": "event-form-definition-ece26e",
-                  "formResponseId": "487517f7-0bec-4363-b22c-0c20090fe284"
+                  'id': 'fb64d705-ee99-4a27-bbad-8349a0e8767d',
+                  'complete': false,
+                  'caseId': 'ff621529-d26b-42cc-a9a1-254179e75622',
+                  'caseEventId': '0ff22322-7734-4cc1-957d-dd25416a9413',
+                  'eventFormDefinitionId': 'event-form-definition-ece26e',
+                  'formResponseId': '487517f7-0bec-4363-b22c-0c20090fe284'
                 },
                 {
-                  "id": "83c502a2-8c82-4ed8-ad05-e8263cd56a0b",
-                  "complete": false,
-                  "caseId": "ff621529-d26b-42cc-a9a1-254179e75622",
-                  "caseEventId": "0ff22322-7734-4cc1-957d-dd25416a9413",
-                  "eventFormDefinitionId": "event-form-definition-574497",
-                  "formResponseId": "3cd53c20-d213-4e8b-bf90-c7091bf95ad6"
+                  'id': '83c502a2-8c82-4ed8-ad05-e8263cd56a0b',
+                  'complete': false,
+                  'caseId': 'ff621529-d26b-42cc-a9a1-254179e75622',
+                  'caseEventId': '0ff22322-7734-4cc1-957d-dd25416a9413',
+                  'eventFormDefinitionId': 'event-form-definition-574497',
+                  'formResponseId': '3cd53c20-d213-4e8b-bf90-c7091bf95ad6'
                 },
-                
               ],
-              "startDate": 0
+              'startDate': 0
             }
           ]
         }

--- a/client/src/app/case/services/cases.service.ts
+++ b/client/src/app/case/services/cases.service.ts
@@ -30,15 +30,16 @@ export class CasesService {
         })], <Array<CaseEventInfo>>[]);
 			return Promise.all(docs).then( data=>data.filter(eventInfo => this.doesOverlap(dateStart, dateEnd, eventInfo) && !(excludeEstimates && eventInfo.estimate))
 			.sort(function (a, b) {
-				return b.dateStart - a.dateStart;
+				return b.estimatedDay - a.estimatedDay;
 			}))
 	}
 
-	private doesOverlap(dateStart, dateEnd, eventInfo):boolean {
+	private doesOverlap(dateStart, dateEnd, eventInfo:CaseEventInfo):boolean {
+		const date = eventInfo.occurredOnDay || eventInfo.scheduledDay || eventInfo.estimatedDay
 		// Return true if lower bound overlap, upper bound overlap, inside bounds, or encompassing bounds.
-		return (eventInfo.dateStart <= dateStart && dateStart <= eventInfo.dateEnd)
-			|| (eventInfo.dateStart <= dateEnd && dateEnd <= eventInfo.dateEnd)
-			|| (eventInfo.dateStart >= dateStart && dateEnd >= eventInfo.dateEnd)
-			|| (eventInfo.dateStart <= dateStart && dateEnd <= eventInfo.dateEnd)
+		return (date <= dateStart && dateStart <= date)
+			|| (date <= dateEnd && dateEnd <= date)
+			|| (date >= dateStart && dateEnd >= date)
+			|| (date <= dateStart && dateEnd <= date)
 	}
 }

--- a/client/src/app/case/services/cases.service.ts
+++ b/client/src/app/case/services/cases.service.ts
@@ -1,45 +1,47 @@
 import { Injectable } from '@angular/core';
 import { UserService } from 'src/app/shared/_services/user.service';
-import { CaseEvent } from '../classes/case-event.class';
 import { Case } from '../classes/case.class';
 import { CaseEventInfo } from './case-event-info.class';
 import { CaseService } from './case.service';
 
 @Injectable({
-	providedIn: 'root'
+  providedIn: 'root'
 })
 export class CasesService {
 
-	constructor(
-    private userService:UserService,
-    private caseService:CaseService
-	) { }
+  constructor(
+    private userService: UserService,
+    private caseService: CaseService
+  ) { }
 
-	async getEventsByDate (dateStart, dateEnd, excludeEstimates = false):Promise<Array<CaseEventInfo>> {
-		const userDb = await this.userService.getUserDatabase(this.userService.getCurrentUser())
-		const allDocs = await userDb.allDocs({include_docs:true})
-		const docs = <Array<CaseEventInfo>>(allDocs)
-			.rows
-			.map(row => row.doc)
-			.filter(doc => doc.collection === 'TangyFormResponse' && doc.type === 'case')
-			.reduce((acc, caseDoc) => [...acc, ...caseDoc.events
-			.map( event=>{
-         return this.caseService.getCaseDefinitionByID(caseDoc.caseDefinitionId).then(caseDefinition=>{
-           return{...event, caseInstance: caseDoc, caseDefinition}
-         })
+  async getEventsByDate(dateStart, dateEnd, excludeEstimates = false): Promise<Array<CaseEventInfo>> {
+    const userDb = await this.userService.getUserDatabase(this.userService.getCurrentUser())
+    const allDocs = await userDb.allDocs({ include_docs: true })
+    const docs = <Array<CaseEventInfo>>(allDocs)
+      .rows
+      .map(row => row.doc)
+      .filter(doc => doc.collection === 'TangyFormResponse' && doc.type === 'case')
+      .reduce((acc, caseDoc) => [...acc, ...caseDoc.events
+        .map(event => {
+          return this.caseService.getCaseDefinitionByID(caseDoc.caseDefinitionId).then(caseDefinition => {
+            return { ...event, caseInstance: caseDoc, caseDefinition }
+          })
         })], <Array<CaseEventInfo>>[]);
-			return Promise.all(docs).then( data=>data.filter(eventInfo => this.doesOverlap(dateStart, dateEnd, eventInfo) && !(excludeEstimates && eventInfo.estimate))
-			.sort(function (a, b) {
-				return b.estimatedDay - a.estimatedDay;
-			}))
-	}
+    return Promise.all(docs).
+    then(data => data.filter(eventInfo => this.doesOverlap(dateStart, dateEnd, eventInfo) && !(excludeEstimates && eventInfo.estimate))
+      .sort(function (a, b) {
+        const dateA = new Date(a.occurredOnDay || a.scheduledDay || a.estimatedDay || a.windowStartDay).getTime()
+        const dateB = new Date(b.occurredOnDay || b.scheduledDay || b.estimatedDay || a.windowEndDay).getTime()
+        return dateA - dateB;
+      }))
+  }
 
-	private doesOverlap(dateStart, dateEnd, eventInfo:CaseEventInfo):boolean {
-		const date = eventInfo.occurredOnDay || eventInfo.scheduledDay || eventInfo.estimatedDay
-		// Return true if lower bound overlap, upper bound overlap, inside bounds, or encompassing bounds.
-		return (date <= dateStart && dateStart <= date)
-			|| (date <= dateEnd && dateEnd <= date)
-			|| (date >= dateStart && dateEnd >= date)
-			|| (date <= dateStart && dateEnd <= date)
-	}
+  private doesOverlap(dateStart, dateEnd, eventInfo: CaseEventInfo): boolean {
+    const date = eventInfo.occurredOnDay || eventInfo.scheduledDay || eventInfo.estimatedDay
+    // Return true if lower bound overlap, upper bound overlap, inside bounds, or encompassing bounds.
+    return (date <= dateStart && dateStart <= date)
+      || (date <= dateEnd && dateEnd <= date)
+      || (date >= dateStart && dateEnd >= date)
+      || (date <= dateStart && dateEnd <= date)
+  }
 }


### PR DESCRIPTION
## Description

---

Create new date properties for cases. Create helper methods to be accessed by the content creators to set the dates

- Fixes #1737 

## Type of Change
- New feature (non-breaking change which adds functionality)

## Proposed Solution

---

Remove `dateStart` and `dateEnd` properties and create new date properties as follows:
* `estimatedDay`
* `scheduledDay`
* `windowStartDay`
* `windowEndDay`
* `occurredOnDay`


Create setters for each of these in the `case-service.ts` file:
* `setEventEstimatedDay`
* `setEventScheduledDay`
* `setEventWindow`
* `setEventOccurredOn`
## Tests

---

Created unit tests for each of the new setter methods

## Notices, Regressions, Breaking Changes

---
Example for Setting a date:
``` javascript
 const now = Date.now()
 const day = 1000*60*60*24
 const month = day*30
 // setting Event window
 caseService.setEventWindow(someEvent.id, now+(1*month), now+(2*month))
 // setting eventOccurredOn
 caseService.setEventOccurredOn(someEvent.id, now+(1*month))
```
The above code can be used in the event handler, e.g `on-submit`
``` html
 on-submit="
            // Some variables for helping calculate time in milliseconds.
            const now = Date.now()
            const day = 1000*60*60*24
            const month = day*30
            // Create events and schedule them.
           
            const someEvent = caseService.createEvent('event-definition-7180d2')
            caseService.setEventWindow(someEvent.id, now+(21*month), now+(21*month))
          }
        "
```
### ***_BREAKING CHANGES_***
**NOTE** `scheduleEvent` method on `case-service` is **deprecated**