### PR TITLE
Add support for an easy to set up SSL frontend

### DIFF
--- a/.proxy-conf
+++ b/.proxy-conf
@@ -1,0 +1,10 @@
+server {
+    listen              443 ssl;
+    server_name         ${T_HOST_NAME};
+    ssl_certificate     /etc/letsencrypt/live/${T_HOST_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${T_HOST_NAME}/privkey.pem;
+
+    location / {
+      proxy_pass http://tangerine/;
+    }
+}

--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -12,8 +12,8 @@
 
 # Domain name of the Tangerine installation.
 T_HOST_NAME='example.com'
-# Set to HTTPS for redirecting any requests to https. However you will need to put a reverse proxy with SSL in front.
-T_PROTOCOL="http"
+# Email for registering SSL Certificates.
+CERTBOT_EMAIL="owner@example.com"
 # Administrator User for logging into 
 T_USER1="user1"
 T_USER1_PASSWORD="password"

--- a/start.sh
+++ b/start.sh
@@ -171,7 +171,6 @@ RUN_OPTIONS="
   --env \"T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH=$T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH\" \
   --env \"T_REPORTING_MARK_SKIPPED_WITH=$T_REPORTING_MARK_SKIPPED_WITH\" \
   --env \"T_HIDE_SKIP_IF=$T_HIDE_SKIP_IF\" \
-  $T_PORT_MAPPING \
   --volume $(pwd)/content-sets:/tangerine/content-sets:delegated \
   --volume $(pwd)/data/dat-output:/dat-output/ \
   --volume $(pwd)/data/reporting-worker-state.json:/reporting-worker-state.json \
@@ -189,6 +188,17 @@ CMD="docker run -d $RUN_OPTIONS tangerine/tangerine:$T_TAG"
 echo "Running $T_CONTAINER_NAME at version $T_TAG"
 echo "$CMD"
 eval ${CMD}
+
+docker run -d \
+  --name nginx-certbot \
+  --env T_HOSTNAME="$T_HOST_NAME" \
+  --env CERTBOT_EMAIL="$CERTBOT_EMAIL" \
+  --volume ./.proxy-conf:/etc/nginx/user.conf.d:ro \
+  --volume letsencrypt:/etc/letsencrypt \
+  -p 80:80/tcp \
+  -p 443:443/tcp \
+  --link $T_CONTAINER_NAME:tangerine \
+  staticfloat/nginx-certbot
 
 echo "Installing missing plugin..."
 docker exec ${T_CONTAINER_NAME} bash -c "cd /tangerine/client/builds/apk/ && cordova --no-telemetry plugin add cordova-plugin-whitelist --save"


### PR DESCRIPTION
@lachko @chrisekelley Here's an idea for how we could roll support for SSL into our start.sh script. The idea is that we would start a third container claiming port 80 and 443 during start.sh, an nginx-certbot container using the image from https://hub.docker.com/r/staticfloat/nginx-certbot/. I haven't tested if this works yet, but the idea is there :). 