### PR TITLE
Fix unnecessary case confirm after creating a case

### DIFF
--- a/client/src/app/case/components/new-case/new-case.component.ts
+++ b/client/src/app/case/components/new-case/new-case.component.ts
@@ -27,6 +27,7 @@ export class NewCaseComponent implements AfterContentInit {
       const formId = params['formId'];
       const caseDefinitions = await this.caseDefinitionsService.load();
       await this.caseService.create(caseDefinitions.find(caseDefinition => caseDefinition.formId === formId).id)
+      this.caseService.openCaseConfirmed = true
       let eventForm:EventForm
       if (this.caseService.caseDefinition.startFormOnOpen && this.caseService.caseDefinition.startFormOnOpen.eventFormId) {
         const caseEvent = this.caseService.createEvent(this.caseService.caseDefinition.startFormOnOpen.eventId, true)


### PR DESCRIPTION
Create a case, finish the first form. Then click back to list of events and you are asked to confirm the case you "opened". This fixes that so you don't need to confirm after creating a case.