### PR TITLE
Device Manager installs many Tangerine APKs on a single device (for #2182)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,5 +58,13 @@ There is no template for this one but make sure to add the `technical` label.
 - Maintainer prepares for a new version by creating a Milestone and adding a place for the release in the `CHANGELOG.md` in the `next` branch.
 - Issues are assigned to the Milestone. 
 - When you are assigned an issue, create a branch based on the `next` branch named after the issue number and description, something like `1325-fix-some-bug`. Put the PR in the milestone, link to the corresponding issue from the PR and mark issue as "in progress".
+- As time progresses while developing your feature, keep your code up-to-date with changes in the next and (after feature freeze) release/v-feature-number branches. The [Gitflow docs](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) explain this process in greater detail. (Main difference - we call the Git Flow 'dev' branch - in our nomenclature - the 'next'branch.)
+  
+  Git commands to keep your branch in-sync:
+  ```shell script
+    git pull
+    git merge release/v3.x.x # (if currently in feature freeze)
+    git merge next
+  ```
 - When your PR is ready, add notes to the `CHANGELOG.md` file in your branch and request a review.
 - After code review, if code is merged, the Maintainer will tag the next branch with a prerelease tag and mark corresponding issue with "review" tag for QA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,9 @@ There is no template for this one but make sure to add the `technical` label.
   
   Git commands to keep your branch in-sync:
   ```shell script
-    git pull
-    git merge release/v3.x.x # (if currently in feature freeze)
-    git merge next
+    git fetch origin
+    git merge origin/release/v3.x.x # (if currently in feature freeze)
+    git merge origin/next  
   ```
 - When your PR is ready, add notes to the `CHANGELOG.md` file in your branch and request a review.
 - After code review, if code is merged, the Maintainer will tag the next branch with a prerelease tag and mark corresponding issue with "review" tag for QA.

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -44,6 +44,8 @@ log.info('heartbeat')
 setInterval(() => log.info('heartbeat'), 5*60*1000)
 var cookieParser = require('cookie-parser');
 const { getPermissionsList } = require('./permissions-list.js');
+const PACKAGENAME = "org.rti.tangerine"
+const APPNAME = "Tangerine"
 
 module.exports = async function expressAppBootstrap(app) {
 
@@ -201,7 +203,10 @@ app.use('/editor/release-apk/:group/:releaseType', isAuthenticated, async functi
   // @TODO Make sure user is member of group.
   const group = sanitize(req.params.group)
   const releaseType = sanitize(req.params.releaseType)
-  const cmd = `cd /tangerine/server/src/scripts && ./release-apk.sh ${group} /tangerine/client/content/groups/${group} ${releaseType} ${process.env.T_PROTOCOL} ${process.env.T_HOST_NAME} 2>&1 | tee -a /apk.log`
+  const config = JSON.parse(await fs.readFile(`/tangerine/client/content/groups/${group}/app-config.json`, "utf8"));
+  const packageName = config.packageName? config.packageName: PACKAGENAME
+  const appName = config.appName ? config.appName: APPNAME
+  const cmd = `cd /tangerine/server/src/scripts && ./release-apk.sh ${group} /tangerine/client/content/groups/${group} ${releaseType} ${process.env.T_PROTOCOL} ${process.env.T_HOST_NAME} ${packageName} "${appName}" 2>&1 | tee -a /apk.log`
   log.info("in release-apk, group: " + group + " releaseType: " + releaseType + ` The command: ${cmd}`)
   // Do not await. The browser just needs to know the process has started and will monitor the status file.
   exec(cmd).catch(log.error)

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -5,6 +5,9 @@ CONTENT_PATH="$2"
 RELEASE_TYPE="$3"
 T_PROTOCOL="$4"
 T_HOST_NAME="$5"
+PACKAGE="$6"
+APPNAME="$7"
+APPNAME_REPLACE="<name>${7}"
 CORDOVA_DIRECTORY="/tangerine/client/builds/apk"
 RELEASE_DIRECTORY="/tangerine/client/releases/$RELEASE_TYPE/apks/$GROUP"
 STATUS_FILE="/tangerine/client/releases/$RELEASE_TYPE/apks/$GROUP.json"
@@ -57,6 +60,12 @@ cd $RELEASE_DIRECTORY
 
 # replace the URL property in config.xml
 sed -i -e "s#CHCP_URL#"$CHCP_URL"#g" $RELEASE_DIRECTORY/config.xml
+
+# replace the package id value in config.xml
+sed -i -e "s#org.rti.tangerine#"$PACKAGE"#g" $RELEASE_DIRECTORY/config.xml
+
+# replace the app name value in config.xml
+sed -i -e s#"<name>Tangerine"#"${APPNAME_REPLACE}"#g $RELEASE_DIRECTORY/config.xml
 
 echo "Copying cordova-hcp.json $RELEASE_DIRECTORY"
 cp /tangerine/client/android-tools/cordova-hot-code-push/cordova-hcp-template.json $RELEASE_DIRECTORY/cordova-hcp.json


### PR DESCRIPTION
## Description

Add packageName and appName to appConfig.json to customize APK package and name. 

```
  "packageName": "org.rti.tangerine.boop",
  "appName": "TangerineBoop Prime"
```

This enables use of more than on APK on a device.
---

[What is the business, user experience or technical problem? What is the motivation or context? Any Dependencies required for the change? e.g `tangy-forms` version etc]
[List the issues fixed and any other relevant issues]

- Fixes #2182

## Type of Change

[Please delete irrelevant options]

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

Added optional packageName and appName properties to appConfig.json. Defaults are in express-app.js. 

```
const PACKAGENAME = "org.rti.tangerine"
const APPNAME = "Tangerine"
```

