### PR TITLE
Change location of case through content (for #2098)

### DIFF
--- a/content-sets/case-module/case-type-1.json
+++ b/content-sets/case-module/case-type-1.json
@@ -68,6 +68,22 @@
           "repeatable": false 
         }
       ]
+    },
+    {
+      "id": "change-location-of-case",
+      "name": "Change location of case",
+      "repeatable": true,
+      "required": false,
+      "eventFormDefinitions": [
+        {
+          "id": "event-form-definition-zibe83",
+          "formId": "change-location-of-case",
+          "forCaseRole": "role-1",
+          "name": "Change location of case",
+          "required": true,
+          "repeatable": false 
+        }
+      ]
     }
   ]
 }

--- a/content-sets/case-module/change-location-of-case/form.html
+++ b/content-sets/case-module/change-location-of-case/form.html
@@ -1,0 +1,9 @@
+<tangy-form title="Change location of case" id="change-location-of-case"
+  on-submit="
+    caseService.case.location = this.response.location
+  "
+>
+  <tangy-form-item id="item1">
+    <tangy-location label="Choose a location to assign this case to." name="location" required></tangy-location>
+  </tangy-form-item>
+</tangy-form>

--- a/content-sets/case-module/forms.json
+++ b/content-sets/case-module/forms.json
@@ -119,6 +119,34 @@
     }
   },
   {
+    "id" : "change-location-of-case",
+    "src" : "./assets/change-location-of-case/form.html",
+    "description" : "Change Location of Case",
+    "listed" : false,
+    "title" : "Change Location of Case  ",
+    "icon" : "assignment",
+    "type" : "form",
+    "searchSettings" : {
+      "shouldIndex" : false,
+      "primaryTemplate" : "",
+      "secondaryTemplate" : "",
+      "variablesToIndex" : [
+      ]
+    },
+    "customSyncSettings": {
+      "enabled": false,
+      "push": false,
+      "pull": false,
+      "excludeIncomplete":false
+    },
+    "couchdbSyncSettings": {
+      "enabled": true,
+      "filterByLocation": true,
+      "push": true,
+      "pull": true
+    }
+  },
+  {
     "id" : "test-issues-created-on-client",
     "src" : "./assets/test-issues-created-on-client/form.html",
     "description" : "Test Issues created on Client",


### PR DESCRIPTION
## Description
Sometimes a Case moves from one location to another. Sometimes a Device is not assigned to the same location it is creating a Case for (example is filling a case out over the phone). In these situations, we need a way to change the location of a case. 

This PR demonstrates how that can be done through the use of a form in the case-module content set. 

- Fixes #2098

## Type of Change

- This change requires a documentation update

## Proposed Solution
Through the use of a "Change location of case" Event and corresponding "Change location of case" form, either a Data Collector or Data Manager is able to change the location of a case. 

The "Change location of case" form has one `<tangy-location>` input who's name is "location" and is required. When the form is submitted, the `on-submit` hook of the form is called which assigns the location selected to `caseService.case.location`. 

## Limitations and Trade-offs
The proposed solution is a "Content Approach". Another approach to this might involve an "App Approach" where we develop feature that exposes a UI for changing the location of a case. 

- One could argue that we could achieve better UX with the App level approach. One could also argue that this approach has better UX because it does not use an additional UI paradigm for the user to learn, they will already be familiar with creating events and filling out forms. 
- Another possible advantage of the "Content Approach" over the "App Approach" is we would have a clear way of seeing when the location changed by scanning the events list. 
- An advantage of the App Approach is it would be less content for the Form Developers to have to create and  maintain.

## Screenshots/Videos

![Jun-10-2020 13-20-30](https://user-images.githubusercontent.com/156575/84298713-8ad77a00-ab1d-11ea-8b7a-cfc0579e9692.gif)



## Tests

Load the case-module case set. Create a case of Case Type 1. Fill out registration form. Create a "Change case location" event. Open the "Change case location" form. Fill out new location and submit form. caseService.case.location should now reflect that location selected.


