### PR TITLE
Update the group icon

### DIFF
--- a/editor/src/app/groups/groups.component.html
+++ b/editor/src/app/groups/groups.component.html
@@ -8,7 +8,7 @@
     <mat-grid-tile *ngFor="let group of groups">
             <mat-card class="mat-elevation-z3 group-card" (click)="navigateToGroup(group._id)">
                 <mat-card-header>
-                    <div mat-card-avatar><i class="material-icons tangy-foreground-secondary group-avatar">group_work</i>
+                    <div mat-card-avatar><i class="material-icons tangy-foreground-secondary group-avatar">supervisor_account</i>
                     </div>
                     <mat-card-title>
                         <a>{{group.label}}</a>


### PR DESCRIPTION
Per @stricarm request, updating the Group icon to `supervisor_account`. https://material.io/resources/icons/?icon=supervisor_account&style=baseline

![image](https://user-images.githubusercontent.com/156575/93385664-8fa27d00-f834-11ea-81ca-d8a7aba5333b.png)
