### PR TITLE
Rbac sitewide updates 

### DIFF
--- a/editor/src/app/core/auth/_components/manage-sitewide-permissions/manage-sitewide-permissions.component.ts
+++ b/editor/src/app/core/auth/_components/manage-sitewide-permissions/manage-sitewide-permissions.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { AuthenticationService } from '../../_services/authentication.service';
 import { NgxPermissionsService } from 'ngx-permissions';
+import { _TRANSLATE } from 'src/app/shared/_services/translation-marker';
+import { TangyErrorHandler } from 'src/app/shared/_services/tangy-error-handler.service';
 
 @Component({
   selector: 'app-manage-sitewide-permissions',
@@ -9,37 +11,38 @@ import { NgxPermissionsService } from 'ngx-permissions';
   styleUrls: ['./manage-sitewide-permissions.component.css']
 })
 export class ManageSitewidePermissionsComponent implements OnInit {
-username;
-permissionsList;
-userPermissions;
-  constructor(private route:ActivatedRoute,
-     private authenticationService:AuthenticationService,
-     private permissionsService:NgxPermissionsService
-     ) { }
+  username;
+  permissionsList;
+  userPermissions;
+  constructor(private route: ActivatedRoute,
+    private authenticationService: AuthenticationService,
+    private permissionsService: NgxPermissionsService,
+    private errorHandler: TangyErrorHandler
+  ) { }
 
   async ngOnInit() {
     this.username = this.username = this.route.snapshot.paramMap.get('username')
     const permissions = await this.authenticationService.getPermissionsList()
     this.permissionsList = permissions['sitewidePermissions'];
-    this.userPermissions=  await this.authenticationService.getUserPermissions(this.username)
+    this.userPermissions = await this.authenticationService.getUserPermissions(this.username)
   }
-  doesUserHavePermission(permission){
-    return this.userPermissions.sitewidePermissions.indexOf(permission)>=0
+  doesUserHavePermission(permission) {
+    return this.userPermissions.sitewidePermissions.indexOf(permission) >= 0
   }
-  onSelectChange(permission, value){
-    if(value){
+  onSelectChange(permission, value) {
+    if (value) {
       this.userPermissions.sitewidePermissions = [...new Set([...this.userPermissions.sitewidePermissions, permission])];
-    } else{
-      this.userPermissions.sitewidePermissions= this.userPermissions.sitewidePermissions.filter(perm=>perm!==permission)
+    } else {
+      this.userPermissions.sitewidePermissions = this.userPermissions.sitewidePermissions.filter(perm => perm !== permission)
     }
   }
 
-  async submit(){
+  async submit() {
     try {
       const data = await this.authenticationService.updateUserPermissions(this.username, this.userPermissions.sitewidePermissions);
-      console.log(data)
+      this.errorHandler.handleError(_TRANSLATE('Permissions Updated Successfully.'));
     } catch (error) {
-      console.error(error)
+      console.error(error);
     }
   }
 }

--- a/editor/src/app/core/auth/auth-routing.module.ts
+++ b/editor/src/app/core/auth/auth-routing.module.ts
@@ -4,11 +4,8 @@ import { LoginComponent } from './_components/login/login.component';
 import { ManageUsersComponent } from './_components/manage-users/manage-users.component';
 import { UserResgistrationComponent } from './_components/user-resgistration/user-resgistration.component';
 import { LoginGuard } from './_guards/login-guard.service';
-import { AdminUserGuard } from './_guards/admin-user-guard.service';
-import {AddUserComponent} from '../../groups/add-users/add-user.component';
 import { NgxPermissionsGuard, NgxPermissionsModule } from 'ngx-permissions';
 import { ManageSitewidePermissionsComponent } from './_components/manage-sitewide-permissions/manage-sitewide-permissions.component';
-const data = {permissions:{only:['can_manage_site_wide_users'], redirectTo:'/projects'}};
 const routes: Routes = [{
   path: 'register-user',
   component: UserResgistrationComponent
@@ -20,25 +17,25 @@ const routes: Routes = [{
   path: 'manage-users',
   component: ManageUsersComponent,
   canActivate: [LoginGuard, NgxPermissionsGuard],
-  data
+  data: { permissions: { only: ['can_manage_site_wide_users'], redirectTo: '/projects' } }
 },
 {
   path: 'manage-users/new-user',
   component: UserResgistrationComponent,
   canActivate: [LoginGuard, NgxPermissionsGuard],
-  data: {permissions:{only:['can_create_user'], redirectTo:'/projects'}}
+  data: { permissions: { only: ['can_create_user'], redirectTo: '/projects' } }
 },
 {
   path: 'manage-users/sitewide-permissions/:username',
   component: ManageSitewidePermissionsComponent,
   canActivate: [LoginGuard, NgxPermissionsGuard],
-  data: {permissions:{only:['can_manage_site_wide_users'], redirectTo:'/projects'}}
+  data: { permissions: { only: ['can_manage_site_wide_users'], redirectTo: '/projects' } }
 },
 {
   path: 'manage-users/users/:id',
   component: UserResgistrationComponent,
   canActivate: [LoginGuard, NgxPermissionsModule],
-  data
+  data: { permissions: { only: ['can_manage_site_wide_users'], redirectTo: '/projects' } }
 }];
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/editor/src/app/core/auth/auth-routing.module.ts
+++ b/editor/src/app/core/auth/auth-routing.module.ts
@@ -4,7 +4,7 @@ import { LoginComponent } from './_components/login/login.component';
 import { ManageUsersComponent } from './_components/manage-users/manage-users.component';
 import { UserResgistrationComponent } from './_components/user-resgistration/user-resgistration.component';
 import { LoginGuard } from './_guards/login-guard.service';
-import { NgxPermissionsGuard, NgxPermissionsModule } from 'ngx-permissions';
+import { NgxPermissionsGuard } from 'ngx-permissions';
 import { ManageSitewidePermissionsComponent } from './_components/manage-sitewide-permissions/manage-sitewide-permissions.component';
 const routes: Routes = [{
   path: 'register-user',
@@ -34,7 +34,7 @@ const routes: Routes = [{
 {
   path: 'manage-users/users/:id',
   component: UserResgistrationComponent,
-  canActivate: [LoginGuard, NgxPermissionsModule],
+  canActivate: [LoginGuard, NgxPermissionsGuard],
   data: { permissions: { only: ['can_manage_site_wide_users'], redirectTo: '/projects' } }
 }];
 @NgModule({

--- a/editor/src/app/groups/groups-routing.module.ts
+++ b/editor/src/app/groups/groups-routing.module.ts
@@ -49,7 +49,7 @@ const groupsRoutes: Routes = [
   // { path: 'projects', component: GroupsComponent },
   { path: '', component: GroupsComponent, canActivate: [LoginGuard] },
   { path: 'projects', component: GroupsComponent, canActivate: [LoginGuard] },
-  { path: 'groups/new-group', component: NewGroupComponent, canActivate: [LoginGuard, AdminUserGuard, NgxPermissionsGuard], data:{permissions:{only:['can_create_group'], redirectTo:'/projects'}} },
+  { path: 'groups/new-group', component: NewGroupComponent, canActivate: [LoginGuard, NgxPermissionsGuard], data:{permissions:{only:['can_create_group'], redirectTo:'/projects'}} },
   { path: 'groups/:groupId', component: GroupComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/author', component: GroupAuthorComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/author/forms', component: GroupFormsComponent, canActivate: [LoginGuard] },

--- a/editor/src/app/groups/new-group/new-group.component.ts
+++ b/editor/src/app/groups/new-group/new-group.component.ts
@@ -39,6 +39,7 @@ export class NewGroupComponent implements OnInit {
       }
     } catch (error) {
       console.log(error);
+      this.errorHandler.handleError(_TRANSLATE('Could not create Group'));
     }
   }
 

--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -127,7 +127,7 @@ const updateUserSiteWidePermissions = async (req, res) => {
     const username = req.params.username;
     const {sitewidePermissions} = req.body;
     if (username && sitewidePermissions.length >= 0 ) {
-    const user = findUserByUsername(username);
+    const user = await findUserByUsername(username);
     user.sitewidePermissions = [...sitewidePermissions];
     const data = await USERS_DB.put(user);
     res.send({ data, statusCode: 200, statusMessage: `User permissions updated` });
@@ -139,14 +139,14 @@ const updateUserSiteWidePermissions = async (req, res) => {
   }
 };
 module.exports = {
+  USERS_DB,
   areCredentialsValid,
   doesUserExist,
   extendSession,
   findUserByUsername,
+  getUserPermissions,
   hashPassword,
   isSuperAdmin,
   login,
-  getUserPermissions,
   updateUserSiteWidePermissions,
-  USERS_DB,
 };

--- a/server/src/core/core.module.ts
+++ b/server/src/core/core.module.ts
@@ -38,7 +38,7 @@ export class CoreModule implements NestModule {
       .apply(isAuthenticated)
       .forRoutes(GroupDeviceManageController)
     consumer
-      .apply(permit(['can_create_group']))
+      .apply(isAuthenticated, permit(['can_create_group']))
       .forRoutes({path: 'nest/group/create', method: RequestMethod.POST});
   }
 }

--- a/server/src/core/core.module.ts
+++ b/server/src/core/core.module.ts
@@ -1,12 +1,13 @@
 import { GroupDevicePublicController } from './group-device/group-device-public.controller';
 import { GroupDeviceManageController } from './group-device/group-device-manage.controller';
-import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer, RequestMethod } from '@nestjs/common';
 import { SharedModule } from '../shared/shared.module';
 import { GroupController } from './group/group.controller';
 import { UserController } from './user/user.controller';
 import { ConfigController } from './config/config.controller';
 import { GroupResponsesController } from './group-responses/group-responses.controller';
-import isAuthenticated = require('../middleware/is-authenticated')
+import isAuthenticated = require('../middleware/is-authenticated');
+const {permit} = require('../middleware/permitted');
 
 @Module({
   controllers: [
@@ -36,5 +37,8 @@ export class CoreModule implements NestModule {
     consumer
       .apply(isAuthenticated)
       .forRoutes(GroupDeviceManageController)
+    consumer
+      .apply(permit(['can_create_group']))
+      .forRoutes({path: 'nest/group/create', method: RequestMethod.POST});
   }
 }

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -100,7 +100,7 @@ app.post('/login', login);
 app.post('/extendSession', isAuthenticated, extendSession);
 app.get('/permissionsList', isAuthenticated, getPermissionsList);
 app.get('/permissions/:username', isAuthenticated, getUserPermissions);
-app.post('/permissions/updateUserSitewidePermissions:username/:username', isAuthenticated, updateUserSiteWidePermissions);
+app.post('/permissions/updateUserSitewidePermissions:username/:username', isAuthenticated,permit(['can_manage_site_wide_users']), updateUserSiteWidePermissions);
 app.get('/login/validate/:userName',
   function (req, res) {
     if (req.user && (req.params.userName === req.user.name)) {

--- a/server/src/middleware/is-authenticated.js
+++ b/server/src/middleware/is-authenticated.js
@@ -4,14 +4,15 @@ module.exports = function(req, res, next) {
   const token = req.headers.authorization || req.cookies.Authorization
   const errorMessage = `Permission denied at ${req.url}`;
   if (token && verifyJWT(token)) {
-    const { username, permissions } = decodeJWT(token);
+    const { username, permissions:{sitewidePermissions = [], groupPermissions = []} } = decodeJWT(token);
     if (!username) {
       log.warn(errorMessage);
       res.status(401).send(errorMessage);
     } else {
       req.user = {};
       req.user.name = username;
-      req.user.permissions = permissions || [];
+      req.user.sitewidePermissions = sitewidePermissions;
+      req.user.groupPermissions = groupPermissions;
       next();
     }
   } else {

--- a/server/src/middleware/permitted.js
+++ b/server/src/middleware/permitted.js
@@ -1,7 +1,7 @@
 const permit = (allowedPermissions) => {
     const isAllowed = permissions => (allowedPermissions.filter(Set.prototype.has, new Set(permissions))).length > 0;
     return (req, res, next) => {
-      if (isAllowed(req.user.permissions)) {
+      if (isAllowed(req.user.sitewidePermissions)) {
           next();
       } else {
         res.status(403).send(`Access Denied at ${req.url}`);


### PR DESCRIPTION
## Description

---

We need Role based Access Control.
The first step is to define sitewide permissions.
A further PR will deal with managing access within groups

- Fixes #2027 
- Updates #2129 and adds  documentation

## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---
* Create a `sitewidePermissions` property of type `Array` in the specific user's document in the database which will keep track of all the sitewide permissions a user has been granted.

When a user logs in successfully, the user's permissions are included in the JWT that is sent back to the client making the request. The list of permissions is stored in `localStorage`. 

We use the `[ngx-permissions](https://github.com/AlexKhymenko/ngx-permissions)` module to manage client side permissions validation which allows us to add directives to `HTML` templates thus conditionally showing or hiding a portion of  the`dom`based on the user's permissions and the permissions required in order to access that portion of the dom. Some routes also need permissions before they can be accessed. These are protected using `NgxPermssionsGuard` route guard with the corresponding permissions .

The server has a `permit` middleware which validates the user's permissions for each resource or route based on the decoded token from the JWT.  If the JWT has been tampered with or if the user has no permissions for the specified route, access is denied to the route and a `403` error is sent to the user. Otherwise, if the user passes the authentication and permission verification, the `permit` middleware passes the request to the next middleware/handler in the chain.

## Limitations and Trade-offs
* When users permissions are changed in the course of an active session, they'll need to re-authenticate before the new permissions are applied.

## Notices, Regressions, Breaking Changes

---
In order to enforce sitewidepermissions to a route on the server:

1. Check in `server/src/permissions-list.js` if the permssion exists in the `sitewidePermissions` Array. If not, add the permission to the array

1. Add the `permit` middleware after the `isAuthenticated` middleware in the route with the permissions required to access the route(an array of strings of the arguments) passed as arguments to the middleware eg `permit(['can_add_users', 'can_delete_users'])` e.g 

```javascript
// add the list of permissions as an array of strings
app.post('/users/register-user', isAuthenticated, permit(['can_create_user']), async (req, res) => {
 // Redacted
});
```

* On the user interface side
1. if required, add the `NgxPermissionsGuard` to the route e.g

```javascript

{
  path: 'manage-users/users/:id',
  component: UserResgistrationComponent,
  canActivate: [LoginGuard, NgxPermissionsGuard],
  data: { permissions: { only: ['can_manage_site_wide_users'], redirectTo: '/projects' } }
}];

```
The `redirect` property denotes the route that the user will be redirected to in case the user does not have the requisite permissions to access the route.

1. If necessary add , directive to conditionally hide or show part of the `DOM` based on the user's permissions e.g

```html

<span *ngxPermissionsOnly="['can_create_group']"><paper-fab  mat-raised-button icon="add" color="accent" class="action" routerLink="/groups/new-group">
</paper-fab>
</span>

```
Note, it may be necessary to "wrap" some elements in a container element e.g `<span></span>` when the element already has directives like `*ngIf` or `*ngFor` applied. A container element may also be required if an element is not an `Angular` component e.g a web component or `tangy-form` element
