### PR TITLE
Added PouchReplicationStream plugin to db.factory

### DIFF
--- a/client/src/app/core/sync-records/_services/peers.service.ts
+++ b/client/src/app/core/sync-records/_services/peers.service.ts
@@ -30,16 +30,11 @@ export class PeersService {
   }
 
   async getLocalDatabase() {
-    // get the local db this.getUserService.getUserdatabase - has a .db property - can use the sync method
-    PouchDB.plugin(window['PouchReplicationStream'].plugin);
-    PouchDB.adapter('writableStream', window['PouchReplicationStream'].adapters.writableStream);
-    // const dbName = new PouchDB((await this.userService.getUserDatabase()).db.name);
     const userDatabase = await this.userService.getUserDatabase();
     const userDatabaseName = userDatabase.db.name;
     const username = userDatabaseName.replace('_pouchdb', '');
     console.log('userDatabaseName: ' + userDatabaseName + ' username: ' + username);
-    const db = new PouchDB(username);
-    return db;
+    return userDatabase.db;
   }
 
   sleep(milliseconds) {

--- a/client/src/app/shared/_factories/db.factory.ts
+++ b/client/src/app/shared/_factories/db.factory.ts
@@ -7,6 +7,8 @@ import * as PouchDBUpsert from 'pouchdb-upsert';
 PouchDB.plugin(PouchDBFind);
 PouchDB.plugin(PouchDBUpsert);
 PouchDB.plugin(cordovaSqlitePlugin);
+PouchDB.plugin(window['PouchReplicationStream'].plugin);
+PouchDB.adapter('writableStream', window['PouchReplicationStream'].adapters.writableStream);
 PouchDB.defaults({auto_compaction: true, revs_limit: 1});
 
 export function DB(name, key = ''):PouchDB {


### PR DESCRIPTION
## Description

---

P2p sync broke - not creating db dump. 

- Fixes #279 https://github.com/Tangerine-Community/Tangerine/issues/279

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)


## Proposed Solution

---

Added necessary Pouchdb plugin/adapter to db.factory

## Limitations and Trade-offs

We should refactor the factory to return a class, not the instance of Pouchdb.

