### PR TITLE
Fixed bug where when you have an autogenerated id, the import fails

### DIFF
--- a/editor/src/app/groups/import-location-list/import-location-list.component.ts
+++ b/editor/src/app/groups/import-location-list/import-location-list.component.ts
@@ -200,8 +200,8 @@ export class ImportLocationListComponent implements OnInit {
     const levels = [...this.locationList.locationsLevels].reverse();
     levels.map((level, index) => {
       this.parsedCSVData.map(item => {
-        const id = String(item[this.mappings[`${level}_id`]]);
-        const parentId = String(item[this.mappings[`${levels[index + 1]}_id`]]);
+        const id = String(item[`${level}_id`]);
+        const parentId = String(item[`${levels[index + 1]}_id`]);
         const parent = index + 1 === levels.length ? 'root' : parentId;
         let value = {
           parent,


### PR DESCRIPTION
## Description

---

When a `location-list` is imported, and any of the `IDs` is set to `autogenerate`, it breaks.

- Fixes #2062 

## Type of Change


- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

Ensure the map query factors in `undefined` and handles it accordingly.

## TODOS/enhancements

---
* Refresh the components without reload when adding location levels and when a location list is imported.
