### PR TITLE
Group permissions

### DIFF
--- a/editor/src/app/core/auth/_components/manage-sitewide-permissions/manage-sitewide-permissions.component.ts
+++ b/editor/src/app/core/auth/_components/manage-sitewide-permissions/manage-sitewide-permissions.component.ts
@@ -25,7 +25,7 @@ export class ManageSitewidePermissionsComponent implements OnInit {
     this.username = this.username = this.route.snapshot.paramMap.get('username')
     const permissions = await this.authenticationService.getPermissionsList()
     this.permissionsList = permissions['sitewidePermissions'];
-    this.userPermissions = await this.authenticationService.getUserPermissions(this.username)
+    this.userPermissions = await this.authenticationService.getSitewidePermissionsByUsername(this.username)
   }
   doesUserHavePermission(permission) {
     return this.userPermissions.sitewidePermissions.indexOf(permission) >= 0

--- a/editor/src/app/core/auth/_services/authentication.service.ts
+++ b/editor/src/app/core/auth/_services/authentication.service.ts
@@ -15,15 +15,7 @@ export class AuthenticationService {
      const data = await this.http.post('/login', {username, password}, {observe: 'response'}).toPromise();
       if (data.status === 200) {
         const token = data.body['data']['token'];
-        const jwtData = jwt_decode(token);
-        document.cookie = `Authorization=${token}`
-        localStorage.setItem('token', token);
-        localStorage.setItem('user_id', jwtData.username);
-        localStorage.setItem('permissions', JSON.stringify(jwtData.permissions));
-        const user = await this.userService.getMyUser()
-        window['userProfile'] = user 
-        window['userId'] = user._id 
-        window['username'] = jwtData.username
+        await this.setTokens(token);
         return true;
       } else {
         return false;
@@ -65,12 +57,7 @@ export class AuthenticationService {
       const data = await this.http.post('/extendSession', {username}, {observe: 'response'}).toPromise();
       if (data.status === 200) {
         const token = data.body['data']['token'];
-        const jwtData = jwt_decode(token);
-        document.cookie = "Authorization=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
-        document.cookie = `Authorization=${token}`
-        localStorage.setItem('token', token);
-        localStorage.setItem('user_id', jwtData.username);
-        localStorage.setItem('permissions', JSON.stringify(jwtData.permissions));
+       await this.setTokens(token);
         return true;
       } else {
         return false;
@@ -80,6 +67,18 @@ export class AuthenticationService {
     }
   }
 
+  async setTokens(token) {
+    const jwtData = jwt_decode(token);
+    document.cookie = "Authorization=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    document.cookie = `Authorization=${token}`;
+    localStorage.setItem('token', token);
+    localStorage.setItem('user_id', jwtData.username);
+    localStorage.setItem('permissions', JSON.stringify(jwtData.permissions));
+    const user = await this.userService.getMyUser();
+    window['userProfile'] = user;
+    window['userId'] = user._id;
+    window['username'] = jwtData.username;
+  }
   async getPermissionsList() {
     try {
       const data = await this.http.get('/permissionsList', {observe: 'response'}).toPromise();

--- a/editor/src/app/core/auth/_services/authentication.service.ts
+++ b/editor/src/app/core/auth/_services/authentication.service.ts
@@ -91,9 +91,9 @@ export class AuthenticationService {
       return {groupPermissions: [], sitewidePermissions: []}
     }
   }
-  async getUserPermissions(username) {
+  async getSitewidePermissionsByUsername(username) {
     try {
-      const data = await this.http.get(`/permissions/${username}`, {observe: 'response'}).toPromise();
+      const data = await this.http.get(`/sitewidePermissionsByUsername/${username}`, {observe: 'response'}).toPromise();
       if (data.status === 200) {
         return data.body;
       }

--- a/editor/src/app/core/auth/_services/authentication.service.ts
+++ b/editor/src/app/core/auth/_services/authentication.service.ts
@@ -131,4 +131,21 @@ export class AuthenticationService {
       return {groupPermissions:[], sitewidePermissions:[]}
     }
   }
+
+  doesUserHaveAPermission(groupId, permission) {
+    const allGroupsPermissions = JSON.parse(localStorage.getItem('permissions'))?.groupPermissions ?? [];
+    const groupPermissions = (allGroupsPermissions.find(group => group.groupName === groupId)).permissions;
+    return groupPermissions.includes(permission);
+  }
+  doesUserHaveAllPermissions(groupId, permissions= []) {
+    const allGroupsPermissions = JSON.parse(localStorage.getItem('permissions'))?.groupPermissions ?? [];
+    const groupPermissions = (allGroupsPermissions.find(group => group.groupName === groupId)).permissions;
+    return permissions.every(e => groupPermissions.includes(e));
+  }
+
+  doesUserHaveSomePermissions(groupId, permissions) {
+    const allGroupsPermissions = JSON.parse(localStorage.getItem('permissions'))?.groupPermissions ?? [];
+    const groupPermissions = (allGroupsPermissions.find(group => group.groupName === groupId)).permissions;
+    return permissions.some(e => groupPermissions.includes(e));
+  }
 }

--- a/editor/src/app/core/auth/_services/authentication.service.ts
+++ b/editor/src/app/core/auth/_services/authentication.service.ts
@@ -101,6 +101,24 @@ export class AuthenticationService {
       return {groupPermissions:[], sitewidePermissions:[]}
     }
   }
+
+  async getUserGroupPermissionsByGroupName(groupName) {
+    try {
+      const data = await this.http.get(`/users/groupPermissionsByGroupName/${groupName}`, {observe: 'response'}).toPromise();
+      if (data.status === 200) {
+        const token = data.body['data']['token'];
+        await this.setTokens(token);
+        return true;
+      }
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  }
+
+  setUserGroupPermissionsByGroupName(groupName) {
+
+  }
   async updateUserPermissions(username, sitewidePermissions) {
     try {
       const data = await this.http.

--- a/editor/src/app/groups/group/group.component.ts
+++ b/editor/src/app/groups/group/group.component.ts
@@ -2,7 +2,7 @@ import { Breadcrumb } from './../../shared/_components/breadcrumb/breadcrumb.com
 import { GroupsService } from './../services/groups.service';
 import { Component, OnInit } from '@angular/core';
 import { UserService } from 'src/app/core/auth/_services/user.service';
-import { NgxPermissionsService } from 'ngx-permissions';
+import { AuthenticationService } from 'src/app/core/auth/_services/authentication.service';
 
 
 @Component({
@@ -15,24 +15,53 @@ export class GroupComponent implements OnInit {
   title:string = ''
   breadcrumbs:Array<Breadcrumb>
   isAdminUser = false
-
+  group
   constructor(
     private groupsService: GroupsService,
-    private userService:UserService,
-    private permissionsService:NgxPermissionsService
+    private userService: UserService,
+    private authenticationService: AuthenticationService
   ) {}
 
   async ngOnInit() {
     this.isAdminUser = await this.userService.isCurrentUserAdmin()
-    const group = await this.groupsService.getGroupInfo(window.location.hash.split('/')[2])
-    this.title = group.label
+    this.group = await this.groupsService.getGroupInfo(window.location.hash.split('/')[2])
+    this.title = this.group.label
     this.breadcrumbs = []
-    const allPermissions = JSON.parse(localStorage.getItem('permissions'));
-    const groupPermissions = allPermissions.groupPermissions;
-    const permissions = groupPermissions.find(permission=>permission.groupName===group._id)
-    this.permissionsService.addPermission(permissions.permissions)
-    this.permissionsService.addPermission(allPermissions.sitewidePermissions)
+    await this.authenticationService.getUserGroupPermissionsByGroupName(this.group._id);
+  }
+/**
+ * Check if a user has a specific permission in a specific group
+ * @param permission A string containing the permission that a user must have on the group in order to access the resource
+ * @return boolean
+ *  @example ```<div *ngIf="hasAPermission('can_manage_group_deployment')"></div>```
+ *
+ * This div will only be shown if the user has the`can_manage_group_deployment` permission for this group
+ */
+  hasAPermission(permission: string) {
+    return this.authenticationService.doesUserHaveAPermission(this.group._id, permission);
   }
 
 
+/**
+ * @param permissions an array of strings with permissions required to access the resource.
+ *  A user must have all the specified permissions in order to access the resource
+ * @return boolean
+ * @example ```<div *ngIf="hasAllPermissions(['can_manage_group_deployment','can_deploy_apk'])"></div>```
+ * This div will only be shown only if the user has the 'can_manage_group_deployment' and 'can_deploy_apk' permissions on this group
+ */
+  hasAllPermissions(permissions: string[]) {
+    return this.authenticationService.doesUserHaveAllPermissions(this.group._id, permissions);
+  }
+
+
+/**
+ * @param permissions an array of strings with permissions required to access the resource.
+ *  A user must have at least one of  the specified permissions in order to access the resource
+ * @return boolean
+ * @example ```<div *ngIf="hasSomePermissions(['can_manage_group_deployment','can_deploy_apk'])"></div>```
+ * This div will only be shown if the user has either 'can_manage_group_deployment' or 'can_deploy_apk' permissions on this group
+ */
+  hasSomePermissions(permissions: string[]) {
+    return this.authenticationService.doesUserHaveSomePermissions(this.group._id, permissions);
+  }
 }

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -134,6 +134,7 @@ app.get('/users/isAdminUser/:username', isAuthenticated, isUserAnAdminUser);
 app.patch('/users/restore/:username', isAuthenticated, permit(['can_edit_users']), restoreUser);
 app.delete('/users/delete/:username', isAuthenticated, permit(['can_edit_users']), deleteUser);
 app.put('/users/update/:username', isAuthenticated, permit(['can_edit_users']), updateUser);
+app.get('/users/groupPermissionsByGroupName/:groupName', isAuthenticated, getUserGroupPermissionsByGroupName);
 
 /*
  * More API

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -37,9 +37,12 @@ const junk = require('junk');
 const cors = require('cors')
 const sep = path.sep;
 const tangyModules = require('./modules/index.js')()
-const {doesUserExist, extendSession, findUserByUsername, isSuperAdmin,
-   USERS_DB, login, getUserPermissions, updateUserSiteWidePermissions} = require('./auth');
-const {registerUser,  getUserByUsername, isUserSuperAdmin, isUserAnAdminUser, getGroupsByUser, deleteUser, getAllUsers, checkIfUserExistByUsername, findOneUserByUsername, findMyUser, updateUser, restoreUser, updateMyUser} = require('./users');
+const { extendSession, findUserByUsername,
+   USERS_DB, login, getSitewidePermissionsByUsername,
+   updateUserSiteWidePermissions, getUserGroupPermissionsByGroupName} = require('./auth');
+const {registerUser,  getUserByUsername, isUserSuperAdmin, isUserAnAdminUser, getGroupsByUser, deleteUser,
+   getAllUsers, checkIfUserExistByUsername, findOneUserByUsername,
+   findMyUser, updateUser, restoreUser, updateMyUser} = require('./users');
 log.info('heartbeat')
 setInterval(() => log.info('heartbeat'), 5*60*1000)
 var cookieParser = require('cookie-parser');
@@ -111,7 +114,8 @@ app.get('/login/validate/:userName',
 );
 app.post('/extendSession', isAuthenticated, extendSession);
 app.get('/permissionsList', isAuthenticated, permit(['can_manage_users_site_wide_permissions']), getPermissionsList);
-app.get('/permissions/:username', isAuthenticated, permit(['can_manage_users_site_wide_permissions']), getUserPermissions);
+app.get('/sitewidePermissionsByUsername/:username', 
+          isAuthenticated, permit(['can_manage_users_site_wide_permissions']), getSitewidePermissionsByUsername);
 app.post('/permissions/updateUserSitewidePermissions:username/:username', isAuthenticated, permit(['can_manage_users_site_wide_permissions']), updateUserSiteWidePermissions);
 
 /*

--- a/server/src/middleware/permitted.js
+++ b/server/src/middleware/permitted.js
@@ -8,6 +8,62 @@ const permit = (allowedPermissions) => {
       }
     };
   };
+
+const permitOnGroupIfAll = (permissions) => {
+  console.log(permissions)
+  const isAllowed = groupPermissions => permissions.every(e => groupPermissions.includes(e));
+  return (req, res, next) => {
+    try {
+      const group = req.params.groupId || req.params.groupName || req.params.group;
+      const allGroupsPermissions = req.user.groupPermissions;
+      const myGroupsPermissions = (allGroupsPermissions.find(g => g.groupName === group)).permissions;
+      if (isAllowed(myGroupsPermissions)) {
+        next();
+      } else {
+        res.status(403).send(`Access Denied at ${req.url}`);
+      }
+    } catch (error) {
+      res.status(403).send(`Access Denied at ${req.url}`);
+    }
+  };
+};
+const permitOnGroupIfEither = (permissions) => {
+  const isAllowed = groupPermissions => (permissions.some(e => groupPermissions.includes(e)));
+  return (req, res, next) => {
+    try {
+      const group = req.params.groupId || req.params.groupName || req.params.group;
+      const allGroupsPermissions = req.user.groupPermissions;
+      const myGroupsPermissions = (allGroupsPermissions.find(g => g.groupName === group)).permissions;
+      if (isAllowed(myGroupsPermissions)) {
+        next();
+      } else {
+        res.status(403).send(`Access Denied at ${req.url}`);
+      }
+    } catch (error) {
+      res.status(403).send(`Access Denied at ${req.url}`);
+    }
+  };
+};
+const permitOnGroupIf = (permission) => {
+  const isAllowed = groupPermissions => groupPermissions.includes(permission);
+  return (req, res, next) => {
+    try {
+      const group = req.params.groupId || req.params.groupName || req.params.group;
+      const allGroupsPermissions = req.user.groupPermissions;
+      const myGroupsPermissions = (allGroupsPermissions.find(g => g.groupName === group)).permissions;
+      if (isAllowed(myGroupsPermissions)) {
+        next();
+      } else {
+        res.status(403).send(`Access Denied at ${req.url}`);
+      }
+    } catch (error) {
+      res.status(403).send(`Access Denied at ${req.url}`);
+    }
+  };
+};
 module.exports = {
   permit,
+  permitOnGroupIf,
+  permitOnGroupIfAll,
+  permitOnGroupIfEither,
 };


### PR DESCRIPTION
## Description

---

* Group users should be able to only access the parts of the app that the y have permissions to. 
* This should be restricted at
    1. The Angular router level
    2. The visibility of elements in a given component
    3. The API route for a given resource

- Fixes #2133 

## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---

* Create api middleware that enforces for permissions at the route level for a given resource. The middleware can be used to pass in:
    1. a single required permission
    1. an array or required permissions i.e. the user must have all the permissions specified in the middleware for a specific group in order to access a resource
    1.  an array of optional permissions i.e. the user has at least one of the permissions for the specific group

* Create helper functions to be used at the ui layer which allow us to define:

    1. a single required permission i.e the user must have the specified permission in order to access a given resource
    1. an array or required permissions i.e. the user must have all the permissions specified in the middleware for a specific group in order to access a resource
    1.  an array of optional permissions i.e. the user has at least one of the permissions for the specific group

## Limitations and Trade-offs
* Currently, at the UI layer, we have to expose the service that checks for the permissions on each component where we want to use the various helper functions

## TODOS/enhancements

---
- Extract the UI permission helpers into angular directives that are aware of the group's context
- Normalize how we name route params on the server-side. Currently we have `groupId`, `group` and `groupName` all representing the same thing. We should use one in order to make checking for the group's ID consistent and safe
