### PR TITLE
fixed regression

### DIFF
--- a/client/src/app/core/update/update/updates.ts
+++ b/client/src/app/core/update/update/updates.ts
@@ -270,11 +270,11 @@ export const updates = [
       // syncProtocol uses a single shared db for all users. Update only once.
       if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.9.0')) return
       console.log('Updating to v3.9.0...')
-      // try {
-      //   const view = await userDb.get('_design/responsesUnLockedAndNotUploaded')
-      //   TangyFormsDocs[0]['_rev'] = view._rev
-      // } catch (e) {
-      // }
+      try {
+        const view = await userDb.get('_design/responsesUnLockedAndNotUploaded')
+        TangyFormsDocs[0]['_rev'] = view._rev
+      } catch (e) {
+      }
       await userDb.put(TangyFormsDocs[0])
       await userDb.query('responsesUnLockedAndNotUploaded')
       await variableService.set('ran-update-v3.9.0', 'true')
@@ -285,11 +285,11 @@ export const updates = [
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
       if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.9.1')) return
       console.log('Updating to v3.9.1...')
-      // try {
-      //   const view = await userDb.get('_design/case-events-by-all-days')
-      //   CaseHomeDocs[0]['_rev'] = view._rev
-      // } catch (e) {
-      // }
+      try {
+        const view = await userDb.get('_design/case-events-by-all-days')
+        CaseHomeDocs[0]['_rev'] = view._rev
+      } catch (e) {
+      }
       await userDb.put(CaseHomeDocs[0])
       await userDb.query('case-events-by-all-days')
       await variableService.set('ran-update-v3.9.1', 'true')
@@ -309,11 +309,11 @@ export const updates = [
       console.log('Updating to v3.13.0...')
       if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.13.0')) return
       // Set up and index new byType query.
-      // try {
-      //   const view = await userDb.get('_design/byType')
-      //   AppDocs[0]['_rev'] = view._rev
-      // } catch (e) {
-      // }
+      try {
+        const view = await userDb.get('_design/byType')
+        AppDocs[0]['_rev'] = view._rev
+      } catch (e) {
+      }
       await userDb.put(AppDocs[0])
       await userDb.query('byType')
       await variableService.set('ran-update-v3.13.0', 'true')

--- a/client/src/app/core/update/update/updates.ts
+++ b/client/src/app/core/update/update/updates.ts
@@ -266,18 +266,18 @@ export const updates = [
   },
   {
     requiresViewsUpdate: false,
-    script: async (userDb, appConfig, userService: UserService) => {
+    script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
       // syncProtocol uses a single shared db for all users. Update only once.
-      if (appConfig.syncProtocol === '2' && localStorage.getItem('ran-update-v3.9.0')) return
+      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.9.0')) return
       console.log('Updating to v3.9.0...')
-      try {
-        const view = await userDb.get('_design/responsesUnLockedAndNotUploaded')
-        TangyFormsDocs[0]['_rev'] = view._rev
-      } catch (e) {
-      }
+      // try {
+      //   const view = await userDb.get('_design/responsesUnLockedAndNotUploaded')
+      //   TangyFormsDocs[0]['_rev'] = view._rev
+      // } catch (e) {
+      // }
       await userDb.put(TangyFormsDocs[0])
       await userDb.query('responsesUnLockedAndNotUploaded')
-      localStorage.setItem('ran-update-v3.9.0', 'true')
+      await variableService.set('ran-update-v3.9.0', 'true')
     }
   },
   {
@@ -285,11 +285,11 @@ export const updates = [
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
       if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.9.1')) return
       console.log('Updating to v3.9.1...')
-      try {
-        const view = await userDb.get('_design/case-events-by-all-days')
-        CaseHomeDocs[0]['_rev'] = view._rev
-      } catch (e) {
-      }
+      // try {
+      //   const view = await userDb.get('_design/case-events-by-all-days')
+      //   CaseHomeDocs[0]['_rev'] = view._rev
+      // } catch (e) {
+      // }
       await userDb.put(CaseHomeDocs[0])
       await userDb.query('case-events-by-all-days')
       await variableService.set('ran-update-v3.9.1', 'true')
@@ -309,11 +309,11 @@ export const updates = [
       console.log('Updating to v3.13.0...')
       if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.13.0')) return
       // Set up and index new byType query.
-      try {
-        const view = await userDb.get('_design/byType')
-        AppDocs[0]['_rev'] = view._rev
-      } catch (e) {
-      }
+      // try {
+      //   const view = await userDb.get('_design/byType')
+      //   AppDocs[0]['_rev'] = view._rev
+      // } catch (e) {
+      // }
       await userDb.put(AppDocs[0])
       await userDb.query('byType')
       await variableService.set('ran-update-v3.13.0', 'true')

--- a/server/src/upgrade/v3.13.0.js
+++ b/server/src/upgrade/v3.13.0.js
@@ -47,8 +47,8 @@ async function go() {
   for (let group of groups) {
     let groupId = group._id
     console.log(`Checking group ${groupId} for needed forms.json fixes from v3.8.0...`)
+    let forms = await fs.readJson(`/tangerine/client/content/groups/${groupId}/forms.json`)
     try {
-      let forms = await fs.readJson(`/tangerine/client/content/groups/${groupId}/forms.json`)
       let hasFormIssues = false
       forms = forms.map(form => {
         if (form.id === 'user-profile' && form.src ==='user-profile/form.html') {


### PR DESCRIPTION
## Description

Fixes regression from using variablesService to localStorage .

Recommend keeping the test for previously-installed view; when updating 3.6.4, I consistently got an error when performing the 3.13 update because it already had the '_design/byType' view.

```
      try {
        const view = await userDb.get('_design/byType')
        AppDocs[0]['_rev'] = view._rev
      } catch (e) {
      }
      await userDb.put(AppDocs[0])
```

- Fixes #2335

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

