### PR TITLE
Fix setEventName API

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -299,8 +299,12 @@ class CaseService {
     return caseEvent
   }
 
-  setEventName(caseEvent:CaseEvent, name:string) {
-    caseEvent.name = name;
+  setEventName(eventId, name:string) {
+    this.case.events = this.case.events.map(event => {
+      return event.id === eventId
+        ? { ...event, ...{ name } }
+        : event
+    })
   }
 
   setEventEstimatedDay(eventId, timeInMs: number) {


### PR DESCRIPTION
First pass at setting the event name programmatically did not work on the device. This is the correct way to set it.