### PR TITLE
Add firstOpentime for each item. Use unix timestamp

### DIFF
--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -87,6 +87,7 @@ const generateFlatResponse = async function (formResponse, locationList) {
   }
   let formID = formResponse.form.id;
   for (let item of formResponse.items) {
+    flatFormResponse[`${item.id}-firstOpenTime`]= item.firstOpenTime? new Date(item.firstOpenTime).getTime():''
     for (let input of item.inputs) {
       if (input.tagName === 'TANGY-LOCATION') {
         // Populate the ID and Label columns for TANGY-LOCATION levels.

--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -87,7 +87,7 @@ const generateFlatResponse = async function (formResponse, locationList) {
   }
   let formID = formResponse.form.id;
   for (let item of formResponse.items) {
-    flatFormResponse[`${item.id}-firstOpenTime`]= item.firstOpenTime? new Date(item.firstOpenTime).getTime():''
+    flatFormResponse[`${item.id}_firstOpenTime`]= item.firstOpenTime? item.firstOpenTime:''
     for (let input of item.inputs) {
       if (input.tagName === 'TANGY-LOCATION') {
         // Populate the ID and Label columns for TANGY-LOCATION levels.


### PR DESCRIPTION
## Description

---

* Record starting time for each section

- Fixes #1789 
- Needs Tangerine-Community/tangy-form#118

## Type of Change

[Please delete irrelevant options]

- New feature (non-breaking change which adds functionality)

## Proposed Solution

---
* Add the time to the item/section when the first item is loaded. For the other items, record the time when `ITEM_NEXT`  finishes.
* The datetime is then emitted as a Unix timestamp when downloading csv
