### PR TITLE
Don't add user-profile to the sanitized db CSV output

### DIFF
--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -69,10 +69,7 @@ module.exports = {
           // @TODO Rename `-reporting` to `-csv`.
           REPORTING_DB = new DB(`${sourceDb.name}-reporting-sanitized`);
           processedResult = flatResponse
-          // Don't add user-profile to the user-profile
-          if (flatResponse.formId !== 'user-profile') {
-            processedResult = await attachUserProfile(processedResult, REPORTING_DB, sourceDb, locationList)
-          }
+          // Don't add user-profile to the sanitized db
           // @TODO Ensure design docs are in the database.
           await saveFormInfo(processedResult, REPORTING_DB);
           await saveFlatFormResponse(processedResult, REPORTING_DB);
@@ -121,7 +118,7 @@ const generateFlatResponse = async function (formResponse, locationList, sanitiz
     tangerineModifiedByUserId: formResponse.tangerineModifiedByUserId,
     ...formResponse.caseId ? {
       caseId: formResponse.caseId,
-      caseEventId: formResponse.caseEventId,
+      eventId: formResponse.eventId,
       eventFormId: formResponse.eventFormId,
       participantId: formResponse.participantId || ''
     } : {}


### PR DESCRIPTION
Don't add user-profile to the sanitized db CSV output
Save eventId instead of caseEventId to flatFormResponse.

## Description

- Fixes #IssueNumber

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

