### PR TITLE
Prevent redirect to device-setup route when window.location.hostname …

### DIFF
--- a/client/src/app/shared/_guards/login-guard.service.ts
+++ b/client/src/app/shared/_guards/login-guard.service.ts
@@ -23,7 +23,7 @@ export class LoginGuard implements CanActivate {
     //   return true;
     // }
     const appConfig = await this.appConfigService.getAppConfig()
-    if (appConfig.associateUserProfileMode === 'local-exists' && !(await this.deviceService.isRegistered())) {
+    if (window.location.hostname !== '127.0.0.1' && window.location.hostname !== 'localhost' && appConfig.associateUserProfileMode === 'local-exists' && !(await this.deviceService.isRegistered())) {
       this.router.navigate(['device-setup'], { queryParams: { returnUrl: state.url } });
     } else {
       this.router.navigate(['login'], { queryParams: { returnUrl: state.url } });


### PR DESCRIPTION
When using a content set with app-config.json's `userProfileMode` set to `"local-exists"`, the login guard will redirect you to the device-setup route if it detects you are on a device not tied to a server. This will always happen on your local sandbox as well as when using the tangerine-preview tool. The work around has been to modify `userProfileMode` to `"local-new"` and then try to remember not to commit that change in the content repository you're working in. What a drag! This PR checks to see if you are in a `localhost` or `127.0.0.1` context and if so will bypass the need to register your device.