### PR TITLE
Limit messages sent to P2P Sync log; APK release messages more granular

### DIFF
--- a/client/src/app/core/sync-records/peers/peers.component.ts
+++ b/client/src/app/core/sync-records/peers/peers.component.ts
@@ -88,7 +88,7 @@ export class PeersComponent implements OnInit, AfterContentInit {
       }
     );
     startAdvertisingBtnEl.addEventListener('progress', e => {
-        console.log('payload: ' + JSON.stringify(e.detail));
+        // console.log('payload: ' + JSON.stringify(e.detail));
         const message: Message = e.detail;
         if (typeof message.originName !== 'undefined') {
           this.endpoints = this.endpoints.map((endpoint) => {
@@ -103,8 +103,7 @@ export class PeersComponent implements OnInit, AfterContentInit {
           const progressMessage = bytesTransferred + '/' + totalBytes + ' transferred from ' + originName;
           document.querySelector('#progress').innerHTML =  '<p>' + progressMessage + '</p>\n';
         }
-        document.querySelector('#p2p-results').innerHTML += message.message + '<br/>';
-        // document.querySelector('#transferProgress').innerHTML = message.message + '<br/>';
+        // document.querySelector('#p2p-results').innerHTML += message.message + '<br/>';
       }
     );
     startAdvertisingBtnEl.addEventListener('done', e => {

--- a/editor/src/app/groups/download-csv/download-csv.component.ts
+++ b/editor/src/app/groups/download-csv/download-csv.component.ts
@@ -13,9 +13,9 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class DownloadCsvComponent implements OnInit {
 
-  title = _TRANSLATE('Donwload CSV')
+  title = _TRANSLATE('Download CSV')
   breadcrumbs:Array<Breadcrumb> = []
- 
+
   months = [];
   years = [];
   selectedMonth = '*';

--- a/editor/src/app/groups/release-apk/release-apk.component.html
+++ b/editor/src/app/groups/release-apk/release-apk.component.html
@@ -10,6 +10,10 @@
   {{'Could Not Generate APK'|translate}}
 </p>
 
+<p *ngIf="step">
+  {{step}}
+</p>
+
 <p *ngIf="status==code.STATUS_DONE">
   {{'Download your APK'|translate}}
   <a target='_new' href="/releases/{{releaseType}}/apks/{{groupId}}/{{groupId}}.apk">{{'here'|translate}}</a>.

--- a/editor/src/app/groups/release-apk/release-apk.component.ts
+++ b/editor/src/app/groups/release-apk/release-apk.component.ts
@@ -20,13 +20,14 @@ export class ReleaseApkComponent implements OnInit {
 
   groupId = '';
   releaseType = '';
+  step = '';
   code = {
     STATUS_BUILDING: 'STATUS_BUILDING',
     STATUS_ERROR: 'STATUS_ERROR',
     STATUS_DONE: 'STATUS_DONE',
     STATUS_WAIT: 'STATUS_WAIT'
   }
-  status: any 
+  status: any
 
   constructor(
     private groupsService: GroupsService
@@ -41,11 +42,19 @@ export class ReleaseApkComponent implements OnInit {
       const result: any = await this.groupsService.releaseAPK(this.groupId, this.releaseType);
       // Wait 5 seconds so the process can start. This can result in false positives. Would be better to have build IDs returns from the release command.
       await sleep(5000)
-      while (await this.groupsService.apkIsBuilding(this.groupId, this.releaseType)) {
+      let statusMessage = {}
+      let processing = true;
+      while (processing === true) {
+        statusMessage = await this.groupsService.apkIsBuilding(this.groupId, this.releaseType)
+        if (typeof statusMessage !== 'undefined') {
+          processing = statusMessage['processing']
+          this.step = statusMessage['step']
+        }
         this.status = this.code.STATUS_BUILDING
         await sleep(10000)
       }
       this.status = this.code.STATUS_DONE;
+      this.step = null;
     } catch (error) {
       this.status = this.code.STATUS_ERROR;
       console.error(error);

--- a/editor/src/app/groups/services/groups.service.ts
+++ b/editor/src/app/groups/services/groups.service.ts
@@ -143,14 +143,14 @@ export class GroupsService {
   async apkIsBuilding(groupName: string, releaseType: string) {
     try {
       const result: any = await this.httpClient.get(`/releases/${releaseType}/apks/${groupName}.json`).toPromise();
-      return (result.processing === true) ? true : false;
+      // return (result.processing === true) ? true : false;
+      return result;
     } catch (error) {
       if (typeof error.status === 'undefined') {
         this.errorHandler.handleError(_TRANSLATE('Could Not Contact Server.'));
       }
     }
   }
-
 
   async releaseAPK(groupName: string, releaseType: string) {
     try {

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -63,7 +63,7 @@ var proxy = require('express-http-proxy');
 var couchProxy = proxy(process.env.T_COUCHDB_ENDPOINT, {
   proxyReqPathResolver: function (req, res) {
     var path = require('url').parse(req.url).path;
-    clog("path:" + path);
+    // clog("path:" + path);
     return path;
   },
   limit: '1gb'

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -34,7 +34,7 @@ if [ "$2" = "--help" ] || [ "$GROUP" = "" ] || [ "$CONTENT_PATH" = "" ] || [ "$R
 fi
 
 # Mark build status early.
-echo '{"processing":true}' > $STATUS_FILE
+echo '{"processing":true,"step":"Generating APK configuration files"}' > $STATUS_FILE
 
 if [ -d "$RELEASE_DIRECTORY" ]; then
   # Clear out the Cordova project in $RELEASE_DIRECTORY
@@ -64,6 +64,7 @@ sed -i -e "s#URL#"$URL"#g" $RELEASE_DIRECTORY/cordova-hcp.json
 
 # Create the chcp manifest.
 /tangerine/server/node_modules/cordova-hot-code-push-cli/bin/cordova-hcp build
+echo '{"processing":true,"step":"Compiling APK"}' > $STATUS_FILE
 
 echo "RELEASE APK: running Cordova build."
 cordova build --no-telemetry android
@@ -71,6 +72,6 @@ cordova build --no-telemetry android
 # Copy the apk to the $RELEASE_DIRECTORY
 cp $RELEASE_DIRECTORY/platforms/android/app/build/outputs/apk/debug/app-debug.apk $RELEASE_DIRECTORY/$GROUP.apk
 
-echo '{"processing":false}' > $STATUS_FILE
+echo '{"processing":false,"step":"APK ready"}' > $STATUS_FILE
 echo 
 echo "Released apk for $GROUP at $RELEASE_DIRECTORY on $DATE with Build ID of $BUILD_ID and release type of $RELEASE_TYPE"


### PR DESCRIPTION
Added progress messages to release APK code

## Description

Some enhancements to P2P sync and APK release process

## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

Reduces logging in P2P Sync to address potential issue of screen becoming non-responsive when many progress transfer messages are sent to the client.

Also provides code to have more fine-grained progress on APK generation. This is useful when testing/developement, so that you can see when the config files are complete when releasing an APK, you can go ahead and update the APK on a tablet instead of waiting for it to finish the longer compile phase.

