### PR TITLE
#2134 Remove group permissions in JWT to avoid cookie byte limit

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -44,7 +44,7 @@ const collateUserPermissions = async username => {
     const groupPermissions = groups.map(group=>{
       return{groupName: group._id, permissions: permissionsList.groupPermissions};
     });
-    return {sitewidePermissions: permissionsList.sitewidePermissions, groupPermissions};
+    return {sitewidePermissions: permissionsList.sitewidePermissions, groupPermissions: []};
   } else {
     const data = await findUserByUsername(username);
     const sitewidePermissions = data.sitewidePermissions || [];
@@ -52,7 +52,7 @@ const collateUserPermissions = async username => {
     const groupPermissions = data.groups.map(group => {
       return {groupName: group.groupName, permissions: group.permissions || []};
     });
-    return {sitewidePermissions, groupPermissions};
+    return {sitewidePermissions, groupPermissions: []};
   } else {
     return {sitewidePermissions, groupPermissions: []};
   }


### PR DESCRIPTION
Because in v3.10.0 we just care if a user is logged in for group protected routes, we can remove info in the JWT about groups.

Related to #2134