### PR TITLE
Data collector views an alert (PR for #2020)

### DIFF
--- a/client/src/app/case/case-routing.module.ts
+++ b/client/src/app/case/case-routing.module.ts
@@ -1,12 +1,30 @@
+import { Observable } from 'rxjs';
 import { EventFormAddComponent } from './components/event-form-add/event-form-add.component';
 import { NgModule, Injectable } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
+import { RouterModule, Routes, CanDeactivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { LoginGuard } from '../shared/_guards/login-guard.service';
 import { _TRANSLATE } from '../shared/translation-marker';
 import { NewCaseComponent } from './components/new-case/new-case.component';
 import { CaseComponent } from './components/case/case.component';
 import { EventComponent } from './components/event/event.component'
 import { EventFormComponent } from './components/event-form/event-form.component'
+
+@Injectable()
+export class CanDeactivateEvent implements CanDeactivate<EventComponent> {
+  constructor() {}
+  canDeactivate(
+    component: EventComponent,
+    currentRoute: ActivatedRouteSnapshot,
+    currentState: RouterStateSnapshot,
+    nextState: RouterStateSnapshot
+  ): Observable<boolean>|Promise<boolean>|boolean {
+    if (component.hasNotificationEnforcingAttention && !component.exitRoutes().includes(nextState.url)) {
+      return confirm(_TRANSLATE('There is an urgent notification that needs attention. Are you sure you want to exit this event?'));
+    } else {
+      return true;
+    }
+  }
+}
 
 const routes: Routes = [
   {
@@ -17,7 +35,8 @@ const routes: Routes = [
   {
     path: 'case/event/:caseId/:eventId',
     component: EventComponent,
-    canActivate: [LoginGuard]
+    canActivate: [LoginGuard],
+    canDeactivate: [ CanDeactivateEvent ]
   },
   {
     path: 'case/event/form-add/:caseId/:eventId/:participantId',
@@ -36,9 +55,10 @@ const routes: Routes = [
   }
 ];
 
+
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],
-  providers: []
+  providers: [ CanDeactivateEvent ]
 })
 export class CaseRoutingModule { }

--- a/client/src/app/case/case.module.ts
+++ b/client/src/app/case/case.module.ts
@@ -17,6 +17,7 @@ import { CaseEventListItemComponent } from './components/case-event-list-item/ca
 import { EventFormListItemComponent } from './components/event-form-list-item/event-form-list-item.component';
 import { QueryComponent } from './components/query/query.component';
 import { EventFormAddComponent } from './components/event-form-add/event-form-add.component';
+import { CaseNotificationsComponent } from './components/case-notifications/case-notifications.component';
 
 @NgModule({
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
@@ -44,7 +45,8 @@ import { EventFormAddComponent } from './components/event-form-add/event-form-ad
     CaseEventListItemComponent,
     EventFormListItemComponent,
     QueryComponent,
-    EventFormAddComponent
+    EventFormAddComponent,
+    CaseNotificationsComponent
   ]
 })
 export class CaseModule { }

--- a/client/src/app/case/classes/case.class.ts
+++ b/client/src/app/case/classes/case.class.ts
@@ -1,6 +1,7 @@
 import { CaseEvent } from './case-event.class'
 import {TangyFormResponseModel} from 'tangy-form/tangy-form-response-model.js'
 import { CaseParticipant } from './case-participant.class';
+import { Notification } from './notification.class';
 
 class Case extends TangyFormResponseModel {
   
@@ -13,6 +14,7 @@ class Case extends TangyFormResponseModel {
   participants:Array<CaseParticipant> = []
   disabledEventDefinitionIds: Array<string> = []
   events: Array<CaseEvent> = []
+  notifications: Array<Notification> = []
   type:string = 'case'
 
   constructor(data?:any) {

--- a/client/src/app/case/classes/notification.class.ts
+++ b/client/src/app/case/classes/notification.class.ts
@@ -1,0 +1,30 @@
+import { AppContext } from './../../app-context.enum';
+export enum NotificationStatus {
+  Open='Open',
+  Closed='Closed'
+}
+
+export enum NotificationType {
+  Critical='Critical',
+  Info='Info',
+}
+
+class Notification {
+  id: string
+  userId:string
+  userName:string
+  label:string
+  description:string
+  status:NotificationStatus 
+  caseId:string
+  eventId:string
+  eventFormId:string
+  formResponseId:string
+  createdOn:number
+  createdAppContext:AppContext
+  constructor(data?:any) {
+    Object.assign(this, data)
+  }
+}
+
+export { Notification }

--- a/client/src/app/case/classes/notification.class.ts
+++ b/client/src/app/case/classes/notification.class.ts
@@ -11,15 +11,14 @@ export enum NotificationType {
 
 class Notification {
   id: string
-  userId:string
-  userName:string
   label:string
   description:string
+  link:string
+  icon:string
+  color:string
+  enforceAttention:boolean
+  persist:boolean
   status:NotificationStatus 
-  caseId:string
-  eventId:string
-  eventFormId:string
-  formResponseId:string
   createdOn:number
   createdAppContext:AppContext
   constructor(data?:any) {

--- a/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.css
+++ b/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.css
@@ -32,3 +32,23 @@
 .secondary iron-icon {
     color: var(--primary-text-color-overlay) !important;
 }
+
+.notification {
+  color: white;
+  position: absolute;
+  top: 16px;
+  right: 58px;
+  z-index:987654323456765432;
+}
+
+.notification::before{
+  content: '';
+  display: inline-block;
+  position: relative;
+  left: 23px;
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  background-color: red;
+  top: -9px;
+}

--- a/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.html
+++ b/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.html
@@ -6,3 +6,4 @@
     <iron-icon icon="chevron-left" routerLink="{{secondaryLink}}"></iron-icon>
     <span [innerHTML]="secondaryText|unsanitizeHtml"></span>
 </div>
+<mwc-icon class="notification" [hidden]="!hasActiveNotification">notifications</mwc-icon>

--- a/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.ts
+++ b/client/src/app/case/components/case-breadcrumb/case-breadcrumb.component.ts
@@ -1,3 +1,4 @@
+import { NotificationStatus } from './../../classes/notification.class';
 import { Component, OnInit, Input, ChangeDetectorRef } from '@angular/core';
 import { CaseService } from '../../services/case.service'
 import { t } from 'tangy-form/util/t.js'
@@ -17,6 +18,7 @@ export class CaseBreadcrumbComponent implements OnInit {
   primaryText = ''
   secondaryText = ''
   secondaryLink = ''
+  hasActiveNotification = false
 
   constructor(
     private caseService: CaseService,
@@ -71,7 +73,13 @@ export class CaseBreadcrumbComponent implements OnInit {
         ? \`${this.caseService.caseDefinition.templateBreadcrumbText}\`
         : \`Case: ${caseInstance._id.substr(0,6)} \`
     `)
+    this.evaluateHasActiveNotifications()
     this.ref.detectChanges()
+  }
+
+  evaluateHasActiveNotifications() {
+    this.hasActiveNotification = this.caseService.case.notifications
+      .reduce((hasActiveNotification, notification) => hasActiveNotification || notification.status === NotificationStatus.Open ? true : false, false) 
   }
 
 }

--- a/client/src/app/case/components/case-notifications/case-notifications.component.html
+++ b/client/src/app/case/components/case-notifications/case-notifications.component.html
@@ -1,7 +1,7 @@
 <div class="icon-list-item" *ngFor="let notification of notifications" style="background: {{notification.color}};">
-  <mwc-icon *ngIf="notification.link" routerLink="notification.link" [innerHTML]="notification.icon" slot="item-icon"></mwc-icon>
+  <mwc-icon *ngIf="notification.link" [routerLink]="notification.link" [innerHTML]="notification.icon" slot="item-icon"></mwc-icon>
   <mwc-icon *ngIf="!notification.link" [innerHTML]="notification.icon" slot="item-icon"></mwc-icon>
-  <div *ngIf="notification.link" routerLink="notification.link">
+  <div *ngIf="notification.link" [routerLink]="notification.link">
     <div>{{notification.label}}</div>
     <div style="white-space: normal" secondary>{{notification.description}}</div>
   </div>

--- a/client/src/app/case/components/case-notifications/case-notifications.component.html
+++ b/client/src/app/case/components/case-notifications/case-notifications.component.html
@@ -1,0 +1,12 @@
+<div class="icon-list-item" *ngFor="let notification of notifications" style="background: {{notification.color}};">
+  <mwc-icon *ngIf="notification.link" routerLink="notification.link" [innerHTML]="notification.icon" slot="item-icon"></mwc-icon>
+  <mwc-icon *ngIf="!notification.link" [innerHTML]="notification.icon" slot="item-icon"></mwc-icon>
+  <div *ngIf="notification.link" routerLink="notification.link">
+    <div>{{notification.label}}</div>
+    <div style="white-space: normal" secondary>{{notification.description}}</div>
+  </div>
+  <div *ngIf="!notification.link">
+    <div>{{notification.label}}</div>
+    <div style="white-space: normal" secondary>{{notification.description}}</div>
+  </div>
+</div>

--- a/client/src/app/case/components/case-notifications/case-notifications.component.spec.ts
+++ b/client/src/app/case/components/case-notifications/case-notifications.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CaseNotificationsComponent } from './case-notifications.component';
+
+describe('CaseNotificationsComponent', () => {
+  let component: CaseNotificationsComponent;
+  let fixture: ComponentFixture<CaseNotificationsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CaseNotificationsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CaseNotificationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/case/components/case-notifications/case-notifications.component.ts
+++ b/client/src/app/case/components/case-notifications/case-notifications.component.ts
@@ -1,0 +1,46 @@
+import { NotificationType, Notification, NotificationStatus } from './../../classes/notification.class';
+import { CaseService } from 'src/app/case/services/case.service';
+import { Component, OnInit } from '@angular/core';
+
+interface NotificationInfo {
+  id:string
+  label: string
+  description:string
+  icon:string
+  caseId:string
+  eventId:string
+  eventFormId:string
+}
+
+const NotificationTypeIconMap = {
+  [NotificationType.Critical]: 'error',
+  [NotificationType.Info]: 'warning'
+}
+
+@Component({
+  selector: 'app-case-notifications',
+  templateUrl: './case-notifications.component.html',
+  styleUrls: ['./case-notifications.component.css']
+})
+export class CaseNotificationsComponent implements OnInit {
+
+  ready = false
+  notificationInfos:Array<NotificationInfo> = []
+  notifications:Array<Notification> = []
+
+  constructor(
+    private caseService:CaseService
+  ) { }
+
+  async ngOnInit() {
+    this.notifications = [...this.caseService.case.notifications.filter(notification => notification.status === NotificationStatus.Open)]
+    this.ready = true
+    for (let notification of this.caseService.case.notifications) {
+      if (!notification.persist) {
+        this.caseService.closeNotification(notification.id)
+        await this.caseService.save()
+      }
+    }
+  }
+
+}

--- a/client/src/app/case/components/case/case.component.css
+++ b/client/src/app/case/components/case/case.component.css
@@ -89,7 +89,6 @@ app-case-breadcrumb {
 }
 
 :host {
-    position: relative;
 }
 
 

--- a/client/src/app/case/components/case/case.component.html
+++ b/client/src/app/case/components/case/case.component.html
@@ -11,7 +11,7 @@
     </div>
   </div>
 </div>
-
+<app-case-notifications></app-case-notifications>
 <div class="wrapper">
   <div class="cover-when-not-confirmed" *ngIf="caseService.openCaseConfirmed === false"></div>
   <div *ngFor="let eventInfo of caseEventsInfo">

--- a/client/src/app/case/components/event/event.component.css
+++ b/client/src/app/case/components/event/event.component.css
@@ -102,5 +102,4 @@ button[type="submit"] {
     border-radius: .25rem;
 }
 :host {
-    position: relative;
 }

--- a/client/src/app/case/components/event/event.component.css
+++ b/client/src/app/case/components/event/event.component.css
@@ -2,6 +2,15 @@ h2 {
     margin: 30px 0px 25px 20px;
 }
 
+.screen {
+    position: absolute;
+    background: #000;
+    opacity: .5;
+    z-index: 987654321;
+    width: 100%;
+    height: 5000px;
+}
+
 .subject-header {
     background: #212a3f;
     color: white;
@@ -34,8 +43,10 @@ h2 {
 }
 
 .wrapper {
+    position: relative;
     margin: 0px;
 }
+
 paper-button {
     background: var(--accent-color);
     color: white;

--- a/client/src/app/case/components/event/event.component.html
+++ b/client/src/app/case/components/event/event.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="loaded">
   <app-case-breadcrumb *ngIf="caseService && caseService.case && caseService.case._id" [caseId]="caseService.case._id" [caseEventId]="caseEvent.id"></app-case-breadcrumb>
-
+  <app-case-notifications></app-case-notifications>
   <div class="wrapper">
     <app-event-form-list-item
       *ngFor="let eventFormInfo of noRoleEventFormInfos"

--- a/client/src/app/case/components/event/event.component.html
+++ b/client/src/app/case/components/event/event.component.html
@@ -2,6 +2,7 @@
   <app-case-breadcrumb *ngIf="caseService && caseService.case && caseService.case._id" [caseId]="caseService.case._id" [caseEventId]="caseEvent.id"></app-case-breadcrumb>
   <app-case-notifications></app-case-notifications>
   <div class="wrapper">
+    <div class="screen" *ngIf="hasNotificationEnforcingAttention"></div>
     <app-event-form-list-item
       *ngFor="let eventFormInfo of noRoleEventFormInfos"
       [case]="caseService.case"

--- a/client/src/app/case/components/event/event.component.ts
+++ b/client/src/app/case/components/event/event.component.ts
@@ -1,3 +1,4 @@
+import { NotificationStatus } from './../../classes/notification.class';
 import { EventFormDefinition } from './../../classes/event-form-definition.class';
 
 import { Component, OnInit, AfterContentInit, ChangeDetectorRef } from '@angular/core';
@@ -34,6 +35,7 @@ export class EventComponent implements OnInit, AfterContentInit {
   loaded = false
   availableEventFormDefinitions:Array<EventFormDefinition> = []
   selectedNewEventFormDefinition = ''
+  hasNotificationEnforcingAttention = false
   window:any
 
   constructor(
@@ -82,6 +84,17 @@ export class EventComponent implements OnInit, AfterContentInit {
       this.getParticipantInfo()
       // ^ Remove this filter??
       //this.calculateAvailableEventFormDefinitions()
+      if (this.caseService.case.notifications) {
+        this.hasNotificationEnforcingAttention = this
+          .caseService
+          .case
+          .notifications
+          .reduce((hasNotificationEnforcingAttention, notification) => {
+            return hasNotificationEnforcingAttention || (notification.enforceAttention && notification.status === NotificationStatus.Open)
+             ? true
+             : false
+          }, false)
+      }
       this.loaded = true
       this.ref.detectChanges()
     })

--- a/client/src/app/case/components/event/event.component.ts
+++ b/client/src/app/case/components/event/event.component.ts
@@ -36,6 +36,7 @@ export class EventComponent implements OnInit, AfterContentInit {
   availableEventFormDefinitions:Array<EventFormDefinition> = []
   selectedNewEventFormDefinition = ''
   hasNotificationEnforcingAttention = false
+  _canExitToRoute = []
   window:any
 
   constructor(
@@ -94,10 +95,23 @@ export class EventComponent implements OnInit, AfterContentInit {
              ? true
              : false
           }, false)
+        this._canExitToRoute = this
+          .caseService
+          .case
+          .notifications
+          .reduce((canExitToRoute, notification) => {
+            return (notification.enforceAttention && notification.status === NotificationStatus.Open)
+             ? [...canExitToRoute, notification.link]
+             : canExitToRoute
+          }, [])
       }
       this.loaded = true
       this.ref.detectChanges()
     })
+  }
+
+  exitRoutes() {
+    return this._canExitToRoute
   }
 
   calculateAvailableEventFormDefinitionsForParticipant(participantId) {

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -325,7 +325,7 @@ class CaseService {
    * Notification API
    */
 
-  createNotification (label = '', description = '', link = '', icon = 'notification_important', color = '#CCC', enforceAttention = false, persist = false) {
+  createNotification (label = '', description = '', link = '', icon = 'notification_important', color = '#CCC', persist = false, enforceAttention = false ) {
     const notification = <Notification>{
       id: UUID(),
       status: NotificationStatus.Open,

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -1,4 +1,4 @@
-import { IssueEventType } from './../classes/issue.class';
+import { NotificationStatus, Notification, NotificationType } from './../classes/notification.class';
 import { Issue, IssueStatus, IssueEvent } from './../classes/issue.class';
 // Services.
 import { DeviceService } from 'src/app/device/services/device.service';
@@ -321,6 +321,53 @@ class CaseService {
     return this.case.participants.find(participant => participant.id === participantId).data[key]
   }
 
+  /*
+   * Notification API
+   */
+  createNotification (label = '', description = '', type:NotificationType, eventId:string, eventFormId:string, userId, userName) {
+    const formResponseId = this.case 
+      .events.find(event => event.id === eventId)
+      .eventForms.find(eventForm => eventForm.id === eventFormId)
+      .formResponseId
+    const notification = <Notification>{
+      id: UUID(),
+      status: NotificationStatus.Open,
+      type,
+      userId,
+      userName,
+      label,
+      description,
+      caseId: this.case._id,
+      eventId,
+      eventFormId,
+      formResponseId,
+      createdAppContext: AppContext.Client,
+      createdOn: Date.now(),
+    }
+    this.case.notifications.push(notification)
+  }
+
+  async openNotification(notificationId:string) {
+    this.case.notifications = this.case.notifications.map(notification => {
+      return notification.id === notificationId
+        ? <Notification>{
+          ...notification,
+          status: NotificationStatus.Open
+        }
+        : notification
+    })
+  }
+
+  async closeNotification(notificationId:string) {
+    this.case.notifications = this.case.notifications.map(notification => {
+      return notification.id === notificationId
+        ? <Notification>{
+          ...notification,
+          status: NotificationStatus.Closed
+        }
+        : notification
+    })
+  }
 
   /*
    *

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -1,5 +1,5 @@
 import { NotificationStatus, Notification, NotificationType } from './../classes/notification.class';
-import { Issue, IssueStatus, IssueEvent } from './../classes/issue.class';
+import { Issue, IssueStatus, IssueEvent, IssueEventType } from './../classes/issue.class';
 // Services.
 import { DeviceService } from 'src/app/device/services/device.service';
 import { TangyFormService } from 'src/app/tangy-forms/tangy-form.service';
@@ -324,26 +324,21 @@ class CaseService {
   /*
    * Notification API
    */
-  createNotification (label = '', description = '', type:NotificationType, eventId:string, eventFormId:string, userId, userName) {
-    const formResponseId = this.case 
-      .events.find(event => event.id === eventId)
-      .eventForms.find(eventForm => eventForm.id === eventFormId)
-      .formResponseId
+
+  createNotification (label = '', description = '', link = '', icon = 'notification_important', color = '#CCC', enforceAttention = false, persist = false) {
     const notification = <Notification>{
       id: UUID(),
       status: NotificationStatus.Open,
-      type,
-      userId,
-      userName,
-      label,
-      description,
-      caseId: this.case._id,
-      eventId,
-      eventFormId,
-      formResponseId,
       createdAppContext: AppContext.Client,
       createdOn: Date.now(),
-    }
+      label,
+      description,
+      link,
+      icon,
+      color,
+      enforceAttention,
+      persist
+   }
     this.case.notifications.push(notification)
   }
 

--- a/content-sets/case-module/.gitignore
+++ b/content-sets/case-module/.gitignore
@@ -1,0 +1,1 @@
+app-config.json

--- a/content-sets/case-module/case-type-1.json
+++ b/content-sets/case-module/case-type-1.json
@@ -66,6 +66,22 @@
           "name": "Data Collector causes Issue to be created due to `discrepancy-if` logic in form",
           "required": true,
           "repeatable": false 
+        },
+        {
+          "id": "event-form-definition-fin2z8",
+          "formId": "create-an-urgent-notification",
+          "forCaseRole": "role-2",
+          "name": "Data Collector causes an urgent notification to be created",
+          "required": true,
+          "repeatable": false 
+        },
+        {
+          "id": "event-form-definition-fdkai3",
+          "formId": "resolve-an-urgent-notification",
+          "forCaseRole": "role-2",
+          "name": "Data Collector resolves urgent notification",
+          "required": false,
+          "repeatable": true 
         }
       ]
     }

--- a/content-sets/case-module/create-an-urgent-notification/form.html
+++ b/content-sets/case-module/create-an-urgent-notification/form.html
@@ -1,0 +1,25 @@
+<tangy-form id="create-an-urgent-notification" title="Data Collector causes an urgent notification to be created"
+
+  on-submit="
+    debugger
+    const resolveNotificationEventForm = caseService.startEventForm(caseEvent.id, 'event-form-definition-fdkai3', participant.id)
+    caseService.createNotification(
+      `This is an urgent notification!`, 
+      `
+        Click here to fill out a form that will cause this notification to go away.
+      `,
+      `/case/event/form/${caseService.case._id}/${caseEvent.id}/${resolveNotificationEventForm.id}`,
+      `warning`,
+      `#ff6961`,
+      true,
+      true 
+    ) 
+  "
+
+>
+  <tangy-form-item id="item1">
+    <tangy-box name="info">
+      Submitting this form will cause an urgent notification to be create requiring another form to be filled out.
+    </tangy-box>
+  </tangy-form-item>
+</tangy-form>

--- a/content-sets/case-module/forms.json
+++ b/content-sets/case-module/forms.json
@@ -147,6 +147,62 @@
     }
   },
   {
+    "id" : "create-an-urgent-notification",
+    "src" : "./assets/create-an-urgent-notification/form.html",
+    "description" : "Data Collector causes an urgent notification to be created",
+    "listed" : false,
+    "title" : "Data Collector causes an urgent notification to be created",
+    "icon" : "assignment",
+    "type" : "form",
+    "searchSettings" : {
+      "shouldIndex" : false,
+      "primaryTemplate" : "",
+      "secondaryTemplate" : "",
+      "variablesToIndex" : [
+      ]
+    },
+    "customSyncSettings": {
+      "enabled": false,
+      "push": false,
+      "pull": false,
+      "excludeIncomplete":false
+    },
+    "couchdbSyncSettings": {
+      "enabled": true,
+      "filterByLocation": true,
+      "push": true,
+      "pull": true
+    }
+  },
+  {
+    "id" : "resolve-an-urgent-notification",
+    "src" : "./assets/resolve-an-urgent-notification/form.html",
+    "description" : "Data Collector resolves urgent notification",
+    "listed" : false,
+    "title" : "Data Collector resolves urgent notification",
+    "icon" : "assignment",
+    "type" : "form",
+    "searchSettings" : {
+      "shouldIndex" : false,
+      "primaryTemplate" : "",
+      "secondaryTemplate" : "",
+      "variablesToIndex" : [
+      ]
+    },
+    "customSyncSettings": {
+      "enabled": false,
+      "push": false,
+      "pull": false,
+      "excludeIncomplete":false
+    },
+    "couchdbSyncSettings": {
+      "enabled": true,
+      "filterByLocation": true,
+      "push": true,
+      "pull": true
+    }
+  },
+  {
     "id" : "test-issues-created-programatically-on-client",
     "src" : "./assets/test-issues-created-programatically-on-client/form.html",
     "description" : "Test Issues created programatically on Client",

--- a/content-sets/case-module/registration-role-1/form.html
+++ b/content-sets/case-module/registration-role-1/form.html
@@ -30,6 +30,20 @@
         caseService.setParticipantData(participantRole2.id, 'participant_id', `${getValue('participant_id')}-${role2ParticipantNumber}`)
         role2ParticipantNumber++
       }
+      caseService.createNotification(
+        `Registration success!`, 
+        `
+          Thank you for registering 
+            ${caseService.getParticipantData(participantRole1.id, 'first_name')}
+            ${caseService.getParticipantData(participantRole1.id, 'last_name')}.
+
+          We have created ${parseInt(getValue('number_of_role_2_participants_to_enroll'))} additional participants for you.
+          Please complete their registration forms.
+        `,
+        ``,
+        `thumb_up`,
+        `#b2fba5`
+      )
     }
   "
 >

--- a/content-sets/case-module/registration-role-1/form.html
+++ b/content-sets/case-module/registration-role-1/form.html
@@ -30,6 +30,9 @@
         caseService.setParticipantData(participantRole2.id, 'participant_id', `${getValue('participant_id')}-${role2ParticipantNumber}`)
         role2ParticipantNumber++
       }
+      // The parameters for caseService.createNotification() are label, description, link, icon (see https://material.io/icons), background color, 
+      // whether or not to persist more than once (true or false), and wether or not this notification should enforce attention and warn when 
+      // navigating away from the case (true or false).
       caseService.createNotification(
         `Registration success!`, 
         `
@@ -42,7 +45,9 @@
         `,
         ``,
         `thumb_up`,
-        `#b2fba5`
+        `#b2fba5`,
+        false,
+        false
       )
     }
   "

--- a/content-sets/case-module/registration-role-2/form.html
+++ b/content-sets/case-module/registration-role-2/form.html
@@ -1,6 +1,6 @@
 <tangy-form
   id="registration-role-2"
-  on-open=""
+
   on-change="
     if (getValue('consent').includes('yes')) {
       itemEnable('item2')

--- a/content-sets/case-module/resolve-an-urgent-notification/form.html
+++ b/content-sets/case-module/resolve-an-urgent-notification/form.html
@@ -1,0 +1,15 @@
+<tangy-form id="resolve-an-urgent-notification" title="Data Collector resolves urgent notification"
+  on-submit="
+    for (let notification of caseService.case.notifications) {
+      if (notification.link === window.location.hash.substr(1)) {
+        caseService.closeNotification(notification.id)
+      }
+    }
+  "
+>
+  <tangy-form-item id="item1">
+    <tangy-box name="info">
+      Submitting this form will resolve the urgent notification related to it.
+    </tangy-box>
+  </tangy-form-item>
+</tangy-form>


### PR DESCRIPTION
## Description

This PR exposes an API for on forms for creating a notification to instruct them what they need to do next.


- Fixes #2020

## Type of Change

- New feature (non-breaking change which adds functionality)


## Proposed Solution


For example, in the `on-submit` of a registration form, you could add a notification detailing what needs to be done next.

```
      caseService.createNotification(
        `Registration success!`, 
        `
          Thank you for registering 
            ${caseService.getParticipantData(participantRole1.id, 'first_name')}
            ${caseService.getParticipantData(participantRole1.id, 'last_name')}.

          We have created ${parseInt(getValue('number_of_role_2_participants_to_enroll'))} additional participants for you.
          Please complete their registration forms.
        `,
        ``,
        `thumb_up`,
        `#b2fba5`
      )
```
When the `on-submit` hook completes, the user is forwarded to the CaseEvent page where they see the notification.

<img width="855" alt="Screen Shot 2020-06-09 at 4 48 29 PM" src="https://user-images.githubusercontent.com/156575/84198671-e1877a00-aa71-11ea-8156-e11aa8a597c9.png">

## Screenshots/Videos

* [ ] Record demo

## Tests

The `case-module` content set can be used. Create a case of case-type-1. After successful completion of the user they should see a notification.

## Notices, Regressions, Breaking Changes
None.

## TODOS/enhancements
* [x] Add a "capture mode" for notifications that prevents users from navigating away until the notification is removed.
* [ ] Port feature to Editor
