### PR TITLE
#2304 Fix CaseService.setEventWindow() improper use of windowStartDayTimeInMs

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -306,7 +306,7 @@ class CaseService {
     })
   }
   setEventWindow(eventId: string, windowStartDayTimeInMs: number, windowEndDayTimeInMs: number) {
-    const windowStartDay = moment((new Date(windowEndDayTimeInMs))).format('YYYY-MM-DD')
+    const windowStartDay = moment((new Date(windowStartDayTimeInMs))).format('YYYY-MM-DD')
     const windowEndDay = moment((new Date(windowEndDayTimeInMs))).format('YYYY-MM-DD')
     this.case.events = this.case.events.map(event => {
       return event.id === eventId


### PR DESCRIPTION
Currently, the CaseService.setEventWindow() function uses the end date parameter for the start time value. This fixes that.