### PR TITLE
Change from async to sync methods when setting dates. Make use of moment for formatting dates into YYYY-MM-DD

### DIFF
--- a/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.ts
+++ b/client/src/app/case/components/case-event-schedule-list/case-event-schedule-list.component.ts
@@ -48,6 +48,9 @@ export class CaseEventScheduleListComponent implements OnInit {
   private _mode = CASE_EVENT_SCHEDULE_LIST_MODE_WEEKLY
   @Input()
   set mode(mode:string) {
+    if (this._mode === mode) {
+      return;
+    }
     this._mode = mode
     this.calculateEvents()
   }

--- a/client/src/app/case/services/case.service.spec.ts
+++ b/client/src/app/case/services/case.service.spec.ts
@@ -14,7 +14,7 @@ import PouchDB from 'pouchdb';
 import { HttpClient } from '@angular/common/http';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 import { CaseParticipant } from '../classes/case-participant.class';
-
+import moment from 'moment/src/moment';
 class MockCaseDefinitionsService {
   async load() {
     return <Array<CaseDefinition>>[
@@ -206,9 +206,8 @@ describe('CaseService', () => {
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
     const timeInMs = new Date().getTime()
-    const dateString = new Date(timeInMs)
-    const date = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
-    await service.setEventOccurredOn(service.case.events[0].id, timeInMs)
+    const date = moment((new Date(timeInMs))).format('YYYY-MM-DD')
+    service.setEventOccurredOn(service.case.events[0].id, timeInMs)
     expect(service.case.events[0].occurredOnDay).toEqual(date)
   })
   it('should set an event EstimatedDay date', async () => {
@@ -216,9 +215,8 @@ describe('CaseService', () => {
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
     const timeInMs = new Date().getTime()
-    const dateString = new Date(timeInMs)
-    const date = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
-    await service.setEventEstimatedDay(service.case.events[0].id, timeInMs)
+    const date = moment((new Date(timeInMs))).format('YYYY-MM-DD')
+    service.setEventEstimatedDay(service.case.events[0].id, timeInMs)
     expect(service.case.events[0].estimatedDay).toEqual(date)
   })
   it('should set an event ScheduledDay date', async () => {
@@ -226,9 +224,8 @@ describe('CaseService', () => {
     await service.create('caseDefinition1')
     await service.createEvent('event-definition-first-visit')
     const timeInMs = new Date().getTime()
-    const dateString = new Date(timeInMs)
-    const date = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
-    await service.setEventScheduledDay(service.case.events[0].id, timeInMs)
+    const date = moment((new Date(timeInMs))).format('YYYY-MM-DD')
+    service.setEventScheduledDay(service.case.events[0].id, timeInMs)
     expect(service.case.events[0].scheduledDay).toEqual(date)
   })
   it('should set an event Window period', async () => {
@@ -237,11 +234,9 @@ describe('CaseService', () => {
     await service.createEvent('event-definition-first-visit')
     const windowStartDayTimeInMs = new Date().getTime()
     const windowEndDayTimeInMs = new Date().getTime()
-    const windowStartDateString = new Date(windowStartDayTimeInMs)
-    const windowEndDateString = new Date(windowEndDayTimeInMs)
-    const windowStartDay = `${windowStartDateString.getFullYear()}-${windowStartDateString.getMonth()}-${windowStartDateString.getDate()}`
-    const windowEndDay = `${windowEndDateString.getFullYear()}-${windowEndDateString.getMonth()}-${windowEndDateString.getDate()}`
-    await service.setEventWindow(service.case.events[0].id, windowStartDayTimeInMs, windowEndDayTimeInMs)
+    const windowStartDay = moment((new Date(windowStartDayTimeInMs))).format('YYYY-MM-DD')
+    const windowEndDay = moment((new Date(windowEndDayTimeInMs))).format('YYYY-MM-DD')
+    service.setEventWindow(service.case.events[0].id, windowStartDayTimeInMs, windowEndDayTimeInMs)
     expect(service.case.events[0].windowStartDay).toEqual(windowStartDay)
     expect(service.case.events[0].windowEndDay).toEqual(windowEndDay)
   })

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -134,60 +134,46 @@ class CaseService {
   startEvent(eventId) {
     // ??
   }
-
-  // async scheduleEvent(eventId, dateStart:number, dateEnd?:number) {
-  //   this.case.events = this.case.events.map(event => {
-  //     return event.id === eventId 
-  //     ? { ...event, ...{ dateStart, dateEnd: dateEnd ? dateEnd : dateStart, estimate: false} }
-  //     : event
-  //   })
-  // }
-
-  async setEventEstimatedDay(eventId, timeInMs: number) {
-    const dateString = new Date(timeInMs)
-    const estimatedDay = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
+  setEventEstimatedDay(eventId, timeInMs: number) {
+    const estimatedDay = moment((new Date(timeInMs))).format('YYYY-MM-DD')
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
-      ? { ...event, ...{ estimatedDay} }
-      : event
+        ? { ...event, ...{ estimatedDay } }
+        : event
     })
   }
-  async setEventScheduledDay(eventId, timeInMs: number) {
-    const dateString = new Date(timeInMs)
-    const scheduledDay = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
+  setEventScheduledDay(eventId, timeInMs: number) {
+    const scheduledDay = moment((new Date(timeInMs))).format('YYYY-MM-DD')
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
-      ? { ...event, ...{ scheduledDay} }
-      : event
+        ? { ...event, ...{ scheduledDay } }
+        : event
     })
   }
-  async setEventWindow(eventId: string, windowStartDayTimeInMs: number, windowEndDayTimeInMs: number) {
-    const windowStartDateString = new Date(windowStartDayTimeInMs)
-    const windowEndDateString = new Date(windowEndDayTimeInMs)
-    const windowStartDay = `${windowStartDateString.getFullYear()}-${windowStartDateString.getMonth()}-${windowStartDateString.getDate()}`
-    const windowEndDay = `${windowEndDateString.getFullYear()}-${windowEndDateString.getMonth()}-${windowEndDateString.getDate()}`
+  setEventWindow(eventId: string, windowStartDayTimeInMs: number, windowEndDayTimeInMs: number) {
+    const windowStartDay = moment((new Date(windowEndDayTimeInMs))).format('YYYY-MM-DD')
+    const windowEndDay = moment((new Date(windowEndDayTimeInMs))).format('YYYY-MM-DD')
     this.case.events = this.case.events.map(event => {
       return event.id === eventId
-      ? { ...event, ...{ windowStartDay, windowEndDay} }
-      : event
+        ? { ...event, ...{ windowStartDay, windowEndDay } }
+        : event
     })
   }
-  async setEventOccurredOn(eventId, timeInMs: number) {
-    const dateString = new Date(timeInMs)
-    const occurredOnDay = `${dateString.getFullYear()}-${dateString.getMonth()}-${dateString.getDate()}`
+  setEventOccurredOn(eventId, timeInMs: number) {
+    const occurredOnDay = moment((new Date(timeInMs))).format('YYYY-MM-DD')
     return this.case.events = this.case.events.map(event => {
       return event.id === eventId
-      ? { ...event, ...{ occurredOnDay} }
-      : event
+        ? { ...event, ...{ occurredOnDay } }
+        : event
     })
   }
-  startEventForm(caseEventId, eventFormDefinitionId, participantId = ''):EventForm {
+  startEventForm(caseEventId, eventFormDefinitionId, participantId = ''): EventForm {
     const eventForm = <EventForm>{
-      id: UUID(), 
-      complete: false, 
-      caseId: this.case._id, 
+      id: UUID(),
+      complete: false,
+      caseId: this.case._id,
       participantId,
-      caseEventId, 
+      caseEventId,
       eventFormDefinitionId: eventFormDefinitionId
     }
     this

--- a/client/src/app/case/services/cases.service.ts
+++ b/client/src/app/case/services/cases.service.ts
@@ -3,6 +3,7 @@ import { UserService } from 'src/app/shared/_services/user.service';
 import { Case } from '../classes/case.class';
 import { CaseEventInfo } from './case-event-info.class';
 import { CaseService } from './case.service';
+import moment from 'moment/src/moment';
 
 @Injectable({
   providedIn: 'root'
@@ -37,11 +38,14 @@ export class CasesService {
   }
 
   private doesOverlap(dateStart, dateEnd, eventInfo: CaseEventInfo): boolean {
-    const date = eventInfo.occurredOnDay || eventInfo.scheduledDay || eventInfo.estimatedDay
-    // Return true if lower bound overlap, upper bound overlap, inside bounds, or encompassing bounds.
-    return (date <= dateStart && dateStart <= date)
-      || (date <= dateEnd && dateEnd <= date)
-      || (date >= dateStart && dateEnd >= date)
-      || (date <= dateStart && dateEnd <= date)
+    // Only show items on schedule view if the following dates are set on the event
+    if (!(eventInfo.scheduledDay || eventInfo.estimatedDay || eventInfo.windowStartDay)){
+      return false;
+    }
+    dateStart = moment(new Date(dateStart)).format('YYYY-MM-DD')
+    dateEnd = moment(new Date(dateEnd)).format('YYYY-MM-DD')
+    console.log({dateStart, dateEnd})
+    return moment(eventInfo.scheduledDay || eventInfo.estimatedDay || eventInfo.windowStartDay).isBetween(dateStart, dateEnd, 'days', '[]')
+    || moment(eventInfo.scheduledDay || eventInfo.estimatedDay ||eventInfo.windowEndDay).isBetween(dateStart, dateEnd, 'days', '[]')
   }
 }


### PR DESCRIPTION
## Description

---

Dates should be set using synchronous methods as there might be a race condition as explained in the issue #1843 
Dates format should be standardized using `moment.js`
Events not showing on schedule and also the UI rerenders twice for every date change event

- Fixes #1843 , #1844, #1845 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---
Changes async date setting methods into synchronous methods.
Use `moment.js` for date formatting
Fix render to only happen when date has changed and mode has chnaged

## Tests

---

Tested using unit tests. Unit tests updated correspondingly

## TODO/ Improvements
* Changing from week view to day view doesnt work