### PR TITLE
Ensure all IDs are cast to strings

### DIFF
--- a/editor/src/app/groups/import-location-list/import-location-list.component.ts
+++ b/editor/src/app/groups/import-location-list/import-location-list.component.ts
@@ -184,12 +184,12 @@ export class ImportLocationListComponent implements OnInit {
     const levels = [...this.locationList.locationsLevels].reverse();
     levels.map((level, index) => {
       this.parsedCSVData.map(item => {
-        const id = item[this.mappings[`${level}_id`]];
-        const parentId = item[this.mappings[`${levels[index + 1]}_id`]];
+        const id = String(item[this.mappings[`${level}_id`]]);
+        const parentId = String(item[this.mappings[`${levels[index + 1]}_id`]]);
         const parent = index + 1 === levels.length ? 'root' : parentId;
         let value = {
           parent,
-          label: item[this.mappings[level]].toString(),
+          label: String(item[this.mappings[level]]),
           id,
           level
         };


### PR DESCRIPTION
## Description

---
When a `location-list csv` file has IDs whose type is of `number`, the user cannot select the location item from the UI. As such we need to ensure all `IDs` are of type `string`

- Fixes #1853 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

Cast `IDs` to type `string` when building up the location list


