### PR TITLE
#2428 Remove support for webpacking custom-scripts.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install global node dependencies
-RUN npm install -g nodemon uuid webpack-cli webpack
+RUN npm install -g nodemon uuid
 
 # T_USER1 is the username of the first user you will log in as. It is also the super user that has all permissions. 
 ENV T_USER1 user1

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -62,14 +62,6 @@ rm -rf $RELEASE_DIRECTORY/package-lock.json
 echo "RELEASE APK: removing Android platform"
 cordova platform rm android --no-telemetry
 
-CUSTOM_SCRIPTS_PATH="$RELEASE_DIRECTORY/www/shell/assets/custom-scripts.js"
-TMP_CUSTOM_SCRIPTS_PATH="$CUSTOM_SCRIPTS_PATH.tmp"
-if [ -f "$CUSTOM_SCRIPTS_PATH" ]; then
-  echo "RELEASE APK webpacking CUSTOM_SCRIPTS"
-  webpack $CUSTOM_SCRIPTS_PATH -o $TMP_CUSTOM_SCRIPTS_PATH
-  cp "$TMP_CUSTOM_SCRIPTS_PATH/main.js" $CUSTOM_SCRIPTS_PATH
-fi
-
 # Stash the Build ID in the release.
 echo $BUILD_ID > $RELEASE_DIRECTORY/www/shell/assets/tangerine-build-id 
 echo $RELEASE_TYPE > $RELEASE_DIRECTORY/www/shell/assets/tangerine-build-channel


### PR DESCRIPTION
Since this web pack process is causing so many issues, let's pass off this duty to the projects themselves. This results in a higher barrier to entry for building custom apps in Tangerine, but it will also let them know if a build is breaking without a silent fail, they'll get more flexibility in the tools they want to use (ie. TypeScript if they want), and they'll be able to use NPM modules.