### PR TITLE
PR for: Editor user views custom dashboard #2300

### DIFF
--- a/editor/src/app/app.component.html
+++ b/editor/src/app/app.component.html
@@ -84,6 +84,17 @@
                     <img class="tangerine-logo-opened" src="/assets/tangerine-logo-box.png">
                 </mat-list-item>
             </mat-nav-list>
+            <mat-nav-list class="tangy-full-width" *ngIf="menuService.groupId">
+                <mat-list-item
+                    [class.active-menu-item]="menuService.section === 'dashboard'"
+                    routerLink="/groups/{{menuService.groupId}}/dashboard"
+                    *appHasAPermission="let i;group:menuService.groupId; permission:'can_access_dashboard'"
+                >
+                    <span class=""><i class="material-icons menu-icon list_alt-icon">dashboard</i></span>
+                    <a matLine>{{'Dashboard'|translate}}</a>
+                </mat-list-item>
+                <mat-divider></mat-divider>
+            </mat-nav-list>
             <mat-nav-list class="tangy-full-width"  *ngIf="menuService.groupId">
                 <mat-list-item 
                     [class.active-menu-item]="menuService.section === 'author'"

--- a/editor/src/app/groups/group-dashboard/group-dashboard.component.html
+++ b/editor/src/app/groups/group-dashboard/group-dashboard.component.html
@@ -1,0 +1,1 @@
+<div #container></div>

--- a/editor/src/app/groups/group-dashboard/group-dashboard.component.spec.ts
+++ b/editor/src/app/groups/group-dashboard/group-dashboard.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GroupDashboardComponent } from './group-dashboard.component';
+
+describe('GroupDashboardComponent', () => {
+  let component: GroupDashboardComponent;
+  let fixture: ComponentFixture<GroupDashboardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GroupDashboardComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/editor/src/app/groups/group-dashboard/group-dashboard.component.ts
+++ b/editor/src/app/groups/group-dashboard/group-dashboard.component.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+
+@Component({
+  selector: 'app-group-dashboard',
+  templateUrl: './group-dashboard.component.html',
+  styleUrls: ['./group-dashboard.component.css']
+})
+export class GroupDashboardComponent implements OnInit {
+
+  @ViewChild('container', {static: true}) container: ElementRef
+  constructor(
+    private http:HttpClient
+  ) { }
+
+  async ngOnInit() {
+    const index = await this.http.get('./files/editor/index.html', {responseType: 'text'}).toPromise()
+    this.container.nativeElement.innerHTML = index
+  }
+
+}

--- a/editor/src/app/groups/group/group.component.html
+++ b/editor/src/app/groups/group/group.component.html
@@ -1,5 +1,15 @@
 <div *ngIf="ready">
   <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
+  <mat-card *appHasAPermission="let i;group:group._id; permission:'can_access_dashboard'" class="mat-elevation-z3" routerLink="dashboard">
+    <mat-card-header>
+        <div mat-card-avatar><i class="material-icons tangy-foreground-secondary group-avatar">dashboard</i>
+        </div>
+        <mat-card-title>
+            <a>Dashboard</a>
+        </mat-card-title>
+        <mat-card-subtitle>Dashboard with custom reports.</mat-card-subtitle>
+    </mat-card-header>
+  </mat-card>
   <mat-card *appHasAPermission="let i;group:group._id; permission:'can_access_author'" class="mat-elevation-z3" routerLink="author">
     <mat-card-header>
         <div mat-card-avatar><i class="material-icons tangy-foreground-secondary group-avatar">edit</i>

--- a/editor/src/app/groups/groups-routing.module.ts
+++ b/editor/src/app/groups/groups-routing.module.ts
@@ -1,3 +1,4 @@
+import { GroupDashboardComponent } from './group-dashboard/group-dashboard.component';
 import { IssueFormComponent } from './../case/components/issue-form/issue-form.component';
 import { IssueComponent } from './../case/components/issue/issue.component';
 import { GroupIssuesComponent } from './group-issues/group-issues.component';
@@ -59,6 +60,7 @@ const groupsRoutes: Routes = [
   { path: 'projects', component: GroupsComponent, canActivate: [LoginGuard] },
   { path: 'groups/new-group', component: NewGroupComponent, canActivate: [LoginGuard, NgxPermissionsGuard], data:{permissions:{only:['can_create_group'], redirectTo:'/projects'}} },
   { path: 'groups/:groupId', component: GroupComponent, canActivate: [LoginGuard] },
+  { path: 'groups/:groupId/dashboard', component: GroupDashboardComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/author', component: GroupAuthorComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/author/forms', component: GroupFormsComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/author/forms/edit/:formId', component: GroupFormsEditComponent, canActivate: [LoginGuard] },

--- a/editor/src/app/groups/groups.module.ts
+++ b/editor/src/app/groups/groups.module.ts
@@ -78,6 +78,7 @@ import { CaseSettingsComponent } from './case-settings/case-settings.component';
 import { ConfigureGroupSecurityComponent } from './configure-group-security/configure-group-security.component';
 import { BrowserModule } from '@angular/platform-browser';
 import { ExportLocationListComponent } from './export-location-list/export-location-list.component';
+import { GroupDashboardComponent } from './group-dashboard/group-dashboard.component';
 
 
 
@@ -163,6 +164,7 @@ import { ExportLocationListComponent } from './export-location-list/export-locat
     CaseSettingsComponent,
     ConfigureGroupSecurityComponent,
     ExportLocationListComponent,
+    GroupDashboardComponent,
   ],
   providers: [GroupsService, FilesService, TangerineFormsService, GroupDevicesService, TangyFormService ],
 })

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -181,6 +181,10 @@ app.use('/app/:group/assets', isAuthenticated, function (req, res, next) {
   let contentPath = '/tangerine/client/content/groups/' + req.params.group
   return express.static(contentPath).apply(this, arguments);
 });
+app.use('/app/:group/files', isAuthenticated, function (req, res, next) {
+  let contentPath = '/tangerine/groups/' + req.params.group
+  return express.static(contentPath).apply(this, arguments);
+});
 
 app.use('/editor/groups', isAuthenticated, express.static('/tangerine/client/content/groups'));
 app.use('/editor/assets/', express.static('/tangerine/client/content/assets/'));

--- a/server/src/permissions-list.js
+++ b/server/src/permissions-list.js
@@ -1,5 +1,6 @@
 const permissionsList = {
   groupPermissions: [
+    'can_access_dashboard',
     'can_access_configure',
       'can_access_security',
         'can_manage_group_users',

--- a/server/src/shared/services/group/group.service.ts
+++ b/server/src/shared/services/group/group.service.ts
@@ -149,9 +149,13 @@ export class GroupService {
     const groupDb = new DB(groupId)
     let groupName = label 
     await this.installViews(groupDb)
-    await exec(`cp -r /tangerine/client/default-assets  /tangerine/client/content/groups/${groupId}`)
-    await exec(`mkdir /tangerine/client/content/groups/${groupId}/media`)
-    //
+    await exec(`mkdir /tangerine/groups/${groupId}/`)
+    await exec(`mkdir /tangerine/groups/${groupId}/editor`)
+    await exec(`cp -r /tangerine/client/default-assets  /tangerine/groups/${groupId}/client`)
+    await exec(`mkdir /tangerine/groups/${groupId}/client/media`)
+    // @TODO Create a symlink to the old group client directory until all the other APIs are updated and we have 
+    // a proper upgrade script to migrate group directories.
+    await exec(`ln -s /tangerine/groups/${groupId}/client /tangerine/client/content/groups/${groupId}`)
     // app-config.json
     //
     let appConfig = <any>{}

--- a/server/src/shared/services/group/group.service.ts
+++ b/server/src/shared/services/group/group.service.ts
@@ -135,7 +135,7 @@ export class GroupService {
     // Instantiate Group Doc, DB, and assets folder.
     const groupId = `group-${UUID()}`
     const created = new Date().toJSON()
-    const adminRole = { role: 'Admin', permissions: permissionsList.groupPermissions.filter(permission => permission !== 'can_manage_group_roles') };
+    const adminRole = { role: 'Admin', permissions: permissionsList.groupPermissions.filter(permission => permission !== 'can_manage_group_roles' && permission !== 'can_access_dashboard') };
     const memberRole = { role: 'Member', permissions: ['can_access_author', 'can_access_forms', 'can_access_data', 'can_access_download_csv'] };
     const group = <Group>{_id: groupId, label, created, roles :[
       adminRole, memberRole


### PR DESCRIPTION
PR for: Editor user view custom dashboard #2300

## Description

Some groups need a flexible way to build out reports. This PR adds a top level group menu item called "Dashboard" that displays a customizable HTML app specific to that group. 

Note below how I've opened up in VSCode the `./data/group/<group id>` folder, expanded the editor folder, and am editing an `index.html` file whose content is reflected into the group on its Dashboard page.

![Aug-13-2020 15-40-27](https://user-images.githubusercontent.com/156575/90179640-c1c74780-dd7b-11ea-9e36-9c846f477981.gif)
 

## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution

1. On group creation, creates a `/tangerine/groups/<groupId>/editor` for putting assets related to custom app for Editor in and `/tangerine/groups/<groupId>/client` for putting client related content. This is a change for the client path from the more verbose path, and for the time being ``/tangerine/groups/<groupId>/client` is symlinked to the old path to provide backwards compatibility with other parts of our app that expect it to still be at the old path. [commit](https://github.com/Tangerine-Community/Tangerine/commit/22338b5dd9d59d8b34f246793c415715050cbff0)
2. A new  `/app/:groupId/files` route to address the new group folder. [commit](https://github.com/Tangerine-Community/Tangerine/commit/5f89189abf292f57f3e6d4a788ece4d92a64c918)
3. A new `can_access_dashboard` permission for limiting access to the top level Dashboard link. [commit](https://github.com/Tangerine-Community/Tangerine/commit/7ecc6ddafece15991ab09f704e19ac45e408dd65)
4. New GroupDashboardComponent and related links for displaying contents of group's `./editor/index.html`. [commit](https://github.com/Tangerine-Community/Tangerine/commit/142d6544d12a7b8adae55b69f54a43a601893b1d)
5. In order to make this feature configurable on a per group basis, I've removed `can_access_dashboard` from the default Admin role permissions in a group. [commit](https://github.com/Tangerine-Community/Tangerine/commit/29de3b806e0547f4cea4a0a6daebee7296ce50e9)

## Upcoming enhancements

This feature will probably result in putting some custom queries in the CouchDB database. It would be nice to have an `./editor/queries.js` file that results in views being automatically added and indexed.

