### PR TITLE
Make client search case unsensitive

### DIFF
--- a/client/src/app/shared/_services/search.service.ts
+++ b/client/src/app/shared/_services/search.service.ts
@@ -140,7 +140,7 @@ export class SearchService {
     })
     return phrase === ''
       ? allDocs
-      : allDocs.filter(doc => JSON.stringify(doc).search(phrase) !== -1)
+      : allDocs.filter(doc => JSON.stringify(doc).toLowerCase().search(phrase.toLowerCase()) !== -1)
   }
 
   async getIndexedDoc(username:string, docId):Promise<SearchDoc> {


### PR DESCRIPTION
When searching on Client, when searching for "facility", we shouldn't have to write "Facility" with a capital "F". This PR makes the string compare lowercase on both the index and search term side.

<img width="354" alt="Screen Shot 2020-08-18 at 10 17 03 AM" src="https://user-images.githubusercontent.com/156575/90525957-d0c44600-e13d-11ea-9f18-0e689d3dd1c6.png">

