### PR TITLE
Implemented device sheets

### DIFF
--- a/client/src/app/sync/sync-custom.service.ts
+++ b/client/src/app/sync/sync-custom.service.ts
@@ -65,6 +65,9 @@ export class SyncCustomService {
     // TODO, only for custom protocol I think.
   }
 
+  /*
+  Generates a list of docIds by querying sync-queue with an array of keys with properties: [needsUploading, formId, isComplete]
+   */
   async uploadQueue(userDb:UserDatabase, formInfos:Array<FormInfo>) {
     let queryKeys = formInfos.reduce((queryKeys, formInfo) => {
       if (formInfo.customSyncSettings.enabled && formInfo.customSyncSettings.push) {

--- a/editor/src/app/groups/group-device-sheet/group-device-sheet.component.css
+++ b/editor/src/app/groups/group-device-sheet/group-device-sheet.component.css
@@ -1,0 +1,11 @@
+table {
+  width: 100%
+}
+
+.qrcode-div {
+  margin: 1em;
+}
+
+@media print {
+  table {page-break-after: always;}
+}

--- a/editor/src/app/groups/group-device-sheet/group-device-sheet.component.html
+++ b/editor/src/app/groups/group-device-sheet/group-device-sheet.component.html
@@ -1,0 +1,14 @@
+<h1>{{'Devices'|translate}}</h1>
+<div *ngFor="let devices of tableArray;let i = index;">
+  <table mat-table [dataSource]="devices" class="mat-elevation-z8">
+    <ng-container matColumnDef="desc">
+      <td mat-cell *matCellDef="let element" [innerHTML]="element.desc" width="60%"></td>
+    </ng-container>
+    <ng-container matColumnDef="qr-code">
+      <td mat-cell *matCellDef="let element">
+        <div class="qrcode-div" [innerHTML]="element.qrSvg"></div>
+      </td>
+    </ng-container>
+    <tr mat-row *matRowDef="let row; columns: devicesDisplayedColumns;"></tr>
+  </table>
+</div>

--- a/editor/src/app/groups/group-device-sheet/group-device-sheet.component.spec.ts
+++ b/editor/src/app/groups/group-device-sheet/group-device-sheet.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GroupDeviceSheetComponent } from './group-device-sheet.component';
+
+describe('GroupDeviceSheetComponent', () => {
+  let component: GroupDeviceSheetComponent;
+  let fixture: ComponentFixture<GroupDeviceSheetComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GroupDeviceSheetComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupDeviceSheetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/editor/src/app/groups/group-device-sheet/group-device-sheet.component.ts
+++ b/editor/src/app/groups/group-device-sheet/group-device-sheet.component.ts
@@ -1,0 +1,134 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {_TRANSLATE} from "../../shared/_services/translation-marker";
+import {GroupDevicesService} from "../services/group-devices.service";
+import {ActivatedRoute} from "@angular/router";
+import {GroupsService} from "../services/groups.service";
+import {HttpClient} from "@angular/common/http";
+import { Loc } from 'tangy-form/util/loc.js';
+import * as qrcode from 'qrcode-generator-es6';
+import * as moment from 'moment'
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+interface LocationNode {
+  level:string
+  value:string
+}
+
+interface VersionStat {
+  id:string
+  percentage:number
+}
+interface DeviceInfo {
+  group:string
+  qrSvg:SafeHtml
+  desc:string
+}
+@Component({
+  selector: 'app-group-device-sheet',
+  templateUrl: './group-device-sheet.component.html',
+  styleUrls: ['./group-device-sheet.component.css']
+})
+export class GroupDeviceSheetComponent implements OnInit {
+
+  title = _TRANSLATE("Devices")
+  deviceInfos:Array<DeviceInfo> = []
+  versionStats:Array<VersionStat>
+  flatLocationList
+  locationFilter:Array<LocationNode> = []
+  devicesDisplayedColumns = ['desc', 'qr-code']
+  tableArray = []
+  group:any
+
+  @Input('groupId') groupId:string
+
+  constructor(
+    private route: ActivatedRoute,
+    private httpClient:HttpClient,
+    private groupsService:GroupsService,
+    private groupDevicesService:GroupDevicesService,
+    private sanitizer: DomSanitizer
+  ) { }
+
+  ngOnInit(): void {
+    this.route.params.subscribe(async params => {
+      this.groupId = params.groupId
+      this.group = await this.groupsService.getGroupInfo(params.groupId)
+      //this.menuService.setContext(group.label, 'Deploy', 'deploy', group._id)
+      const locationList = await this.httpClient.get('./assets/location-list.json').toPromise()
+      this.flatLocationList = Loc.flatten(locationList)
+      //this.locationEl.nativeElement.addEventListener('change', (event) => this.onLocationSelection(event.target.value))
+      await this.listDevices()
+    })
+  }
+
+  async listDevices() {
+    const devices = await this.groupDevicesService.list(this.groupId)
+    const countsByVersion = devices
+      .reduce((countsByVersion, device) => {
+        countsByVersion[device.version] = countsByVersion[device.version]
+          ? countsByVersion[device.version]++
+          : 1
+        return countsByVersion
+      }, {})
+    this.versionStats = Object.keys(countsByVersion)
+      .reduce((versionStats, versionId) => {
+        return [
+          ...versionStats,
+          {
+            id: versionId,
+            percentage: countsByVersion[versionId] / devices.length
+          }
+        ]
+      }, [])
+    this.deviceInfos = devices
+      .sort(function (a, b) {
+        return !a.registeredOn ? -1 : !b.registeredOn ? 1 : b.registeredOn - a.registeredOn;
+      })
+      .filter(device => {
+        return this.locationFilter
+          .filter(node => !!node.value)
+          .reduce((matchesAll, node) => {
+            return device.assignedLocation.value.find(n => n.level === node.level) && device.assignedLocation.value.find(n => n.level === node.level).value === node.value
+              ? true
+              : false
+          }, true)
+      })
+      .map(device => {
+        const qr = new qrcode.default(0, 'H')
+        qr.addData(`{"id":"${device._id}","token":"${device.token}"}`)
+        qr.make()
+        const qrCode = qr.createSvgTag({cellSize:500, margin:0,cellColor:(c, r) =>''})
+        let svg:SafeHtml;
+        svg = this.sanitizer.bypassSecurityTrustHtml(qrCode);
+        const loc =  device.assignedLocation.value ? device.assignedLocation.value.map(value => `<b>${value.level}</b>: ${this.flatLocationList.locations.find(node => node.id === value.value).label}`).join('<br>') : ''
+        const description = `<p>${this.group.label}</p><p>${device._id.substr(0,6)}</p><p>${loc}</p>`
+        return <DeviceInfo>{
+          ...device,
+          group: this.group.name,
+          desc: description,
+          qrSvg: svg
+        }
+      })
+    let currentDeviceInfoArray:Array<DeviceInfo> = []
+    if (this.deviceInfos.length > 0 && this.deviceInfos.length < 4) {
+      this.tableArray.push(this.deviceInfos)
+    } else {
+      this.deviceInfos.forEach((deviceInfo, index) => {
+        if ((index+1) % 3 === 0) {
+          currentDeviceInfoArray.push(deviceInfo)
+          this.tableArray.push(currentDeviceInfoArray)
+          currentDeviceInfoArray = []
+        } else {
+          currentDeviceInfoArray.push(deviceInfo)
+          if ((index+1) == this.deviceInfos.length) {
+            this.tableArray.push(currentDeviceInfoArray)
+          }
+        }
+      })
+    }
+    // console.log("tableArray: " + JSON.stringify(this.tableArray))
+  }
+
+
+
+}

--- a/editor/src/app/groups/group-devices/group-devices.component.css
+++ b/editor/src/app/groups/group-devices/group-devices.component.css
@@ -15,3 +15,9 @@ mat-table {
 .location-cell {
   padding: 5px;
 }
+.device-sheet-btn {
+  position: relative;
+  top: -60px;
+  float: right;
+  margin-right: 1em;
+}

--- a/editor/src/app/groups/group-devices/group-devices.component.html
+++ b/editor/src/app/groups/group-devices/group-devices.component.html
@@ -1,4 +1,11 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
+<div class="device-sheet-btn">
+  <a routerLink="../device-sheet">
+    <button mat-raised-button color="accent">
+      Export Device Sheet
+    </button>
+  </a>
+</div>
     <mat-table [dataSource]="deviceInfos" class="mat-elevation-z8">
       <ng-container matColumnDef="id">
         <mat-header-cell *matHeaderCellDef> ID </mat-header-cell>

--- a/editor/src/app/groups/groups-routing.module.ts
+++ b/editor/src/app/groups/groups-routing.module.ts
@@ -48,6 +48,10 @@ import { AddRoleToGroupComponent } from '../core/auth/_components/add-role-to-gr
 import { UpdateGroupRolesComponent } from '../core/auth/_components/update-group-roles/update-group-roles.component';
 import { AddUserToAGroupComponent } from '../core/auth/_components/add-user-to-a-group/add-user-to-a-group.component';
 import { UpdateUserRoleComponent } from '../core/auth/_components/update-user-role/update-user-role.component';
+import { GroupDeviceSheetComponent } from './group-device-sheet/group-device-sheet.component';
+import {MatTableModule} from "@angular/material/table";
+import {CommonModule} from "@angular/common";
+import {TranslateModule} from "@ngx-translate/core";
 
 const groupsRoutes: Routes = [
   // { path: 'projects', component: GroupsComponent },
@@ -83,6 +87,7 @@ const groupsRoutes: Routes = [
   { path: 'groups/:groupId/deploy/device-users', component: GroupDeviceUsersComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/device-users/:responseId', component: GroupDeviceUserComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/devices', component: GroupDevicesComponent, canActivate: [LoginGuard] },
+  { path: 'groups/:groupId/deploy/device-sheet', component: GroupDeviceSheetComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/releases', component: GroupReleasesComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/releases/release-pwa-test', component: GroupReleasePwaTestComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/releases/release-pwa-live', component: GroupReleasePwaLiveComponent, canActivate: [LoginGuard] },
@@ -111,10 +116,14 @@ const groupsRoutes: Routes = [
 ];
 @NgModule({
   imports: [
-    RouterModule.forChild(groupsRoutes)
+    RouterModule.forChild(groupsRoutes),
+    MatTableModule,
+    CommonModule,
+    TranslateModule
   ],
   exports: [
     RouterModule
-  ]
+  ],
+  declarations: [GroupDeviceSheetComponent]
 })
 export class GroupsRoutingModule { }


### PR DESCRIPTION
## Description

User clicks "Export Device sheet" button on Device listing and views listing of devices with barcodes. 3 devices per page when printed.

- Fixes #2269

## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

