### PR TITLE
WIP: Fix for sync crash; Simplified pouchDbSyncOptions

### DIFF
--- a/client/src/app/device/components/device-sync/device-sync.component.ts
+++ b/client/src/app/device/components/device-sync/device-sync.component.ts
@@ -25,7 +25,7 @@ export class DeviceSyncComponent implements OnInit {
     this.syncInProgress = true
     this.syncService.syncMessage$.subscribe({
       next: (progress) => {
-        this.syncMessage =  progress.docs_written + ' docs saved.'
+        this.syncMessage =  progress.docs_written + ' docs saved; ' + progress.pending + ' pending'
         console.log('Sync Progress: ' + JSON.stringify(progress))
       }
     })

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -23,5 +23,6 @@ export class AppConfig {
   p2pSync = 'false'
   passwordPolicy:string
   passwordRecipe:string
+  couchdbSync4All:boolean
 }
 

--- a/client/src/app/sync/components/sync/sync.component.ts
+++ b/client/src/app/sync/components/sync/sync.component.ts
@@ -29,7 +29,7 @@ export class SyncComponent implements OnInit {
     this.status = STATUS_IN_PROGRESS
     this.syncService.syncMessage$.subscribe({
       next: (progress) => {
-        this.syncMessage =  progress.docs_written + ' docs saved.'
+        this.syncMessage =  progress.docs_written + ' docs saved; ' + progress.pending + ' pending'
         console.log('Sync Progress: ' + JSON.stringify(progress))
       }
     })

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -8,6 +8,7 @@ import { Injectable } from '@angular/core';
 import PouchDB from 'pouchdb'
 import {Subject} from 'rxjs';
 import {VariableService} from '../shared/_services/variable.service';
+import {AppConfigService} from '../shared/_services/app-config.service';
 
 export interface LocationQuery {
   level:string
@@ -33,7 +34,8 @@ export class SyncCouchdbService {
 
   constructor(
     private http: HttpClient,
-    private variableService: VariableService
+    private variableService: VariableService,
+    private appConfigService: AppConfigService
   ) { }
 
   async uploadQueue(userDb:UserDatabase, syncDetails:SyncCouchdbDetails) {
@@ -53,16 +55,25 @@ export class SyncCouchdbService {
   async sync(userDb:UserDatabase, syncDetails:SyncCouchdbDetails): Promise<ReplicationStatus> {
     const syncSessionUrl = await this.http.get(`${syncDetails.serverUrl}sync-session/start/${syncDetails.groupId}/${syncDetails.deviceId}/${syncDetails.deviceToken}`, {responseType:'text'}).toPromise()
     const remoteDb = new PouchDB(syncSessionUrl)
-    let last_seq = await this.variableService.get('sync-checkpoint')
-    if (typeof last_seq === 'undefined') {
-      last_seq = 0;
+    let pull_last_seq = await this.variableService.get('sync-pull-last_seq')
+    let push_last_seq = await this.variableService.get('sync-push-last_seq')
+    if (typeof pull_last_seq === 'undefined') {
+      pull_last_seq = 0;
+    }
+    if (typeof push_last_seq === 'undefined') {
+      push_last_seq = 0;
     }
     const remotePouchOptions = {
-      "since": last_seq
+      "since": pull_last_seq
+    }
+
+    const localPouchOptions = {
+      "since": push_last_seq
     }
 
     if (syncDetails.deviceSyncLocations.length > 0) {
       const locationConfig = syncDetails.deviceSyncLocations[0]
+      // Get last value, that's the focused sync point.
       const location = locationConfig.value.slice(-1).pop()
       const selector = {
           [`location.${location.level}`]: {
@@ -72,18 +83,50 @@ export class SyncCouchdbService {
       remotePouchOptions['selector'] = selector
     }
 
-    const localPouchOptions = {
-      "since": 0
-    }
+    let pouchOptions;
 
-    const pouchOptions = {
-      "push": localPouchOptions,
-      "pull": remotePouchOptions
+    const appConfig = await this.appConfigService.getAppConfig();
+
+    if (appConfig.couchdbSync4All) {
+      // Passing false prevents the changes feed from keeping all the documents in memory
+      pouchOptions = {
+        "return_docs": false,
+        "push": localPouchOptions,
+        "pull": remotePouchOptions
+      }
+    } else {
+      pouchOptions = {
+        selector: {
+          "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
+            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled) {
+              $or = [
+                ...$or,
+                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                    // Get last value, that's the focused sync point.
+                    let location = locationConfig.value.slice(-1).pop()
+                    return {
+                      "form.id": formInfo.id,
+                      [`location.${location.level}`]: location.value
+                    }
+                  })
+                  : [
+                    {
+                      "form.id": formInfo.id
+                    }
+                  ]
+              ]
+            }
+            return $or
+          }, [])
+        }
+      }
     }
 
     const replicationStatus = <ReplicationStatus>await new Promise((resolve, reject) => {
       userDb.sync(remoteDb, pouchOptions).on('complete', async  (info) => {
-        await this.variableService.set('sync-checkpoint', info.pull.last_seq)
+        await this.variableService.set('sync-push-last_seq', info.push.last_seq)
+        await this.variableService.set('sync-pull-last_seq', info.pull.last_seq)
         const conflictsQuery = await userDb.query('sync-conflicts');
         resolve(<ReplicationStatus>{
           pulled: info.pull.docs_written,
@@ -91,12 +134,22 @@ export class SyncCouchdbService {
           conflicts: conflictsQuery.rows.map(row => row.id)
         })
       }).on('change', async (info) => {
-        await this.variableService.set('sync-checkpoint', info.change.last_seq)
+        if (typeof info.direction !== 'undefined') {
+          if (info.direction === 'push') {
+            await this.variableService.set('sync-push-last_seq', info.change.last_seq)
+          } else {
+            await this.variableService.set('sync-pull-last_seq', info.change.last_seq)
+          }
+        }
+        let pending = info.change.pending
+        if (typeof info.change.pending === 'undefined') {
+          pending = 0;
+        }
         const progress = {
           'docs_read': info.change.docs_read,
           'docs_written': info.change.docs_written,
           'doc_write_failures': info.change.doc_write_failures,
-          'pending': info.change.pending
+          'pending': pending
         };
         this.syncMessage$.next(progress)
       }).on('error', function (errorMessage) {

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -60,15 +60,18 @@ export class SyncService {
       deviceSyncLocations: device.syncLocations,
       formInfos
     })
-    // console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
-    // await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
-    //   appConfig: appConfig,
-    //   serverUrl: appConfig.serverUrl,
-    //   groupId: appConfig.groupId,
-    //   deviceId: device._id,
-    //   deviceToken: device.token,
-    //   formInfos
-    // })
+    console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
+
+    if (!appConfig.couchdbSync4All) {
+      await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
+        appConfig: appConfig,
+        serverUrl: appConfig.serverUrl,
+        groupId: appConfig.groupId,
+        deviceId: device._id,
+        deviceToken: device.token,
+        formInfos
+      })
+    }
     await this.deviceService.didSync()
   }
 

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -61,14 +61,14 @@ export class SyncService {
       formInfos
     })
     // console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
-    await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
-      appConfig: appConfig,
-      serverUrl: appConfig.serverUrl,
-      groupId: appConfig.groupId,
-      deviceId: device._id,
-      deviceToken: device.token,
-      formInfos
-    })
+    // await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
+    //   appConfig: appConfig,
+    //   serverUrl: appConfig.serverUrl,
+    //   groupId: appConfig.groupId,
+    //   deviceId: device._id,
+    //   deviceToken: device.token,
+    //   formInfos
+    // })
     await this.deviceService.didSync()
   }
 

--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -94,3 +94,6 @@ T_HIDE_SKIP_IF="true"
 # In CSV output, set cell value to this when something is skipped. Set to "ORIGINAL_VALUE" if you want the actual value stored.
 T_REPORTING_MARK_SKIPPED_WITH="SKIPPED"
 
+# Set to true if you want Tangerine to ignore any settings in Sync Configuration and use Couchdb Sync for replication.
+T_COUCHDB_SYNC_4_ALL="false"
+

--- a/server/src/shared/classes/tangerine-config.ts
+++ b/server/src/shared/classes/tangerine-config.ts
@@ -11,4 +11,5 @@ export interface TangerineConfig {
   uploadToken: string
   reportingDelay: number
   hideSkipIf: boolean
+  couchdbSync4All: boolean
 }

--- a/server/src/shared/services/tangerine-config/tangerine-config.service.ts
+++ b/server/src/shared/services/tangerine-config/tangerine-config.service.ts
@@ -21,7 +21,8 @@ export class TangerineConfigService {
       syncUsername: process.env.T_SYNC_USERNAME,
       syncPassword: process.env.T_SYNC_PASSWORD,
       hideSkipIf: process.env.T_HIDE_SKIP_IF === 'true' ? true : false,
-      reportingDelay: parseInt(process.env.T_REPORTING_DELAY)
+      reportingDelay: parseInt(process.env.T_REPORTING_DELAY),
+      couchdbSync4All: process.env.T_COUCHDB_SYNC_4_ALL === 'true' ? true : false
     }
   }
 }


### PR DESCRIPTION
Added pending to sync progress output

## Description

This is a work-around for memory issues when syncing with the Cordova-Sqlcipher plugin

- Fixes https://github.com/Tangerine-Community/Tangerine/issues/1995

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Proposed Solution

I simplified the code for creating the selector in the mango query. If a site is using 2-way sync, we are recommending syncing all forms; therefore, I removed the code that builds a very long $or statement. 

Before the sync, the code checks for sync-checkpoint, which is populated during the first sync. 

```
 this.variableService.get('sync-checkpoint')
```

## Limitations and Trade-offs

This code ignores any settings in Sync Configuration; instead, it syncs all forms. There is no checking of the couchdbSyncSettings.enabled property in each formInfo.

Also, after this sync process is done, the code progresses to this.syncCustomService.sync and does a push of most of the docs that were just synced (marked as customSyncSettings enabled and push). Note it is not a sync, using the changes feed, but instead a push using the doc _id's. Wouldn't it be better to do a couch sync instead? One thing the customSyncSettings can do is remove a field's value if a field is marked as private. 



