### PR TITLE
Fix inifinite save loop when editing forms (for #1903)

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -37,7 +37,7 @@
     "redux": "^4.0.1",
     "rxjs": "~6.3.3",
     "tangy-form": "4.11.0",
-    "tangy-form-editor": "6.12.0",
+    "tangy-form-editor": "6.12.1",
     "translation-web-component": "0.0.3",
     "tslib": "^1.9.0",
     "underscore": "^1.9.1",

--- a/editor/src/app/ng-tangy-form-editor/ng-tangy-form-editor/ng-tangy-form-editor.component.html
+++ b/editor/src/app/ng-tangy-form-editor/ng-tangy-form-editor/ng-tangy-form-editor.component.html
@@ -1,15 +1,14 @@
-<mat-tab-group *ngIf="hasClassModule" class="tangy-full-width" (selectedTabChange)="tabChanged($event)" [selectedIndex]="selectedIndex">
+<mat-tab-group class="tangy-full-width" [selectedIndex]="selectedIndex">
     <mat-tab>
       <ng-template mat-tab-label>
         {{'Form Editor'|translate}}
       </ng-template>
-        <div #container></div>
+      <div #container></div>
     </mat-tab>
-    <mat-tab>
+    <mat-tab *ngIf="hasClassModule">
       <ng-template mat-tab-label>
         {{'Feedback Editor'|translate}}
       </ng-template>
-      <feedback-editor [groupName]="groupName" [formId]="formId"></feedback-editor>
+      <feedback-editor [groupName]="groupId" [formId]="formId"></feedback-editor>
     </mat-tab>
 </mat-tab-group>
-<div *ngIf="!hasClassModule" #container></div>

--- a/editor/src/app/ng-tangy-form-editor/ng-tangy-form-editor/ng-tangy-form-editor.component.ts
+++ b/editor/src/app/ng-tangy-form-editor/ng-tangy-form-editor/ng-tangy-form-editor.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, ElementRef, Component, ViewChild, Inject, AfterContentChecked } from '@angular/core';
+import { AfterContentInit, OnInit, ElementRef, Component, ViewChild, Inject, AfterContentChecked } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import {MatTabChangeEvent} from "@angular/material";
@@ -11,12 +11,12 @@ import {Feedback} from "../feedback-editor/feedback";
   templateUrl: './ng-tangy-form-editor.component.html',
   styleUrls: ['./ng-tangy-form-editor.component.css']
 })
-export class NgTangyFormEditorComponent implements AfterContentChecked {
+export class NgTangyFormEditorComponent implements OnInit {
 
   @ViewChild('container') container: ElementRef;
   @ViewChild('header') header: ElementRef;
   containerEl: any;
-  selectedIndex = 1;
+  selectedIndex = 0;
   print = false;
   groupId;
   formId;
@@ -33,11 +33,7 @@ export class NgTangyFormEditorComponent implements AfterContentChecked {
     private appConfigService: AppConfigService,
   ) { }
 
-  async ngAfterContentInit() {
-
-  }
-  
-  async ngAfterContentChecked() {
+  async ngOnInit() {
 
     this.containerEl = this.container.nativeElement
 
@@ -90,19 +86,11 @@ export class NgTangyFormEditorComponent implements AfterContentChecked {
     }
   }
 
-  tabChanged = async (tabChangeEvent: MatTabChangeEvent): Promise<void> => {
-     if (tabChangeEvent.index === 0) {
-        window.history.back()
-      } else if  (tabChangeEvent.index === 1) {
-       this.ngAfterContentInit()
-     }
-  }
-
   async saveForm(formHtml) {
     let files = []
     let state = this.containerEl.querySelector('tangy-form-editor').store.getState()
     // Update forms.json.
-    let formsJson = await this.http.get<Array<any>>(`/editor/${this.route.snapshot.paramMap.get('groupName')}/content/forms.json`).toPromise()
+    let formsJson = await this.http.get<Array<any>>(`/editor/${this.groupId}/content/forms.json`).toPromise()
     const updatedFormsJson = formsJson.map(formInfo => {
       if (formInfo.id !== state.form.id) return Object.assign({}, formInfo)
       return Object.assign({}, formInfo, {
@@ -110,13 +98,13 @@ export class NgTangyFormEditorComponent implements AfterContentChecked {
       })
     })
     files.push({
-      groupId: this.route.snapshot.paramMap.get('groupName'),
+      groupId: this.groupId,
       filePath:`./forms.json`,
       fileContents: JSON.stringify(updatedFormsJson)
     })
     // Update form.html.
     files.push({
-      groupId: this.route.snapshot.paramMap.get('groupName'),
+      groupId: this.groupId,
       filePath:`./${state.form.id}/form.html`,
       fileContents: formHtml
     })


### PR DESCRIPTION
Fixes #1903. The root of the problem was that we switched to using the ngAfterContentChecked lifecycle hook for starting form editing but resulted in an infinite loop. I also found another issue when flipping between "feedback" and "form edit" tabs where tangy-form-editor breaks due a lifecycle hook issue where connectedCallback gets called more than once, so it now uses `ready()`. 