### PR TITLE
Add a ready flag to AppComponent so template logic can check to make …

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -22,7 +22,7 @@
 
   <paper-icon-button icon="more-vert" [matMenuTriggerFor]="appMenu" class="hamburger-menu"></paper-icon-button>
   <mat-menu #appMenu="matMenu">
-    <button *ngIf="window && window.appConfig && !window.appConfig.hideProfile" routerLink="manage-user-profile" mat-menu-item>
+    <button *ngIf="ready && !appConfig.hideProfile" routerLink="manage-user-profile" mat-menu-item>
       <mat-icon class="material-icons menu-tangy-location-list-icon">create</mat-icon>
       <span>{{'Manage Profile'|translate}}</span>
     </button>
@@ -34,7 +34,7 @@
       <mat-icon class="material-icons menu-tangy-location-list-icon">autorenew</mat-icon>
       <span>{{'Sync: Online'|translate}}</span>
     </button>
-    <button *ngIf="appConfig.p2pSync === 'true'" routerLink="/peers" mat-menu-item>
+    <button *ngIf="ready && appConfig.p2pSync === 'true'" routerLink="/peers" mat-menu-item>
       <mat-icon class="material-icons menu-tangy-location-list-icon">autorenew</mat-icon>
       <span>{{'Sync: P2P'|translate}}</span>
     </button>

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -32,6 +32,7 @@ export class AppComponent implements OnInit {
   languageDirection:string
   languagePath:string
   translate: TranslateService
+  ready = false
   @ViewChild(MatSidenav) sidenav: QueryList<MatSidenav>;
 
   constructor(
@@ -96,6 +97,7 @@ export class AppComponent implements OnInit {
     this.checkIfUpdateScriptRequired();
     this.checkStorageUsage()
     setInterval(this.checkStorageUsage.bind(this), 60*1000);
+    this.ready = true
   }
 
   async install() {


### PR DESCRIPTION
We're getting a lot of noise from the app component template because it's trying to access a property in appConfig and appConfig doesn't exist before the first render of the template. This reduces noise by adding a ready flag on AppComponent and making sure the logic in the template first checks for ready. Note this is a common pattern I use for any time you need to asynchronously load some stuff in `ngOnInit`/etc.