### PR TITLE
Show sync, update, and about menu links without logging in

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -8,8 +8,8 @@
   </div>
 </div>
 
-<mat-toolbar *ngIf="installed && showNav" dir="{{languageDirection}}" color="primary" class="mat-typography mat-tangy-custom-toolbar">
-  <span class="home-icon">
+<mat-toolbar *ngIf="installed" dir="{{languageDirection}}" color="primary" class="mat-typography mat-tangy-custom-toolbar">
+  <span class="home-icon" *ngIf="isLoggedIn">
     <a class="tangy-no-text-decoration tangy-app-name" routerLink="/home">
       <app-tangy-svg-logo [tangyLogoStyle]="{'height':'45px'}"></app-tangy-svg-logo>
     </a>
@@ -20,13 +20,13 @@
   </span>
   <span class="tangy-spacer"></span>
 
-  <paper-icon-button icon="more-vert" *ngIf="showNav" [matMenuTriggerFor]="appMenu" class="hamburger-menu"></paper-icon-button>
+  <paper-icon-button icon="more-vert" [matMenuTriggerFor]="appMenu" class="hamburger-menu"></paper-icon-button>
   <mat-menu #appMenu="matMenu">
     <button *ngIf="window && window.appConfig && !window.appConfig.hideProfile" routerLink="manage-user-profile" mat-menu-item>
       <mat-icon class="material-icons menu-tangy-location-list-icon">create</mat-icon>
       <span>{{'Manage Profile'|translate}}</span>
     </button>
-    <button routerLink="settings" mat-menu-item>
+    <button *ngIf="isLoggedIn" routerLink="settings" mat-menu-item>
       <mat-icon class="material-icons menu-tangy-location-list-icon">settings</mat-icon>
       <span>{{'Settings'|translate}}</span>
     </button>
@@ -38,7 +38,7 @@
       <mat-icon class="material-icons menu-tangy-location-list-icon">autorenew</mat-icon>
       <span>{{'Sync: P2P'|translate}}</span>
     </button>
-    <button routerLink="/export-data" mat-menu-item>
+    <button *ngIf="isLoggedIn" routerLink="/export-data" mat-menu-item>
       <mat-icon class="material-icons menu-tangy-location-list-icon">import_export</mat-icon>
       <span>{{'Export Data'|translate}}</span>
     </button>
@@ -54,7 +54,7 @@
       <mat-icon class="material-icons menu-tangy-location-list-icon">info</mat-icon>
       <span>{{'About'|translate}}</span>
     </button>
-    <button mat-menu-item (click)="logout()">
+    <button *ngIf="isLoggedIn" mat-menu-item (click)="logout()">
       <mat-icon class="material-icons menu-tangy-location-list-icon">exit_to_app</mat-icon>
       <span>{{'Logout'|translate}}</span>
     </button>

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -22,10 +22,10 @@ const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true),
 export class AppComponent implements OnInit {
 
   appConfig:AppConfig
-  showNav;
   showUpdateAppLink;
   window:any;
   installed = false
+  isLoggedIn = false
   freespaceCorrectionOccuring = false;
   updateIsRunning = false;
   languageCode:string
@@ -86,9 +86,9 @@ export class AppComponent implements OnInit {
     // Set translation for t function used in Web Components.
     const translation = await this.http.get(`./assets/${this.languagePath}.json`).toPromise();
     this.window.translation = translation
-    this.showNav = this.authenticationService.isLoggedIn();
+    this.isLoggedIn = this.authenticationService.isLoggedIn();
     this.authenticationService.currentUserLoggedIn$.subscribe((isLoggedIn) => {
-      this.showNav = isLoggedIn;
+      this.isLoggedIn = isLoggedIn;
     });
     // Keep GPS chip warm.
     // @TODO Make this configurable. Not all installations use GPS and don't need to waste the battery.

--- a/client/src/app/core/auth/login/login.component.css
+++ b/client/src/app/core/auth/login/login.component.css
@@ -1,6 +1,6 @@
 :host {
   position: relative;
-  top: -64px;
+  top: -20px;
 }
 
 #header {

--- a/client/src/app/core/auth/registration/registration.component.css
+++ b/client/src/app/core/auth/registration/registration.component.css
@@ -1,6 +1,6 @@
 :host {
   position: relative;
-  top: -64px;
+  top: -20px;
 }
 
 #header {


### PR DESCRIPTION
When devices are being prepared before going out to where they will be delivered, you cannot currently update the app, sync content, or see the about page without creating a throw away account. This creates a lot of work for deployments. This PR exposes those menu items without the need to log in.

![image](https://user-images.githubusercontent.com/156575/72369824-e7e61580-36ce-11ea-8c1d-c3a54961b824.png)
