### PR TITLE
WIP: Fix for sync crash; Simplified pouchDbSyncOptions

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -499,8 +499,6 @@ class CaseService {
 
       this.db = await this.userService.getUserDatabase(this.userService.getCurrentUser())
 
-      // Upload the profiles first
-      // now upload the others
       for (let doc of templateDocs) {
         // @ts-ignore
         // sometimes doc is false...

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -459,7 +459,6 @@ class CaseService {
           }
         }],
       }
-      console.log("motherId: " + caseId + " participantId: " + participant_id);
       const doc = Object.assign({}, caseDoc, caseMother);
       caseDoc.items[0].inputs[1].value = participant_id;
       caseDoc.items[0].inputs[2].value = enrollment_date;
@@ -512,6 +511,7 @@ class CaseService {
         }
       }
       numberOfCasesCompleted++
+      console.log("motherId: " + caseId + " participantId: " + participant_id + " Completed " + numberOfCasesCompleted + " of " + numberOfCases);
     }
   }
 

--- a/client/src/app/device/components/device-sync/device-sync.component.ts
+++ b/client/src/app/device/components/device-sync/device-sync.component.ts
@@ -25,7 +25,7 @@ export class DeviceSyncComponent implements OnInit {
     this.syncInProgress = true
     this.syncService.syncMessage$.subscribe({
       next: (progress) => {
-        this.syncMessage =  progress.docs_written + ' docs saved.'
+        this.syncMessage =  progress.docs_written + ' docs saved; ' + progress.pending + ' pending'
         console.log('Sync Progress: ' + JSON.stringify(progress))
       }
     })

--- a/client/src/app/device/services/device.service.ts
+++ b/client/src/app/device/services/device.service.ts
@@ -5,6 +5,7 @@ import { Device } from './../classes/device.class';
 import { AppConfigService } from './../../shared/_services/app-config.service';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import {AppConfig} from '../../shared/_classes/app-config.class';
 const bcrypt = window['dcodeIO'].bcrypt
 
 export interface AppInfo {
@@ -23,6 +24,8 @@ export class DeviceService {
 
   username:string
   password:string
+  rawBuildChannel:string
+  buildId:string
 
   constructor(
     private httpClient:HttpClient,
@@ -122,7 +125,8 @@ export class DeviceService {
 
   async getBuildId() {
     try {
-      return await this.httpClient.get('./assets/tangerine-build-id', {responseType: 'text'}).toPromise()
+      this.buildId = this.buildId ? this.buildId : await this.httpClient.get('./assets/tangerine-build-id', {responseType: 'text'}).toPromise();
+      return this.buildId
     } catch (e) {
       return 'N/A'
     }
@@ -130,10 +134,10 @@ export class DeviceService {
 
   async getBuildChannel() {
     try {
-      const raw = await this.httpClient.get('./assets/tangerine-build-channel', {responseType: 'text'}).toPromise()
-      return raw.includes('prod')
+      this.rawBuildChannel = this.rawBuildChannel ? this.rawBuildChannel : await this.httpClient.get('./assets/tangerine-build-channel', {responseType: 'text'}).toPromise()
+      return this.rawBuildChannel.includes('prod')
         ? 'live'
-        : raw.includes('qa')
+        : this.rawBuildChannel.includes('qa')
           ? 'test'
           : 'unknown'
     } catch (e) {

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -23,5 +23,6 @@ export class AppConfig {
   p2pSync = 'false'
   passwordPolicy:string
   passwordRecipe:string
+  couchdbSync4All:boolean
 }
 

--- a/client/src/app/sync/components/sync/sync.component.ts
+++ b/client/src/app/sync/components/sync/sync.component.ts
@@ -29,9 +29,13 @@ export class SyncComponent implements OnInit {
     this.status = STATUS_IN_PROGRESS
     this.syncService.syncMessage$.subscribe({
       next: (progress) => {
-        this.syncMessage =  progress.docs_written + ' docs saved; ' + progress.pending + ' pending;'
+        let pendingMessage = ''
+        if (progress.pending) {
+          pendingMessage = progress.pending + ' pending;'
+        }
+        this.syncMessage =  progress.docs_written + ' docs saved; ' + pendingMessage
         if (progress.direction !== '') {
-          this.syncMessage = this.syncMessage + '; Direction: ' + progress.direction
+          this.syncMessage = this.syncMessage + ' Direction: ' + progress.direction
         }
         console.log('Sync Progress: ' + JSON.stringify(progress))
       }

--- a/client/src/app/sync/components/sync/sync.component.ts
+++ b/client/src/app/sync/components/sync/sync.component.ts
@@ -29,7 +29,7 @@ export class SyncComponent implements OnInit {
     this.status = STATUS_IN_PROGRESS
     this.syncService.syncMessage$.subscribe({
       next: (progress) => {
-        this.syncMessage =  progress.docs_written + ' docs saved.'
+        this.syncMessage =  progress.docs_written + ' docs saved; ' + progress.pending + ' pending'
         console.log('Sync Progress: ' + JSON.stringify(progress))
       }
     })

--- a/client/src/app/sync/components/sync/sync.component.ts
+++ b/client/src/app/sync/components/sync/sync.component.ts
@@ -29,7 +29,10 @@ export class SyncComponent implements OnInit {
     this.status = STATUS_IN_PROGRESS
     this.syncService.syncMessage$.subscribe({
       next: (progress) => {
-        this.syncMessage =  progress.docs_written + ' docs saved; ' + progress.pending + ' pending'
+        this.syncMessage =  progress.docs_written + ' docs saved; ' + progress.pending + ' pending;'
+        if (progress.direction !== '') {
+          this.syncMessage = this.syncMessage + '; Direction: ' + progress.direction
+        }
         console.log('Sync Progress: ' + JSON.stringify(progress))
       }
     })

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -67,6 +67,8 @@ export class SyncCouchdbService {
     const pouchOptions = {
       "push": {
         "since": push_last_seq,
+        "batch_size": 50,
+        "batches_limit": 5,
         ...(await this.appConfigService.getAppConfig()).couchdbSync4All ? {} : { "selector": {
             "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
               if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.push) {
@@ -95,6 +97,8 @@ export class SyncCouchdbService {
       },
       "pull": {
         "since": pull_last_seq,
+        "batch_size": 50,
+        "batches_limit": 5,
         "selector": {
           "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
             if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -51,7 +51,7 @@ export class SyncCouchdbService {
       .map(row => row.id)
   }
 
-  // Note that this ignores the sync config settings.
+  // Note that if you run this with no forms configured to CouchDB sync, that will result in no filter query and everything will be synced. Use carefully.
   async sync(userDb:UserDatabase, syncDetails:SyncCouchdbDetails): Promise<ReplicationStatus> {
     const syncSessionUrl = await this.http.get(`${syncDetails.serverUrl}sync-session/start/${syncDetails.groupId}/${syncDetails.deviceId}/${syncDetails.deviceToken}`, {responseType:'text'}).toPromise()
     const remoteDb = new PouchDB(syncSessionUrl)
@@ -81,19 +81,8 @@ export class SyncCouchdbService {
 
     let pouchOptions;
     const appConfig = await this.appConfigService.getAppConfig();
-    // TODO: replace with test for sync-protocol-2 instead ?
-    // actually, don't even need it - we are already sp2!
     if (appConfig.couchdbSync4All) {
-      // Passing false prevents the changes feed from keeping all the documents in memory
-      // pouchOptions = {
-      //   "return_docs": false,
-      //   "push": {
-      //     "since": push_last_seq
-      //   },
-      //   "pull": remotePouchOptions
-      // }
       pouchOptions = {
-
         "push": {
           "return_docs": false,
           "since": push_last_seq

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -81,6 +81,8 @@ export class SyncCouchdbService {
 
     let pouchOptions;
     const appConfig = await this.appConfigService.getAppConfig();
+    // couchdbSync4All = true:  creates separate push and pull options for sync.
+    // couchdbSync4All = false: it uses only the pull settings, and does custom sync for push.
     if (appConfig.couchdbSync4All) {
       pouchOptions = {
         "push": {

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -8,6 +8,7 @@ import { Injectable } from '@angular/core';
 import PouchDB from 'pouchdb'
 import {Subject} from 'rxjs';
 import {VariableService} from '../shared/_services/variable.service';
+import {AppConfigService} from '../shared/_services/app-config.service';
 
 export interface LocationQuery {
   level:string
@@ -33,7 +34,8 @@ export class SyncCouchdbService {
 
   constructor(
     private http: HttpClient,
-    private variableService: VariableService
+    private variableService: VariableService,
+    private appConfigService: AppConfigService
   ) { }
 
   async uploadQueue(userDb:UserDatabase, syncDetails:SyncCouchdbDetails) {
@@ -53,16 +55,25 @@ export class SyncCouchdbService {
   async sync(userDb:UserDatabase, syncDetails:SyncCouchdbDetails): Promise<ReplicationStatus> {
     const syncSessionUrl = await this.http.get(`${syncDetails.serverUrl}sync-session/start/${syncDetails.groupId}/${syncDetails.deviceId}/${syncDetails.deviceToken}`, {responseType:'text'}).toPromise()
     const remoteDb = new PouchDB(syncSessionUrl)
-    let last_seq = await this.variableService.get('sync-checkpoint')
-    if (typeof last_seq === 'undefined') {
-      last_seq = 0;
+    let pull_last_seq = await this.variableService.get('sync-pull-last_seq')
+    let push_last_seq = await this.variableService.get('sync-push-last_seq')
+    if (typeof pull_last_seq === 'undefined') {
+      pull_last_seq = 0;
+    }
+    if (typeof push_last_seq === 'undefined') {
+      push_last_seq = 0;
     }
     const remotePouchOptions = {
-      "since": last_seq
+      "since": pull_last_seq
+    }
+
+    const localPouchOptions = {
+      "since": push_last_seq
     }
 
     if (syncDetails.deviceSyncLocations.length > 0) {
       const locationConfig = syncDetails.deviceSyncLocations[0]
+      // Get last value, that's the focused sync point.
       const location = locationConfig.value.slice(-1).pop()
       const selector = {
           [`location.${location.level}`]: {
@@ -72,18 +83,50 @@ export class SyncCouchdbService {
       remotePouchOptions['selector'] = selector
     }
 
-    const localPouchOptions = {
-      "since": 0
-    }
+    let pouchOptions;
 
-    const pouchOptions = {
-      "push": localPouchOptions,
-      "pull": remotePouchOptions
+    const appConfig = await this.appConfigService.getAppConfig();
+
+    if (appConfig.couchdbSync4All) {
+      // Passing false prevents the changes feed from keeping all the documents in memory
+      pouchOptions = {
+        "return_docs": false,
+        "push": localPouchOptions,
+        "pull": remotePouchOptions
+      }
+    } else {
+      pouchOptions = {
+        selector: {
+          "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
+            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled) {
+              $or = [
+                ...$or,
+                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                    // Get last value, that's the focused sync point.
+                    let location = locationConfig.value.slice(-1).pop()
+                    return {
+                      "form.id": formInfo.id,
+                      [`location.${location.level}`]: location.value
+                    }
+                  })
+                  : [
+                    {
+                      "form.id": formInfo.id
+                    }
+                  ]
+              ]
+            }
+            return $or
+          }, [])
+        }
+      }
     }
 
     const replicationStatus = <ReplicationStatus>await new Promise((resolve, reject) => {
       userDb.sync(remoteDb, pouchOptions).on('complete', async  (info) => {
-        await this.variableService.set('sync-checkpoint', info.pull.last_seq)
+        await this.variableService.set('sync-push-last_seq', info.push.last_seq)
+        await this.variableService.set('sync-pull-last_seq', info.pull.last_seq)
         const conflictsQuery = await userDb.query('sync-conflicts');
         resolve(<ReplicationStatus>{
           pulled: info.pull.docs_written,
@@ -91,12 +134,22 @@ export class SyncCouchdbService {
           conflicts: conflictsQuery.rows.map(row => row.id)
         })
       }).on('change', async (info) => {
-        await this.variableService.set('sync-checkpoint', info.change.last_seq)
+        if (typeof info.direction !== 'undefined') {
+          if (info.direction === 'push') {
+            await this.variableService.set('sync-push-last_seq', info.change.last_seq)
+          } else {
+            await this.variableService.set('sync-pull-last_seq', info.change.last_seq)
+          }
+        }
+        let pending = info.change.pending
+        if (typeof info.change.pending === 'undefined') {
+          pending = 0;
+        }
         const progress = {
           'docs_read': info.change.docs_read,
           'docs_written': info.change.docs_written,
           'doc_write_failures': info.change.doc_write_failures,
-          'pending': info.change.pending
+          'pending': pending
         };
         this.syncMessage$.next(progress)
       }).on('error', function (errorMessage) {

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -67,33 +67,35 @@ export class SyncCouchdbService {
     let pouchOptions = {
       "push": {
         "since": push_last_seq,
-        selector: {
-          "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
-            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.push) {
-              $or = [
-                ...$or,
-                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
-                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
-                    // Get last value, that's the focused sync point.
-                    let location = locationConfig.value.slice(-1).pop()
-                    return {
-                      "form.id": formInfo.id,
-                      [`location.${location.level}`]: location.value
-                    }
-                  })
-                  : [
-                    {
-                      "form.id": formInfo.id
-                    }
-                  ]
-              ]
-            }
-            return $or
-          }, [])
-        }
+        "return_docs": false
+        // selector: {
+        //   "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
+        //     if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.push) {
+        //       $or = [
+        //         ...$or,
+        //         ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+        //           ? syncDetails.deviceSyncLocations.map(locationConfig => {
+        //             // Get last value, that's the focused sync point.
+        //             let location = locationConfig.value.slice(-1).pop()
+        //             return {
+        //               "form.id": formInfo.id,
+        //               [`location.${location.level}`]: location.value
+        //             }
+        //           })
+        //           : [
+        //             {
+        //               "form.id": formInfo.id
+        //             }
+        //           ]
+        //       ]
+        //     }
+        //     return $or
+        //   }, [])
+        // }
       },
       "pull": {
         "since": pull_last_seq,
+        "return_docs": false,
         selector: {
           "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
             if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -63,25 +63,9 @@ export class SyncCouchdbService {
     if (typeof push_last_seq === 'undefined') {
       push_last_seq = 0;
     }
-    const remotePouchOptions = {
-      "since": pull_last_seq
-    }
-
-    if (syncDetails.deviceSyncLocations.length > 0) {
-      const locationConfig = syncDetails.deviceSyncLocations[0]
-      // Get last value, that's the focused sync point.
-      const location = locationConfig.value.slice(-1).pop()
-      const selector = {
-          [`location.${location.level}`]: {
-            '$eq' : location.value
-          }
-        }
-      remotePouchOptions['selector'] = selector
-    }
 
     let pouchOptions = {
       "push": {
-        "return_docs": false,
         "since": push_last_seq,
         selector: {
           "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
@@ -109,7 +93,6 @@ export class SyncCouchdbService {
         }
       },
       "pull": {
-        "return_docs": false,
         "since": pull_last_seq,
         selector: {
           "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
@@ -158,9 +141,6 @@ export class SyncCouchdbService {
         }
         let pending = info.change.pending
         let direction = info.direction
-        if (typeof info.change.pending === 'undefined') {
-          pending = 0;
-        }
         if (typeof info.direction === 'undefined') {
           direction = ''
         }
@@ -168,7 +148,7 @@ export class SyncCouchdbService {
           'docs_read': info.change.docs_read,
           'docs_written': info.change.docs_written,
           'doc_write_failures': info.change.doc_write_failures,
-          'pending': pending,
+          'pending': info.change.pending,
           'direction': direction
         };
         this.syncMessage$.next(progress)

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -64,61 +64,36 @@ export class SyncCouchdbService {
       push_last_seq = 0;
     }
 
-    let pouchOptions = {
+    const pouchOptions = {
       "push": {
-        "since": push_last_seq,
-        "return_docs": false
-        // selector: {
-        //   "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
-        //     if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.push) {
-        //       $or = [
-        //         ...$or,
-        //         ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
-        //           ? syncDetails.deviceSyncLocations.map(locationConfig => {
-        //             // Get last value, that's the focused sync point.
-        //             let location = locationConfig.value.slice(-1).pop()
-        //             return {
-        //               "form.id": formInfo.id,
-        //               [`location.${location.level}`]: location.value
-        //             }
-        //           })
-        //           : [
-        //             {
-        //               "form.id": formInfo.id
-        //             }
-        //           ]
-        //       ]
-        //     }
-        //     return $or
-        //   }, [])
-        // }
+        "since": push_last_seq
       },
       "pull": {
         "since": pull_last_seq,
-        "return_docs": false,
-        selector: {
-          "$or": syncDetails.formInfos.reduce(($or, formInfo) => {
-            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
-              $or = [
-                ...$or,
-                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
-                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
-                    // Get last value, that's the focused sync point.
-                    let location = locationConfig.value.slice(-1).pop()
-                    return {
-                      "form.id": formInfo.id,
-                      [`location.${location.level}`]: location.value
-                    }
-                  })
-                  : [
-                    {
-                      "form.id": formInfo.id
-                    }
-                  ]
-              ]
-            }
-            return $or
-          }, [])
+        ...(await this.appConfigService.getAppConfig()).couchdbSync4All ? {} : { "selector": {
+            "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
+              if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
+                $or = [
+                  ...$or,
+                  ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+                    ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                      // Get last value, that's the focused sync point.
+                      let location = locationConfig.value.slice(-1).pop()
+                      return {
+                        "form.id": formInfo.id,
+                        [`location.${location.level}`]: location.value
+                      }
+                    })
+                    : [
+                      {
+                        "form.id": formInfo.id
+                      }
+                    ]
+                ]
+              }
+              return $or
+            }, [])
+          }
         }
       }
     }

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -66,13 +66,10 @@ export class SyncCouchdbService {
 
     const pouchOptions = {
       "push": {
-        "since": push_last_seq
-      },
-      "pull": {
-        "since": pull_last_seq,
+        "since": push_last_seq,
         ...(await this.appConfigService.getAppConfig()).couchdbSync4All ? {} : { "selector": {
             "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
-              if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
+              if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.push) {
                 $or = [
                   ...$or,
                   ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
@@ -94,6 +91,33 @@ export class SyncCouchdbService {
               return $or
             }, [])
           }
+        }
+      },
+      "pull": {
+        "since": pull_last_seq,
+        "selector": {
+          "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
+            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
+              $or = [
+                ...$or,
+                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                    // Get last value, that's the focused sync point.
+                    let location = locationConfig.value.slice(-1).pop()
+                    return {
+                      "form.id": formInfo.id,
+                      [`location.${location.level}`]: location.value
+                    }
+                  })
+                  : [
+                    {
+                      "form.id": formInfo.id
+                    }
+                  ]
+              ]
+            }
+            return $or
+          }, [])
         }
       }
     }

--- a/client/src/app/sync/sync-custom.service.ts
+++ b/client/src/app/sync/sync-custom.service.ts
@@ -28,7 +28,9 @@ export class SyncCustomService {
 
   async sync(userDb:UserDatabase, syncDetails:SyncCustomDetails) {
     const uploadQueue = await this.uploadQueue(userDb, syncDetails.formInfos)
-    await this.push(userDb, syncDetails, uploadQueue)
+    if (uploadQueue.length > 0) {
+      await this.push(userDb, syncDetails, uploadQueue)
+    }
     // @TODO pull
   }
 
@@ -74,7 +76,7 @@ export class SyncCustomService {
         }
       }
       return queryKeys
-    }, []) 
+    }, [])
     const response = await userDb.query('sync-queue', { keys: queryKeys })
     return response
       .rows

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -62,7 +62,6 @@ export class SyncService {
     })
     console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
 
-    if (!appConfig.couchdbSync4All) {
       await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
         appConfig: appConfig,
         serverUrl: appConfig.serverUrl,
@@ -71,7 +70,6 @@ export class SyncService {
         deviceToken: device.token,
         formInfos
       })
-    }
     await this.deviceService.didSync()
   }
 

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -60,15 +60,18 @@ export class SyncService {
       deviceSyncLocations: device.syncLocations,
       formInfos
     })
-    // console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
-    // await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
-    //   appConfig: appConfig,
-    //   serverUrl: appConfig.serverUrl,
-    //   groupId: appConfig.groupId,
-    //   deviceId: device._id,
-    //   deviceToken: device.token,
-    //   formInfos
-    // })
+    console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
+
+    if (!appConfig.couchdbSync4All) {
+      await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
+        appConfig: appConfig,
+        serverUrl: appConfig.serverUrl,
+        groupId: appConfig.groupId,
+        deviceId: device._id,
+        deviceToken: device.token,
+        formInfos
+      })
+    }
     await this.deviceService.didSync()
   }
 

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -62,14 +62,14 @@ export class SyncService {
     })
     console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
 
-      await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
-        appConfig: appConfig,
-        serverUrl: appConfig.serverUrl,
-        groupId: appConfig.groupId,
-        deviceId: device._id,
-        deviceToken: device.token,
-        formInfos
-      })
+    await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
+      appConfig: appConfig,
+      serverUrl: appConfig.serverUrl,
+      groupId: appConfig.groupId,
+      deviceId: device._id,
+      deviceToken: device.token,
+      formInfos
+    })
     await this.deviceService.didSync()
   }
 

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -61,14 +61,14 @@ export class SyncService {
       formInfos
     })
     // console.log('this.syncMessage: ' + JSON.stringify(this.syncMessage))
-    await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
-      appConfig: appConfig,
-      serverUrl: appConfig.serverUrl,
-      groupId: appConfig.groupId,
-      deviceId: device._id,
-      deviceToken: device.token,
-      formInfos
-    })
+    // await this.syncCustomService.sync(userDb, <SyncCustomDetails>{
+    //   appConfig: appConfig,
+    //   serverUrl: appConfig.serverUrl,
+    //   groupId: appConfig.groupId,
+    //   deviceId: device._id,
+    //   deviceToken: device.token,
+    //   formInfos
+    // })
     await this.deviceService.didSync()
   }
 

--- a/client/src/app/tangy-forms/classes/form-info.class.ts
+++ b/client/src/app/tangy-forms/classes/form-info.class.ts
@@ -26,6 +26,7 @@ export class FormInfo {
 
 export interface CouchdbSyncSettings {
   enabled: boolean
+  push: boolean
   pull: boolean
   filterByLocation:boolean
 }

--- a/client/src/app/tangy-forms/classes/form-info.class.ts
+++ b/client/src/app/tangy-forms/classes/form-info.class.ts
@@ -26,6 +26,7 @@ export class FormInfo {
 
 export interface CouchdbSyncSettings {
   enabled: boolean
+  pull: boolean
   filterByLocation:boolean
 }
 

--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -94,3 +94,6 @@ T_HIDE_SKIP_IF="true"
 # In CSV output, set cell value to this when something is skipped. Set to "ORIGINAL_VALUE" if you want the actual value stored.
 T_REPORTING_MARK_SKIPPED_WITH="SKIPPED"
 
+# Set to true if you want Tangerine to ignore any settings in Sync Configuration and use Couchdb Sync for replication.
+T_COUCHDB_SYNC_4_ALL="false"
+

--- a/server/src/shared/classes/tangerine-config.ts
+++ b/server/src/shared/classes/tangerine-config.ts
@@ -11,4 +11,5 @@ export interface TangerineConfig {
   uploadToken: string
   reportingDelay: number
   hideSkipIf: boolean
+  couchdbSync4All: boolean
 }

--- a/server/src/shared/services/tangerine-config/tangerine-config.service.ts
+++ b/server/src/shared/services/tangerine-config/tangerine-config.service.ts
@@ -21,7 +21,8 @@ export class TangerineConfigService {
       syncUsername: process.env.T_SYNC_USERNAME,
       syncPassword: process.env.T_SYNC_PASSWORD,
       hideSkipIf: process.env.T_HIDE_SKIP_IF === 'true' ? true : false,
-      reportingDelay: parseInt(process.env.T_REPORTING_DELAY)
+      reportingDelay: parseInt(process.env.T_REPORTING_DELAY),
+      couchdbSync4All: process.env.T_COUCHDB_SYNC_4_ALL === 'true' ? true : false
     }
   }
 }


### PR DESCRIPTION
Added pending to sync progress output

## Description

This is a work-around for memory issues when syncing with the Cordova-Sqlcipher plugin

- Fixes https://github.com/Tangerine-Community/Tangerine/issues/1995

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Proposed Solution

I simplified the code for creating the selector in the mango query. If a site is using 2-way sync, we are recommending syncing all forms; therefore, I removed the code that builds a very long $or statement. 

Before the sync, the code checks for sync-checkpoint, which is populated during the first sync. 

```
 this.variableService.get('sync-checkpoint')
```

## Limitations and Trade-offs

This code ignores any settings in Sync Configuration; instead, it syncs all forms. There is no checking of the couchdbSyncSettings.enabled property in each formInfo.

Also, after this sync process is done, the code progresses to this.syncCustomService.sync and does a push of most of the docs that were just synced (marked as customSyncSettings enabled and push). Note it is not a sync, using the changes feed, but instead a push using the doc _id's. Wouldn't it be better to do a couch sync instead? One thing the customSyncSettings can do is remove a field's value if a field is marked as private. 
