### PR TITLE
Batch generate devices from Group Devices screen in Editor

### DIFF
--- a/editor/src/app/groups/group-devices/group-devices.component.html
+++ b/editor/src/app/groups/group-devices/group-devices.component.html
@@ -1,4 +1,9 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
+<div class="generate-devices-btn">
+  <button mat-raised-button color="accent" (click)="generateDevices()">
+    Generate Devices
+  </button>
+</div>
 <div class="device-sheet-btn">
   <a routerLink="../device-sheet">
     <button mat-raised-button color="accent">

--- a/editor/src/app/groups/group-devices/group-devices.component.html
+++ b/editor/src/app/groups/group-devices/group-devices.component.html
@@ -1,9 +1,4 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
-<div class="generate-devices-btn">
-  <button mat-raised-button color="accent" (click)="generateDevices()">
-    Generate Devices
-  </button>
-</div>
 <div class="device-sheet-btn">
   <a routerLink="../device-sheet">
     <button mat-raised-button color="accent">
@@ -79,5 +74,5 @@
       <tr mat-row *matRowDef="let row; columns: devicesDisplayedColumns;"></tr>
     </table>
 </div>
-    <paper-fab mat-raised-button icon="add" color="accent" class="action" (click)="addDevice()">
+    <paper-fab mat-raised-button icon="add" color="accent" class="action" (click)="generateDevices()">
     </paper-fab>

--- a/editor/src/app/groups/group-devices/group-devices.component.ts
+++ b/editor/src/app/groups/group-devices/group-devices.component.ts
@@ -172,11 +172,6 @@ export class GroupDevicesComponent implements OnInit {
     })
   }
 
-  async addDevice() {
-    const device = <GroupDevice>await this.groupDevicesService.createDevice(this.groupId)
-    this.editDevice(device._id)
-  }
-
   async resetDevice(deviceId:string) {
     const device = await this.groupDevicesService.resetDevice(this.groupId, deviceId)
     this.update()
@@ -279,7 +274,7 @@ export class GroupDevicesComponent implements OnInit {
       <tangy-form>
         <tangy-form-item id="edit-device" on-change="
         ">
-          <tangy-input name="number_of_devices" label="Number of devices to generate" type="number" required></tangy-input>
+          <tangy-input name="number_of_devices" value="1" label="Number of devices to generate" type="number" required></tangy-input>
           <tangy-location
             required
             name="assigned_location"
@@ -302,7 +297,6 @@ export class GroupDevicesComponent implements OnInit {
     `
     window['dialog'].querySelector('tangy-form').addEventListener('submit', async (event) => {
       const numberOfDevicesToGenerate = parseInt(event.target.inputs.find(input => input.name === 'number_of_devices').value) 
-      debugger
       const assignedLevels = event.target.inputs.find(input => input.name === 'assigned_location').showLevels.split(',')
       const assignedLocationNodes = event.target.inputs.find(input => input.name === 'assigned_location').value
       const syncLevels = event.target.inputs

--- a/editor/src/app/groups/group-devices/group-devices.component.ts
+++ b/editor/src/app/groups/group-devices/group-devices.component.ts
@@ -272,4 +272,69 @@ export class GroupDevicesComponent implements OnInit {
 
   }
 
+  async generateDevices() {
+    const locationList = <any>await this.httpClient.get('./assets/location-list.json').toPromise()
+    window['dialog'].innerHTML = `
+    <paper-dialog-scrollable>
+      <tangy-form>
+        <tangy-form-item id="edit-device" on-change="
+        ">
+          <tangy-input name="number_of_devices" label="Number of devices to generate" type="number" required></tangy-input>
+          <tangy-location
+            required
+            name="assigned_location"
+            label="Assign devices which location?"
+            show-levels='${locationList.locationsLevels.join(',')}'
+          >
+          </tangy-location>
+          <tangy-radio-buttons
+            required
+            label="Sync device to location at which level?"
+            name="sync_location__show_levels"
+          >
+            ${locationList.locationsLevels.map(level => `
+              <option value="${level}">${level}</option>
+            `).join('')}
+          </tangy-radio-buttons>
+        </tangy-form-item>
+      </tangy-form>
+    </paper-dialog-scrollable>
+    `
+    window['dialog'].querySelector('tangy-form').addEventListener('submit', async (event) => {
+      const numberOfDevicesToGenerate = parseInt(event.target.inputs.find(input => input.name === 'number_of_devices').value) 
+      debugger
+      const assignedLevels = event.target.inputs.find(input => input.name === 'assigned_location').showLevels.split(',')
+      const assignedLocationNodes = event.target.inputs.find(input => input.name === 'assigned_location').value
+      const syncLevels = event.target.inputs
+        .find(input => input.name === 'sync_location__show_levels')
+        .value
+        .slice(
+          0,
+          event.target.inputs
+            .find(input => input.name === 'sync_location__show_levels')
+            .value
+            .findIndex(option => option.value === 'on')+1
+        )
+        .map(option => option.name)
+      const syncLocationNodes = event.target.inputs.find(input => input.name === 'assigned_location').value
+        .filter(node => syncLevels.includes(node.level))
+      let numberOfDevicesGenerated = 0
+      window['dialog'].innerHTML = `<h1>Generating Devices...</h1>`
+      while (numberOfDevicesGenerated < numberOfDevicesToGenerate) {
+        const device = await this.groupDevicesService.createDevice(this.groupId)
+        device.assignedLocation.value = assignedLocationNodes
+        device.assignedLocation.showLevels = assignedLevels 
+        device.syncLocations[0] = {
+          value: syncLocationNodes,
+          showLevels: syncLevels
+        }
+        await this.groupDevicesService.updateDevice(this.groupId, device)
+        numberOfDevicesGenerated++
+      }
+      this.update()
+      window['dialog'].close()
+    })
+    setTimeout(() => window['dialog'].open(), 450)
+
+  }
 }


### PR DESCRIPTION
This PR replaces the default "New Device" form with a form that will generate multiple devices, default of 1. It also improves the UX of assigning the Sync settings from one where you could shoot yourself in the foot by setting a sync location different to what the assigned location is. Instead, it just asks for what level you want to sync at, and the sync location is then implied by that plus the assigned location.

<img width="341" alt="image" src="https://user-images.githubusercontent.com/156575/92633823-5bade180-f2a1-11ea-8256-855dba306e9a.png">
