### PR TITLE
Refactor couchdb sync to use doc ids not selector

### DIFF
--- a/client/default-assets/app-config.json
+++ b/client/default-assets/app-config.json
@@ -12,5 +12,7 @@
   "homeUrl": "case-management",
   "centrallyManagedUserProfile": false,
   "languageDirection": "ltr",
-  "languageCode": "en"
+  "languageCode": "en",
+  "couchdbPush4All": true,
+  "couchdbPullUsingDocIds": false
 }

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -23,6 +23,7 @@ export class AppConfig {
   p2pSync = 'false'
   passwordPolicy:string
   passwordRecipe:string
-  couchdbSync4All:boolean
+  couchdbPush4All:boolean
+  couchdbPullUsingDocIds:boolean
 }
 

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -55,6 +55,33 @@ export class SyncCouchdbService {
   async sync(userDb:UserDatabase, syncDetails:SyncCouchdbDetails): Promise<ReplicationStatus> {
     const syncSessionUrl = await this.http.get(`${syncDetails.serverUrl}sync-session/start/${syncDetails.groupId}/${syncDetails.deviceId}/${syncDetails.deviceToken}`, {responseType:'text'}).toPromise()
     const remoteDb = new PouchDB(syncSessionUrl)
+    const remoteDocs = await remoteDb.find({
+        "selector": {
+          "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
+            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
+              $or = [
+                ...$or,
+                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                    // Get last value, that's the focused sync point.
+                    let location = locationConfig.value.slice(-1).pop()
+                    return {
+                      "form.id": formInfo.id,
+                      [`location.${location.level}`]: location.value
+                    }
+                  })
+                  : [
+                    {
+                      "form.id": formInfo.id
+                    }
+                  ]
+              ]
+            }
+            return $or
+          }, [])
+        }
+      })
+
     let pull_last_seq = await this.variableService.get('sync-pull-last_seq')
     let push_last_seq = await this.variableService.get('sync-push-last_seq')
     if (typeof pull_last_seq === 'undefined') {
@@ -99,30 +126,7 @@ export class SyncCouchdbService {
         "since": pull_last_seq,
         "batch_size": 50,
         "batches_limit": 5,
-        "selector": {
-          "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
-            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
-              $or = [
-                ...$or,
-                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
-                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
-                    // Get last value, that's the focused sync point.
-                    let location = locationConfig.value.slice(-1).pop()
-                    return {
-                      "form.id": formInfo.id,
-                      [`location.${location.level}`]: location.value
-                    }
-                  })
-                  : [
-                    {
-                      "form.id": formInfo.id
-                    }
-                  ]
-              ]
-            }
-            return $or
-          }, [])
-        }
+        "doc_ids": remoteDocs.docs.map(doc => doc._id)
       }
     }
 

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -53,35 +53,59 @@ export class SyncCouchdbService {
 
   // Note that if you run this with no forms configured to CouchDB sync, that will result in no filter query and everything will be synced. Use carefully.
   async sync(userDb:UserDatabase, syncDetails:SyncCouchdbDetails): Promise<ReplicationStatus> {
+    const appConfig = await this.appConfigService.getAppConfig()
     const syncSessionUrl = await this.http.get(`${syncDetails.serverUrl}sync-session/start/${syncDetails.groupId}/${syncDetails.deviceId}/${syncDetails.deviceToken}`, {responseType:'text'}).toPromise()
     const remoteDb = new PouchDB(syncSessionUrl)
-    const remoteDocs = await remoteDb.find({
-        "selector": {
-          "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
-            if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
-              $or = [
-                ...$or,
-                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
-                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
-                    // Get last value, that's the focused sync point.
-                    let location = locationConfig.value.slice(-1).pop()
-                    return {
-                      "form.id": formInfo.id,
-                      [`location.${location.level}`]: location.value
-                    }
-                  })
-                  : [
-                    {
-                      "form.id": formInfo.id
-                    }
-                  ]
+    // From Form Info, generate the pull and push selectors.
+    const pullSelector = {
+      "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
+        if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
+          $or = [
+            ...$or,
+            ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+              ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                // Get last value, that's the focused sync point.
+                let location = locationConfig.value.slice(-1).pop()
+                return {
+                  "form.id": formInfo.id,
+                  [`location.${location.level}`]: location.value
+                }
+              })
+              : [
+                {
+                  "form.id": formInfo.id
+                }
               ]
-            }
-            return $or
-          }, [])
+          ]
         }
-      })
-
+        return $or
+      }, [])
+    }
+    const pushSelector = {
+        "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
+          if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.push) {
+            $or = [
+              ...$or,
+              ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+                ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                  // Get last value, that's the focused sync point.
+                  let location = locationConfig.value.slice(-1).pop()
+                  return {
+                    "form.id": formInfo.id,
+                    [`location.${location.level}`]: location.value
+                  }
+                })
+                : [
+                  {
+                    "form.id": formInfo.id
+                  }
+                ]
+            ]
+          }
+          return $or
+        }, [])
+    }
+    // Get the sequences we'll be starting with.
     let pull_last_seq = await this.variableService.get('sync-pull-last_seq')
     let push_last_seq = await this.variableService.get('sync-push-last_seq')
     if (typeof pull_last_seq === 'undefined') {
@@ -90,48 +114,34 @@ export class SyncCouchdbService {
     if (typeof push_last_seq === 'undefined') {
       push_last_seq = 0;
     }
-
-    const pouchOptions = {
+    // Build the PouchSyncOptions.
+    const pouchSyncOptions = {
       "push": {
         "since": push_last_seq,
         "batch_size": 50,
         "batches_limit": 5,
-        ...(await this.appConfigService.getAppConfig()).couchdbSync4All ? {} : { "selector": {
-            "$or" : syncDetails.formInfos.reduce(($or, formInfo) => {
-              if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.push) {
-                $or = [
-                  ...$or,
-                  ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
-                    ? syncDetails.deviceSyncLocations.map(locationConfig => {
-                      // Get last value, that's the focused sync point.
-                      let location = locationConfig.value.slice(-1).pop()
-                      return {
-                        "form.id": formInfo.id,
-                        [`location.${location.level}`]: location.value
-                      }
-                    })
-                    : [
-                      {
-                        "form.id": formInfo.id
-                      }
-                    ]
-                ]
-              }
-              return $or
-            }, [])
-          }
-        }
+        ...appConfig.couchdbPush4All ? { } : { "selector": pushSelector }
       },
       "pull": {
         "since": pull_last_seq,
         "batch_size": 50,
         "batches_limit": 5,
-        "doc_ids": remoteDocs.docs.map(doc => doc._id)
+        ...appConfig.couchdbPullUsingDocIds
+          ? {
+            "doc_ids": (await remoteDb.find({ 
+              "limit": 987654321, 
+              "fields": ["_id"], 
+              "selector":  pullSelector 
+            })).docs.map(doc => doc._id)
+          }
+          : {
+            "selector": pullSelector
+          }
       }
     }
 
     const replicationStatus = <ReplicationStatus>await new Promise((resolve, reject) => {
-      userDb.sync(remoteDb, pouchOptions).on('complete', async  (info) => {
+      userDb.sync(remoteDb, pouchSyncOptions).on('complete', async  (info) => {
         await this.variableService.set('sync-push-last_seq', info.push.last_seq)
         await this.variableService.set('sync-pull-last_seq', info.pull.last_seq)
         const conflictsQuery = await userDb.query('sync-conflicts');

--- a/editor/src/app/groups/group-forms-sync/group-forms-sync.component.ts
+++ b/editor/src/app/groups/group-forms-sync/group-forms-sync.component.ts
@@ -94,7 +94,7 @@ export class GroupFormsSyncComponent implements OnInit, AfterViewInit {
             ...form,
             couchdbSyncSettings: {
               enabled: true,
-              filterByLocation: false,
+              filterByLocation: true,
               push: true,
               pull: form.couchdbSyncSettings.pull ? false : true
             }

--- a/editor/src/app/groups/manage-location-list-levels/manage-location-list-levels.component.ts
+++ b/editor/src/app/groups/manage-location-list-levels/manage-location-list-levels.component.ts
@@ -51,6 +51,7 @@ export class ManageLocationListLevelsComponent implements OnInit {
           index: {
             fields: [
               'type',
+              'form.id',
               `location.${this.locationLabel.trim()}`
             ]
           }

--- a/server/src/scripts/generate-location-level-indexes/bin.js
+++ b/server/src/scripts/generate-location-level-indexes/bin.js
@@ -22,7 +22,8 @@ async function go() {
       index: {
         fields: [
           'type',
-          `location.${level}`
+          `location.${level}`,
+          'form.id'
         ]
       }
     })
@@ -32,7 +33,8 @@ async function go() {
       await db.find({
         selector: {
           type: '',
-          [`location.${level}`]: ''
+          [`location.${level}`]: '',
+          'form.id': ''
         },
         limit: 1
       })


### PR DESCRIPTION
Related to https://github.com/Tangerine-Community/Tangerine/issues/2040

This PR adds a new configurable boolean to app-config.json of "couchdbPullUsingDocsIds", default is false. This PR also refactors `couchdbSync4All` to be called `couchdbPush4All`, default is true. 