### PR TITLE
Add tangerine-preview support copying app-config.json_example to app-config.json

### DIFF
--- a/tangerine-preview/index.js
+++ b/tangerine-preview/index.js
@@ -10,12 +10,28 @@ const ASSETS_DIR = `${TANGERINE_CLIENT_DIR}${path.normalize('/assets/')}`
 
 const app = express()
 const port = 3000
+const url = `http://localhost:${port}`
 
 app.use(express.static(TANGERINE_CLIENT_DIR))
 
 // Listen
 
 async function go() {
+  const appConfigPath = `${process.cwd()}/app-config.json`
+  const appConfigExamplePath = `${process.cwd()}/app-config.json_example`
+  // Set up app-config.json using app-config.json_example, unless app-config.json is already set up.
+  if (!fs.existsSync(appConfigPath) && fs.existsSync(appConfigExamplePath)) {
+    fs.copyFileSync(appConfigExamplePath, appConfigPath)
+    appConfig = await fs.readJSON(appConfigPath)
+    appConfig.serverUrl = url
+    await fs.writeJson(appConfigPath, appConfig)
+  }
+  // If neither an app-config.json or app-config.json_example file exists, we're likely not in a content set directory.
+  if (!fs.existsSync(appConfigPath) && !fs.existsSync(appConfigExamplePath)) {
+    console.log('')
+    console.log('This does not appear to be a Tangerine content set. No app-config.json or app-config.json_example found. See the documentation on content sets at https://docs.tangerinecentral.org/.')
+    console.log('')
+  }
   try {
     const raw = fs.readFileSync(`${process.cwd()}/app-config.json`)
     const appConfig = JSON.parse(raw)


### PR DESCRIPTION
This PR adds support in tangerine-preview for copying `app-config.json_example` to `app-config.json`. This cuts out a manual step from getting started with a content set. 