### PR TITLE
Fix group refresh token

### DIFF
--- a/server/src/auth.js
+++ b/server/src/auth.js
@@ -126,10 +126,10 @@ const hashPassword = async password => {
 const extendSession = async (req, res) => {
   const { username } = req.body;
   let permissions;
-  if (!req.params.groupName) {
+  if (req.user.groupPermissions.length <= 0) {
     permissions = await getSitewidePermissions(username);
   } else {
-    permissions = await getGroupAndSitewidePermissions(username, req.params.groupName);
+    permissions = await getGroupAndSitewidePermissions(username, req.user.groupPermissions[0].groupName);
   }
   const token = createLoginJWT({ username, permissions });
   return res.status(200).send({ data: { token } });


### PR DESCRIPTION
## Description

---

When a user extends their session within the group context, the user's group permissions should also be part of the new token.
- Closes https://github.com/Tangerine-Community/Tangerine/issues/2266
## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

For any session extensions within the group context, add the group's permissions

