### PR TITLE
Enforce a strong password policy

### DIFF
--- a/client/src/app/core/auth/registration/registration.component.ts
+++ b/client/src/app/core/auth/registration/registration.component.ts
@@ -83,6 +83,7 @@ export class RegistrationComponent implements OnInit {
             } catch (error) {
                 console.log(error);
                 this.statusMessage = this.couldNotCreateUserMessage;
+                this.disableSubmit = false
             };
         } else {
             this.statusMessage = this.userNameUnavailableMessage;

--- a/client/src/app/core/auth/registration/registration.component.ts
+++ b/client/src/app/core/auth/registration/registration.component.ts
@@ -32,6 +32,7 @@ export class RegistrationComponent implements OnInit {
     userNameAvailableMessage = { type: 'success', message: _TRANSLATE('Username Available') };
     loginUnsucessfulMessage = { type: 'error', message: _TRANSLATE('Login Unsuccesful') };
     couldNotCreateUserMessage = { type: 'error', message: _TRANSLATE('Could Not Create User') };
+    incorrectAdminPassword = { type: 'error', message: _TRANSLATE('Incorrect Admin Password') };
     securityQuestionText: string;
     passwordPolicy: string
     passwordRecipe: string
@@ -82,7 +83,11 @@ export class RegistrationComponent implements OnInit {
                 this.loginUserAfterRegistration(this.userSignup.username, this.userSignup.password);
             } catch (error) {
                 console.log(error);
-                this.statusMessage = this.couldNotCreateUserMessage;
+                if (error.message === 'Malformed UTF-8 data') {
+                  this.statusMessage = this.incorrectAdminPassword;
+                } else {
+                  this.statusMessage = this.couldNotCreateUserMessage;
+                }
                 this.disableSubmit = false
             };
         } else {

--- a/client/src/app/core/auth/registration/registration.component.ts
+++ b/client/src/app/core/auth/registration/registration.component.ts
@@ -26,12 +26,15 @@ export class RegistrationComponent implements OnInit {
     statusMessage: object;
     disableSubmit = false;
     passwordsDoNotMatchMessage = { type: 'error', message: _TRANSLATE('Passwords do not match') };
+    passwordIsNotStrong = { type: 'error', message: _TRANSLATE('Password is not strong enough.') };
     devicePasswordDoesNotMatchMessage = { type: 'error', message: _TRANSLATE('Device password does not match') };
     userNameUnavailableMessage = { type: 'error', message: _TRANSLATE('Username Unavailable') };
     userNameAvailableMessage = { type: 'success', message: _TRANSLATE('Username Available') };
     loginUnsucessfulMessage = { type: 'error', message: _TRANSLATE('Login Unsuccesful') };
     couldNotCreateUserMessage = { type: 'error', message: _TRANSLATE('Could Not Create User') };
     securityQuestionText: string;
+    passwordPolicy: string
+    passwordRecipe: string
     constructor(
         private userService: UserService,
         private route: ActivatedRoute,
@@ -45,6 +48,9 @@ export class RegistrationComponent implements OnInit {
         this.requiresAdminPassword = appConfig.syncProtocol === '2' ? true : false
         const homeUrl = appConfig.homeUrl;
         this.securityQuestionText = appConfig.securityQuestionText;
+        this.passwordPolicy = appConfig.passwordPolicy;
+        this.passwordRecipe = appConfig.passwordRecipe;
+        this.passwordIsNotStrong.message = this.passwordIsNotStrong.message + ' ' + this.passwordRecipe
         this.returnUrl = this.route.snapshot.queryParams['returnUrl'] || homeUrl;
         if (this.userService.isLoggedIn()) {
             this.router.navigate([this.returnUrl]);
@@ -54,14 +60,21 @@ export class RegistrationComponent implements OnInit {
     async register() {
         this.disableSubmit = true
         if (this.requiresAdminPassword && !this.userService.confirmPassword('admin', this.userSignup.adminPassword)) {
-            this.statusMessage = this.devicePasswordDoesNotMatchMessage 
+            this.statusMessage = this.devicePasswordDoesNotMatchMessage
             this.disableSubmit = false
             return
-        } 
+        }
         if (this.userSignup.password!==this.userSignup.confirmPassword) {
             this.statusMessage = this.passwordsDoNotMatchMessage
             this.disableSubmit = false
-            return 
+            return
+        }
+      // const policy = new RegExp('^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})');
+        const policy = new RegExp(this.passwordPolicy)
+        if (!policy.test(this.userSignup.password)) {
+          this.statusMessage = this.passwordIsNotStrong
+          this.disableSubmit = false
+          return
         }
         if (!this.isUsernameTaken) {
             try {

--- a/client/src/app/device/components/device-registration/device-registration.component.ts
+++ b/client/src/app/device/components/device-registration/device-registration.component.ts
@@ -96,12 +96,12 @@ export class DeviceRegistrationComponent implements OnInit {
       if (typeof error !== 'undefined') {
         if ((typeof error.message !== 'undefined') && (error.message.includes('Http failure response'))) {
           const errorMessage = error.message.slice(0, 50) + '...'
-          this.gatherInfo(_TRANSLATE(`Something went wrong; you may not have Internet access. <br/>Error:  ${errorMessage}`))
+          this.gatherInfo(_TRANSLATE('Something went wrong; you may not have Internet access.') + ` <br/>Error:  ${errorMessage}`)
         } else {
-          this.gatherInfo(_TRANSLATE(`Something went wrong, please try again. Error:  ${error.message}`))
+          this.gatherInfo(_TRANSLATE('Something went wrong, please try again.') + ` Error:  ${error.message}`)
         }
       } else {
-        this.gatherInfo(_TRANSLATE(`Something went wrong, please try again.`))
+        this.gatherInfo(_TRANSLATE('Something went wrong, please try again.'))
       }
     }
     this.container.nativeElement.innerHTML = `

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -21,5 +21,7 @@ export class AppConfig {
   groupId:string
   groupName:string
   p2pSync = 'false'
-} 
+  passwordPolicy:string
+  passwordRecipe:string
+}
 

--- a/client/src/app/shared/_services/lock-box.service.ts
+++ b/client/src/app/shared/_services/lock-box.service.ts
@@ -54,9 +54,10 @@ export class LockBoxService {
   async openLockBox(username, password) {
     const lockBoxData = await this.db.get(username)
     const lockBoxContentsDescrypted = CryptoJS.AES.decrypt(lockBoxData.contents, password)
+    const codepage = CryptoJS.enc.Utf8
     const lockBox = <LockBox>{
       ...lockBoxData,
-      contents: JSON.parse(lockBoxContentsDescrypted.toString(CryptoJS.enc.Utf8))
+      contents: JSON.parse(lockBoxContentsDescrypted.toString(codepage))
     }
     const openLockBoxes = this.getOpenLockBoxes()
     openLockBoxes.push(lockBox)

--- a/client/src/app/shared/_services/lock-box.service.ts
+++ b/client/src/app/shared/_services/lock-box.service.ts
@@ -53,9 +53,10 @@ export class LockBoxService {
 
   async openLockBox(username, password) {
     const lockBoxData = await this.db.get(username)
+    const lockBoxContentsDescrypted = CryptoJS.AES.decrypt(lockBoxData.contents, password)
     const lockBox = <LockBox>{
       ...lockBoxData,
-      contents: JSON.parse(CryptoJS.AES.decrypt(lockBoxData.contents, password).toString(CryptoJS.enc.Utf8))
+      contents: JSON.parse(lockBoxContentsDescrypted.toString(CryptoJS.enc.Utf8))
     }
     const openLockBoxes = this.getOpenLockBoxes()
     openLockBoxes.push(lockBox)
@@ -69,5 +70,5 @@ export class LockBoxService {
   setOpenLockBoxes(openLockBoxes) {
     this._openLockBoxes = openLockBoxes
   }
-  
+
 }

--- a/client/src/app/shared/_services/user.service.ts
+++ b/client/src/app/shared/_services/user.service.ts
@@ -191,7 +191,12 @@ export class UserService {
     if (this.config.syncProtocol === '2') {
       // Open the admin's lockBox, copy it, and stash it in the new user's lockBox.
       await this.lockBoxService.openLockBox('admin', userSignup.adminPassword)
-      const adminLockBox = this.lockBoxService.getOpenLockBox('admin')
+      let adminLockBox
+      try {
+        adminLockBox = this.lockBoxService.getOpenLockBox('admin');
+      } catch (e) {
+        throw new Error(e)
+      }
       this.lockBoxService.closeLockBox('admin')
       const userLockBoxContents = <LockBoxContents>{...adminLockBox.contents}
       await this.lockBoxService.fillLockBox(userSignup.username, userSignup.password, userLockBoxContents)


### PR DESCRIPTION
Enforce a strong password policy
Make device error messages translatable again.

## Description

Implements issue described here: https://github.com/Tangerine-Community/Tangerine/issues/1867

![image](https://user-images.githubusercontent.com/861535/75002544-71090e80-542a-11ea-9977-71a708f3ba85.png)

---

- Fixes #1867

## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update - describe password requirements

## Proposed Solution

Enter passwordPolicy and passwordRecipe (message that describes password) in app-config.json. 
The Regexp runs when the form is submitted.

## Limitations and Trade-offs

It would be cool if it validated as you leave the input, but this is sufficient for now.

## Screenshots/Videos

See above

## Tests

---

[How you tested (or have not tested) this PR and what where those steps.]

No tests.

---

[Optional. List out the remaining tasks that would complete this pull request.]

- [Develop more tests for this PR.]
- [Follow up on something else.]
