### PR TITLE
Migrate 'info'doc to variablesService

### DIFF
--- a/client/src/app/shared/_services/user.service.ts
+++ b/client/src/app/shared/_services/user.service.ts
@@ -17,6 +17,7 @@ import { DEFAULT_USER_DOCS } from '../_tokens/default-user-docs.token';
 import { AppConfig } from '../_classes/app-config.class';
 import { LockBoxContents } from '../_classes/lock-box-contents.class';
 import { DB } from '../_factories/db.factory';
+import {VariableService} from "./variable.service";
 
 @Injectable()
 export class UserService {
@@ -41,7 +42,8 @@ export class UserService {
     private lockBoxService:LockBoxService,
     private deviceService:DeviceService,
     private appConfigService: AppConfigService,
-    private http: HttpClient
+    private http: HttpClient,
+    private variableService:VariableService,
   ) {
     this.window = window;
   }
@@ -76,10 +78,7 @@ export class UserService {
     } catch (e) {
       console.log("Error: " + JSON.stringify(e))
     }
-    await this.sharedUserDatabase.put({
-      _id: 'info',
-      atUpdateIndex: updates.length - 1
-    })
+    await this.variableService.set('atUpdateIndex', updates.length - 1);
   }
 
   async uninstall() {
@@ -260,10 +259,7 @@ export class UserService {
       })
       await this.usersDb.post(userAccount)
       const userDb = await this.createUserDatabase(userAccount.username, userAccount.userUUID)
-      await userDb.put({
-        _id: 'info',
-        atUpdateIndex: updates.length - 1
-      })
+      await this.variableService.set('atUpdateIndex', updates.length - 1);
       await userDb.put(userProfile)
     }
     return userAccount

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -119,8 +119,6 @@ export class SyncCouchdbService {
     }
 
     // First do the push:
-    // Build the PouchSyncOptions.
-    // TODO: consider using a similar doc_id approach
     const pushSyncOptions = {
       "since": push_last_seq,
       "batch_size": 50,
@@ -140,6 +138,7 @@ export class SyncCouchdbService {
 
     let replicationStatus = await this.push(userDb, remoteDb, pushSyncOptions);
 
+    // Then do the pull:
     let pullSyncOptions = {
         "since": pull_last_seq,
         "batch_size": 50,


### PR DESCRIPTION
## Description

Fixes potential sync conflict if 'info'doc is sync'd.

Note this is only an issue w/ sync-protocol-1. sync-protocol-2 uses VAR_CURRENT_UPDATE_INDEX in variableService.

- Fixes https://github.com/Tangerine-Community/Tangerine/issues/2286

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

Migrated atUpdateIndex to variableService.

## Limitations and Trade-offs

sync-protocol-2 uses 'VAR_CURRENT_UPDATE_INDEX' instead of atUpdateIndex; should we switch to using that?
