### PR TITLE
Add tests.csv

### DIFF
--- a/test/tests.csv
+++ b/test/tests.csv
@@ -1,3 +1,3 @@
-name,description,is automated,steps
-Automated Issue creation on Client, Tests the APIs on client to make sure an Issue is created on a form submit and that the issue is uploaded to the server., no,"1) Load the 'case' content set into a group. 2) Deploy the app to either APK or PWA. 3) Create a case of type 'Mother'. 4) Fill out the registration form with an age of 85. 5) After submitting the registration, upload to server. 6) In Editor, navigate to test group's Data -> Issues. 7) Confirm that an Issue appears titled 'Out of bounds age’."
-Granting site-wide permission of can_create_group allows Editor user to create a group, ..., no,...
+name,description,steps
+Automated Issue creation on Client, Tests the APIs on client to make sure an Issue is created on a form submit and that the issue is uploaded to the server.,"1) Load the 'case' content set into a group. 2) Deploy the app to either APK or PWA. 3) Create a case of type 'Mother'. 4) Fill out the registration form with an age of 85. 5) After submitting the registration, upload to server. 6) In Editor, navigate to test group's Data -> Issues. 7) Confirm that an Issue appears titled 'Out of bounds age’."
+Granting site-wide permission of can_create_group allows Editor user to create a group, ...,...

--- a/test/tests.csv
+++ b/test/tests.csv
@@ -1,0 +1,3 @@
+name,description,is automated,steps
+Automated Issue creation on Client, Tests the APIs on client to make sure an Issue is created on a form submit and that the issue is uploaded to the server., no,"1) Load the 'case' content set into a group. 2) Deploy the app to either APK or PWA. 3) Create a case of type 'Mother'. 4) Fill out the registration form with an age of 85. 5) After submitting the registration, upload to server. 6) In Editor, navigate to test group's Data -> Issues. 7) Confirm that an Issue appears titled 'Out of bounds age’."
+Granting site-wide permission of can_create_group allows Editor user to create a group, ..., no,...


### PR DESCRIPTION
When a developer such as myself is developing a new feature, certain integration tests are currently outside of what we can automate in our current testing frameworks. As our numbers of feature increase in every release, so does the number of these integration tests need to be performed manually. It may not be obvious to folks performing QA exactly where the gaps are in automated testing, so this PR proposes a way to allow the developer to submit a testing plan with their PR.

This PR adds a top level `test` folder to the repository, inside of which contains a `tests.csv` file. The CSV contains columns of "name", "description", and "steps" along with two example tests. In the future I imagine this test folder could also contain a `content-sets` folder where we would stash content sets for groups that the tests can reference as starting places. To improve the testing workflow, a tangerine CLI command could be developed to create a new group from one of these content sets.