### PR TITLE
Case Participant APIs to copy, move or delete participants in another case

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -527,6 +527,60 @@ class CaseService {
     return this.case.participants.find(participant => participant.id === participantId).data[key]
   }
 
+  async copyParticipantFromCaseToCase(sourceParticipantId, sourceCaseId, destCaseId) {
+    await this.load(sourceCaseId)
+
+    if (this.case._id === sourceCaseId) {
+      const sourceCase = this.case
+      const sourceParticipant = sourceCase.participants.find(sourceParticipant =>
+        sourceParticipant.id === sourceParticipantId)
+      if (sourceParticipant !== undefined) {
+        await this.load(destCaseId)
+        this.case.participants.push(sourceParticipant)
+        await this.save()
+
+      }
+    }
+  }
+
+  async moveParticipantFromCaseToCase(sourceParticipantId, sourceCaseId, destCaseId) {
+    await this.load(sourceCaseId)
+
+    if (this.case._id === sourceCaseId) {
+      const sourceCase = this.case
+      const sourceParticipant = sourceCase.participants.find(sourceParticipant =>
+        sourceParticipant.id === sourceParticipantId)
+      if (sourceParticipant !== undefined) {
+        const sourceParticipantIdx = sourceCase.participants.findIndex(sourceParticipant =>
+          sourceParticipant.id === sourceParticipantId)
+        sourceCase.participants.splice(sourceParticipantIdx)
+        await this.save()
+
+        // if the destination load fails, the participant could be orphaned
+        await this.load(destCaseId)
+        this.case.participants.push(sourceParticipant)
+        await this.save()
+
+      }
+    }
+  }
+
+  async deleteParticipantFromCase(sourceParticipantId, sourceCaseId) {
+    await this.load(sourceCaseId)
+
+    if (this.case._id === sourceCaseId) {
+      const sourceCase = this.case
+      const sourceParticipant = sourceCase.participants.find(sourceParticipant =>
+        sourceParticipant.id === sourceParticipantId)
+      if (sourceParticipant !== undefined) {
+        const sourceParticipantIdx = sourceCase.participants.findIndex(sourceParticipant =>
+          sourceParticipant.id === sourceParticipantId)
+        sourceCase.participants.splice(sourceParticipantIdx)
+        await this.save()
+      }
+    }
+  }
+
   /*
    * Notification API
    */

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -527,7 +527,7 @@ class CaseService {
     return this.case.participants.find(participant => participant.id === participantId).data[key]
   }
 
-  addParticipant(caseParticipant, caseRoleId) {
+  addParticipant(caseParticipant:CaseParticipant) {
     this.case.participants.push(caseParticipant)
     for (let caseEvent of this.case.events) {
       const caseEventDefinition = this
@@ -536,7 +536,7 @@ class CaseService {
         .find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
       for (let eventFormDefinition of caseEventDefinition.eventFormDefinitions) {
         if (
-          caseRoleId === eventFormDefinition.forCaseRole && 
+          caseParticipant.caseRoleId === eventFormDefinition.forCaseRole && 
           (
             eventFormDefinition.autoPopulate || 
             (eventFormDefinition.autoPopulate === undefined && eventFormDefinition.required === true)
@@ -562,7 +562,7 @@ class CaseService {
     return sourceParticipant
   }
 
-  async deleteParticipantFromAnotherCase(sourceCaseId, sourceParticipantId) {
+  async deleteParticipantInAnotherCase(sourceCaseId, sourceParticipantId) {
     const currCaseId = this.case._id
 
     await this.load(sourceCaseId)
@@ -580,17 +580,17 @@ class CaseService {
   async copyParticipantFromAnotherCase(sourceCaseId, sourceParticipantId) {
     const caseParticipant = await this.getParticipantFromAnotherCase(sourceCaseId, sourceParticipantId)
     if (caseParticipant !== undefined) {
-      this.addParticipant(caseParticipant, caseParticipant.caseRoleId)
+      this.addParticipant(caseParticipant)
     }
   }
 
   async moveParticipantFromAnotherCase(sourceCaseId, sourceParticipantId) {
     const caseParticipant = await this.getParticipantFromAnotherCase(sourceCaseId, sourceParticipantId)
     if (caseParticipant !== undefined) {
-      this.addParticipant(caseParticipant, caseParticipant.caseRoleId)
+      this.addParticipant(caseParticipant)
 
       // Only delete the participant from the other case after adding it to this case is successful
-      await this.deleteParticipantFromAnotherCase(sourceCaseId, sourceParticipantId)
+      await this.deleteParticipantInAnotherCase(sourceCaseId, sourceParticipantId)
     }
   }
 


### PR DESCRIPTION
Addresses Use Case #2353 

The new APIs allow the user to transition participants in a few ways. 

The first three functions `addParticipant()`, `getParticipantFromAnotherCase()` and `deleteParticipantInAnotherCase()` provide the framework for transitioning a participant from another case to the current case. 

The other two, `copyParticipantFromAnotherCase()` and `moveParticipantFromAnotherCase()`, are convenience functions that use the first three functions.  

`copyParticipantFromAnotherCase()` is a direct copy of the participant from one case to another. After calling this function, the participant exists in both cases.

`moveParticipantFromAnotherCase()` adds the participant to the current case and removes it from the 'other' case.
