### PR TITLE
Refactor how Editor saves form responses so it has similar metadata when Client saves

### DIFF
--- a/editor/src/app/shared/_classes/user-database.class.ts
+++ b/editor/src/app/shared/_classes/user-database.class.ts
@@ -10,22 +10,24 @@ export class UserDatabase {
   buildChannel:string;
   groupId:string;
 
-  constructor(username: string, userId: string, key:string = '', deviceId: string, shared = false, buildId = '', buildChannel = '', groupId = '') {
+  constructor(userId: string, groupId = '') {
     this.userId = userId
-    this.username = username
-    this.name = username
-    this.deviceId = deviceId
-    this.buildId = buildId
-    this.buildChannel = buildChannel
+    this.username = userId
+    this.name = userId
+    this.deviceId = 'EDITOR' 
+    this.buildId = 'EDITOR' 
+    this.buildChannel = 'EDITOR' 
     this.groupId = groupId 
   }
 
   async get(id) {
-    await axios.get(`/api/${this.groupId}/${id}`)
+    const token = localStorage.getItem('token');
+    return (<any>await axios.get(`/group-responses/read/${this.groupId}/${id}`, { headers: { authorization: token }})).data
   }
 
   async put(doc) {
-    return await axios.put(`/api/${this.groupId}`, {
+    const token = localStorage.getItem('token');
+    return await (<any>axios.post(`/group-responses/update/${this.groupId}`, {response: {
       ...doc,
       tangerineModifiedByUserId: this.userId,
       tangerineModifiedByDeviceId: this.deviceId,
@@ -36,11 +38,18 @@ export class UserDatabase {
       buildChannel: this.buildChannel,
       // Backwards compatibility for sync protocol 1. 
       lastModified: Date.now()
-    });
+    }},
+    {
+      headers: {
+        authorization: token
+      }
+    })).data;
   }
 
   async post(doc) {
-    return await axios.post(`/api/${this.groupId}`, {
+    const token = localStorage.getItem('token');
+    debugger
+    return (<any>await axios.post(`/group-responses/update/${this.groupId}`, {response: {
       ...doc,
       tangerineModifiedByUserId: this.userId,
       tangerineModifiedByDeviceId: this.deviceId,
@@ -51,10 +60,18 @@ export class UserDatabase {
       buildChannel: this.buildChannel,
       // Backwards compatibility for sync protocol 1. 
       lastModified: Date.now()
-    });
+    }},
+    {
+      headers: {
+        authorization: token
+      }
+    }
+    )).data;
   }
 
   async remove(doc) {
+    // This is not implemented...
+    const token = localStorage.getItem('token');
     return await axios.delete(`/api/${this.groupId}`, doc)
   }
 

--- a/editor/src/app/tangy-forms/tangy-form.service.ts
+++ b/editor/src/app/tangy-forms/tangy-form.service.ts
@@ -1,3 +1,4 @@
+import { UserDatabase } from './../shared/_classes/user-database.class';
 import { HttpClient } from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {TangyFormResponseModel} from 'tangy-form/tangy-form-response-model.js'
@@ -16,14 +17,14 @@ export class TangyFormService {
   }
 
   initialize(groupId) {
-    this.groupId = groupId
+    this.db = new UserDatabase('Editor', groupId)
   }
 
   // Would be nice if this was queue based so if two saves get called at the same time, the differentials are sequentials updated
   // into the database. Using a getter and setter for property fields, this would be one way to queue.
   async saveResponse(response) {
     try {
-      const doc = <any>await this.httpClient.post(`/group-responses/update/${this.groupId}`, { response }).toPromise()
+      const doc = <any>await this.db.post(response)
       return doc
     } catch (e) {
       return false
@@ -32,7 +33,7 @@ export class TangyFormService {
 
   async getResponse(responseId) {
     try {
-      const doc = <any>await this.httpClient.get(`/group-responses/read/${this.groupId}/${responseId}`).toPromise()
+      const doc = <any>await this.db.get(responseId)
       return doc
     } catch (e) {
       return false


### PR DESCRIPTION
This refactors TangerineFormService in Editor to use the UserDatabase class which will add metadata similar to how client adds metadata to every save. Adding this metadata is crucial to being able to sort Editor created records on `tangerineLastModified`, otherwise records created on Editor are excluded in places like the list of Issues.

Fixes https://github.com/Tangerine-Community/Tangerine/issues/2331