### PR TITLE
Fix broken module links in custom scripts for apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install global node dependencies
-RUN npm install -g nodemon uuid
+RUN npm install -g nodemon uuid webpack-cli webpack
 
 # T_USER1 is the username of the first user you will log in as. It is also the super user that has all permissions. 
 ENV T_USER1 user1

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,6 @@ ADD client /tangerine/client
 RUN cd /tangerine/client && \
     ./node_modules/.bin/ng build --base-href "./"
 
-# Modify links to javascript modules (Angular 8 work-around)
-RUN sed -i 's/type="module"/type="text\/javascript"/g' /tangerine/client/dist/tangerine-client/index.html
-
 # Build PWA tools.
 RUN cd /tangerine/client/pwa-tools/updater-app && \
     npm run build && \
@@ -73,6 +70,9 @@ RUN cd /tangerine/client && \
     cp -r pwa-tools/updater-app/build/default builds/pwa && \
     mkdir builds/pwa/release-uuid && \
     cp -r dist/tangerine-client builds/pwa/release-uuid/app
+
+# Modify links to javascript modules because they won't work in an APK (Angular 8 work-around)
+RUN sed -i 's/type="module"/type="text\/javascript"/g' /tangerine/client/builds/apk/www/shell/index.html
 
 # Add the rest of server.
 ADD server /tangerine/server

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -52,6 +52,12 @@ rm -rf $RELEASE_DIRECTORY/www/shell/assets
 cp -r $CONTENT_PATH $RELEASE_DIRECTORY/www/shell/assets
 cp /tangerine/logo.svg $RELEASE_DIRECTORY/www/
 
+CUSTOM_SCRIPTS_PATH="$CONTENT_PATH $RELEASE_DIRECTORY/www/shell/assets/custom-scripts.js"
+if [ -f "$CUSTOM_SCRIPTS_PATH" ]; then
+  webpack $CUSTOM_SCRIPTS_PATH -o "$CUSTOM_SCRIPTS_PATH.tmp"
+  mv "$CUSTOM_SCRIPTS_PATH.tmp" $CUSTOM_SCRIPTS_PATH 
+fi
+
 # Stash the Build ID in the release.
 echo $BUILD_ID > $RELEASE_DIRECTORY/www/shell/assets/tangerine-build-id 
 echo $RELEASE_TYPE > $RELEASE_DIRECTORY/www/shell/assets/tangerine-build-channel

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -52,7 +52,7 @@ rm -rf $RELEASE_DIRECTORY/www/shell/assets
 cp -r $CONTENT_PATH $RELEASE_DIRECTORY/www/shell/assets
 cp /tangerine/logo.svg $RELEASE_DIRECTORY/www/
 
-CUSTOM_SCRIPTS_PATH="$CONTENT_PATH $RELEASE_DIRECTORY/www/shell/assets/custom-scripts.js"
+CUSTOM_SCRIPTS_PATH="$RELEASE_DIRECTORY/www/shell/assets/custom-scripts.js"
 if [ -f "$CUSTOM_SCRIPTS_PATH" ]; then
   webpack $CUSTOM_SCRIPTS_PATH -o "$CUSTOM_SCRIPTS_PATH.tmp"
   mv "$CUSTOM_SCRIPTS_PATH.tmp" $CUSTOM_SCRIPTS_PATH 


### PR DESCRIPTION
In `./assets/custom-scripts.js`, we now do things like `import './some-component.js`. However, that's not allowed  by browsers in an APK because the app is at `file://`. This PR webpack compiles `custom-scripts.js` into one file so that browsers no longer complain.