### PR TITLE
2441 automerge conflicts with canonical data

### DIFF
--- a/client/src/app/sync/conflict/diff-type--event.spec.ts
+++ b/client/src/app/sync/conflict/diff-type--event.spec.ts
@@ -138,7 +138,6 @@ describe('diffType_Event', () => {
       caseDefinition
     })
     if (diffInfo.a['canonicalTimestamp'] && (diffInfo.a['canonicalTimestamp'] > diffInfo.b['tangerineModifiedOn'])) {
-      debugger;
       diffInfo.canonical = true
     }
     expect(diffInfo.canonical).toEqual(true)

--- a/client/src/app/sync/conflict/diff-type--event.spec.ts
+++ b/client/src/app/sync/conflict/diff-type--event.spec.ts
@@ -106,7 +106,7 @@ describe('diffType_Event', () => {
     expect(diffInfo.diffs[0].info.differences[0]).toEqual('new')
   })
   
-  it('should override difference and mark as canonical', () => {
+  fit('should mark "a" doc as canonical', () => {
     const aCopy = JSON.parse(JSON.stringify(a))
     const bCopy = JSON.parse(JSON.stringify(b))
     const tangerineModifiedOn = moment().subtract(10, 'days').valueOf();
@@ -137,10 +137,53 @@ describe('diffType_Event', () => {
       diffs: [],
       caseDefinition
     })
-    if (diffInfo.a['canonicalTimestamp'] && (diffInfo.a['canonicalTimestamp'] > diffInfo.b['tangerineModifiedOn'])) {
-      diffInfo.canonical = true
+    if (diffInfo.a['canonicalTimestamp'] && !diffInfo.b['canonicalTimestamp']) {
+        diffInfo.canonicalTimestampOverrideDoc = 'a'
     }
-    expect(diffInfo.canonical).toEqual(true)
+    expect(diffInfo.canonicalTimestampOverrideDoc).toEqual('a')
+    expect(diffInfo.diffs.length).toEqual(1)
+    expect(diffInfo.diffs[0].type).toEqual(DIFF_TYPE__EVENT)
+    expect(diffInfo.diffs[0].resolved).toEqual(false)
+    expect(diffInfo.diffs[0].info.where).toEqual('b')
+    expect(diffInfo.diffs[0].info.differences[0]).toEqual('new')
+  })
+  
+fit('should mark "b" doc as canonical', () => {
+    const aCopy = JSON.parse(JSON.stringify(a))
+    const bCopy = JSON.parse(JSON.stringify(b))
+    const tangerineModifiedOn = moment().subtract(10, 'days').valueOf();
+    let canonicalTimestamp = Date.now();
+    const diffInfo = diffType_Event.detect({
+      a:{
+        ...aCopy,
+        tangerineModifiedOn: tangerineModifiedOn,
+      },
+      b:{
+        ...bCopy,
+        canonicalTimestamp: canonicalTimestamp,
+        events: [...bCopy.events,
+          {
+            id: 'event2',
+            caseEventDefinitionId: 'event-definition-1',
+            eventForms: [
+              {
+                id: 'event-form-2',
+                "caseEventId": "event2",
+                eventFormDefinitionId: 'event-form-definition-1',
+                formResponseId: 'form-response-2'
+              }
+            ]
+          }
+        ]
+      },
+      diffs: [],
+      caseDefinition
+    })
+    // if (diffInfo.a['canonicalTimestamp'] && !diffInfo.b['canonicalTimestamp']) {
+    if (diffInfo.b['canonicalTimestamp'] > diffInfo.a['canonicalTimestamp'] || (diffInfo.b['canonicalTimestamp'] && !diffInfo.a['canonicalTimestamp'])) {
+      diffInfo.canonicalTimestampOverrideDoc = 'b'
+    }
+    expect(diffInfo.canonicalTimestampOverrideDoc).toEqual('b')
     expect(diffInfo.diffs.length).toEqual(1)
     expect(diffInfo.diffs[0].type).toEqual(DIFF_TYPE__EVENT)
     expect(diffInfo.diffs[0].resolved).toEqual(false)

--- a/client/src/app/sync/conflict/diff-type--event.spec.ts
+++ b/client/src/app/sync/conflict/diff-type--event.spec.ts
@@ -106,7 +106,7 @@ describe('diffType_Event', () => {
     expect(diffInfo.diffs[0].info.differences[0]).toEqual('new')
   })
   
-  fit('should mark "a" doc as canonical', () => {
+  it('should mark "a" doc as canonical', () => {
     const aCopy = JSON.parse(JSON.stringify(a))
     const bCopy = JSON.parse(JSON.stringify(b))
     const tangerineModifiedOn = moment().subtract(10, 'days').valueOf();
@@ -148,7 +148,7 @@ describe('diffType_Event', () => {
     expect(diffInfo.diffs[0].info.differences[0]).toEqual('new')
   })
   
-fit('should mark "b" doc as canonical', () => {
+  it('should mark "b" doc as canonical', () => {
     const aCopy = JSON.parse(JSON.stringify(a))
     const bCopy = JSON.parse(JSON.stringify(b))
     const tangerineModifiedOn = moment().subtract(10, 'days').valueOf();

--- a/client/src/app/sync/conflict/diff-types.const.ts
+++ b/client/src/app/sync/conflict/diff-types.const.ts
@@ -1,7 +1,6 @@
 import {
   diffType_EventForm
 } from "./diff-type--event-form";
-import {diffType_Metadata} from "./diff-type--metadata";
 import {diffType_Event} from "./diff-type--event";
 
 export interface DiffTypes {
@@ -25,7 +24,6 @@ export interface ResponseDiffTypes extends DiffTypes {
 
 export const DIFF_TYPES = [
   diffType_Event,
-  diffType_EventForm,
-  diffType_Metadata
+  diffType_EventForm
 ]
 

--- a/client/src/app/sync/services/conflict.service.ts
+++ b/client/src/app/sync/services/conflict.service.ts
@@ -52,7 +52,7 @@ export class ConflictService {
               error: 'Force merge due to canonicalTimestamp override'
             }
             // provide the conflict diff in the issuesMetadata rather than sending the response to be diffed, because the issues differ works on responses instead of cases.
-            const issue = await this.caseService.createIssue(`Unresolved Conflict on ${a.form.id}`, 'Unable to detect conflict type.', a._id, a.events[0].id, a.events[0].eventForms[0].id, window['userProfile']._id, window['username'], [AppContext.Editor], conflict)
+            const issue = await this.caseService.createIssue(`Force merge conflict on ${a.form.id}`, 'Force merge due to canonicalTimestamp override.', a._id, a.events[0].id, a.events[0].eventForms[0].id, window['userProfile']._id, window['username'], [AppContext.Editor], conflict)
             try {
               await userDb.db.remove(diffInfo.a._id, conflictRev)
             } catch (e) {

--- a/client/src/app/sync/services/conflict.service.ts
+++ b/client/src/app/sync/services/conflict.service.ts
@@ -40,55 +40,77 @@ export class ConflictService {
           }
           let caseDefinition = <CaseDefinition>caseDefinitions.find(caseDefinition => caseDefinition.id === caseDefinitionId)
           let diffInfo = diff(a, b, caseDefinition)
-          // Create issue if we have not detected the conflict type...
-          if (diffInfo.diffs.length === 0) {
+          // Override using the winning doc if canonicalTimestamp is available and is newer than this document.
+          if (a['canonicalTimestamp'] && (a['canonicalTimestamp'] > b['tangerineModifiedOn'])) {
+            diffInfo['canonical'] = true
             let conflict:Conflict = {
               diffInfo: diffInfo,
               mergeInfo: null,
               type: 'conflict',
               docType: 'case',
               merged: false,
-              error: 'Unable to detect conflict type.'
+              error: 'Force merge due to canonicalTimestamp override'
             }
             // provide the conflict diff in the issuesMetadata rather than sending the response to be diffed, because the issues differ works on responses instead of cases.
             const issue = await this.caseService.createIssue(`Unresolved Conflict on ${a.form.id}`, 'Unable to detect conflict type.', a._id, a.events[0].id, a.events[0].eventForms[0].id, window['userProfile']._id, window['username'], [AppContext.Editor], conflict)
-            // TODO delete the conflict!!!
             try {
               await userDb.db.remove(diffInfo.a._id, conflictRev)
             } catch (e) {
               console.log("Error: " + e)
             }
           } else {
-            const mergeInfo:MergeInfo = merge(diffInfo)
+            // Create issue if we have not detected the conflict type...
+            if (diffInfo.diffs.length === 0) {
+              let conflict:Conflict = {
+                diffInfo: diffInfo,
+                mergeInfo: null,
+                type: 'conflict',
+                docType: 'case',
+                merged: false,
+                error: 'Unable to detect conflict type.'
+              }
+              // provide the conflict diff in the issuesMetadata rather than sending the response to be diffed, because the issues differ works on responses instead of cases.
+              const issue = await this.caseService.createIssue(`Unresolved Conflict on ${a.form.id}`, 'Unable to detect conflict type.', a._id, a.events[0].id, a.events[0].eventForms[0].id, window['userProfile']._id, window['username'], [AppContext.Editor], conflict)
+              // TODO delete the conflict!!!
+              try {
+                await userDb.db.remove(diffInfo.a._id, conflictRev)
+              } catch (e) {
+                console.log("Error: " + e)
+              }
+            } else {
+              const mergeInfo:MergeInfo = merge(diffInfo)
 
-            // TODO: run markQualifyingCaseAsComplete and markQualifyingEventsAsComplete
-            // remove the conflict
-            try {
-              await userDb.db.remove(mergeInfo.merged._id, conflictRev)
-            } catch (e) {
-              console.log("Error: " + e)
-            }
-            try {
-              await userDb.put(mergeInfo.merged) // create a new rev
-            } catch (e) {
-              console.log("Error: " + e)
-            }
-            // Replicate the merged doc to the remoteDb.
-            // TODO: confirm this is unnecessary - it will get eventually pushed to the server in the next sync...
-            // const options = {doc_ids:[mergeInfo.merged._id]}
-            // PouchDB.replicate(userDb.db, remoteDb, options)
+              // TODO: run markQualifyingCaseAsComplete and markQualifyingEventsAsComplete
+              // remove the conflict
+              try {
+                await userDb.db.remove(mergeInfo.merged._id, conflictRev)
+              } catch (e) {
+                console.log("Error: " + e)
+              }
+              try {
+                await userDb.put(mergeInfo.merged) // create a new rev
+              } catch (e) {
+                console.log("Error: " + e)
+              }
+              // Replicate the merged doc to the remoteDb.
+              // TODO: confirm this is unnecessary - it will get eventually pushed to the server in the next sync...
+              // const options = {doc_ids:[mergeInfo.merged._id]}
+              // PouchDB.replicate(userDb.db, remoteDb, options)
 
-            let conflict:Conflict = {
-              diffInfo: null,
-              mergeInfo: mergeInfo,
-              type: 'conflict',
-              docType: currentDoc.type,
-              merged: true,
-              error:null,
-            }
+              let conflict:Conflict = {
+                diffInfo: null,
+                mergeInfo: mergeInfo,
+                type: 'conflict',
+                docType: currentDoc.type,
+                merged: true,
+                error:null,
+              }
 
-            const issue = await this.caseService.createIssue(`Conflict on ${a.form.id}`, '', a._id, null, null, window['userProfile']._id, window['username'], [AppContext.Editor], conflict)
+              const issue = await this.caseService.createIssue(`Conflict on ${a.form.id}`, '', a._id, null, null, window['userProfile']._id, window['username'], [AppContext.Editor], conflict)
+            }
           }
+          
+          
         } else {
           // TODO indicate that the merge did happen - and which rev won.
           let conflict:Conflict = {

--- a/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.spec.ts
+++ b/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.spec.ts
@@ -57,7 +57,7 @@ describe('TangyFormsPlayerComponent', () => {
   // - formVersionId but no formVersions
   // - no formVersionId
   // check if isSandbox.
-  fit('should load response and show correct version', (done) => {
+  it('should load response and show correct version', (done) => {
     // See MockTangyFormsInfoService for the data and template being used.
     component.formId = 'original'
     component.formResponseId = '123'

--- a/editor/src/app/case/components/case/case.component.ts
+++ b/editor/src/app/case/components/case/case.component.ts
@@ -88,10 +88,12 @@ export class CaseComponent implements AfterContentInit {
   }
 
   async onSubmit() {
-    const newDate = moment(this.inputSelectedDate, 'YYYY-MM-DD').unix()*1000
-    const caseEvent = this.caseService.createEvent(this.selectedNewEventType)
-    await this.caseService.save()
-    this.calculateTemplateData()
+    if (confirm("Creating a new event or form can cause conflicts with data on tablets. Are you sure you want to proceed?")) {
+      const newDate = moment(this.inputSelectedDate, 'YYYY-MM-DD').unix()*1000
+      const caseEvent = this.caseService.createEvent(this.selectedNewEventType)
+      await this.caseService.save()
+      this.calculateTemplateData()
+    }
   }
 
 }

--- a/editor/src/app/case/components/event-form-list-item/event-form-list-item.component.ts
+++ b/editor/src/app/case/components/event-form-list-item/event-form-list-item.component.ts
@@ -53,11 +53,14 @@ export class EventFormListItemComponent implements OnInit {
   async ngOnInit() {
     this.canUserDeleteForms = ((this.eventFormDefinition.allowDeleteIfFormNotCompleted && !this.eventForm.complete)
     || (this.eventFormDefinition.allowDeleteIfFormNotStarted && !this.eventForm.formResponseId));
-    const response = await this.formService.getResponse(this.eventForm.formResponseId);
-    this.response = response
+    if (this.eventForm.formResponseId) {
+      const response = await this.formService.getResponse(this.eventForm.formResponseId);
+      this.response = response
+    }
+    
     const getValue = (variableName) => {
-      if (response) {
-        const variablesByName = response.items.reduce((variablesByName, item) => {
+      if (this.response) {
+        const variablesByName = this.response.items.reduce((variablesByName, item) => {
           for (const input of item.inputs) {
             variablesByName[input.name] = input.value;
           }

--- a/editor/src/app/case/components/event-form/event-form.component.ts
+++ b/editor/src/app/case/components/event-form/event-form.component.ts
@@ -87,7 +87,7 @@ export class EventFormComponent implements OnInit {
       // After render of the player, it will have created a new form response if one was not assigned.
       // Make sure to save that new form response ID into the EventForm.
       this.formPlayer.$rendered.subscribe(async () => {
-        if (!this.formResponseId) {
+        if (!this.formResponseId && (this.formPlayer.formResponseId !== '')) {
           this.eventForm.formResponseId = this.formPlayer.formResponseId
           await this.caseService.save()
         }

--- a/editor/src/app/case/components/issue/issue.component.ts
+++ b/editor/src/app/case/components/issue/issue.component.ts
@@ -183,7 +183,13 @@ export class IssueComponent implements OnInit {
       });
       this.diffOutput = diffArray
       this.conflictMarkup = conflictTemplate(this.diffOutput, false)
-      let mergedClone = JSON.parse(JSON.stringify(merged))
+      let mergedClone;
+      if (merged) {
+        mergedClone = JSON.parse(JSON.stringify(merged))
+      } else {
+        // If not merged, use the winner, a.
+        mergedClone = JSON.parse(JSON.stringify(a))
+      }
       // remove some noise
       delete mergedClone.form
       let diffMergedArray = []

--- a/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -45,7 +45,7 @@ export class TangyFormsPlayerComponent {
   @ViewChild('container', {static: true}) container: ElementRef;
   constructor(
     private tangyFormsInfoService:TangyFormsInfoService,
-    private tangyFormService: TangyFormService,
+    private tangyFormService: TangyFormService
   ) {
     this.window = window
   }
@@ -101,10 +101,15 @@ export class TangyFormsPlayerComponent {
       if (formResponse) {
         formEl.response = formResponse
       } else {
-        formEl.newResponse()
-        this.formResponseId = formEl.response._id
-        formEl.response.formVersionId = this.formInfo.formVersionId
-        this.throttledSaveResponse(formEl.response)
+        if (confirm("Clicking this link will create a new record that could cause conflicts with data on tablets. Are you sure you want to proceed?")) {
+          formEl.newResponse()
+          this.formResponseId = formEl.response._id
+          formEl.response.formVersionId = this.formInfo.formVersionId
+          this.throttledSaveResponse(formEl.response)
+        } else {
+          this.skipSaving = true
+          window.location.hash = `#/${['case', window['T'].case.id].join('/')}`
+        }
       }
       this.response = formEl.response
       // Listen up, save in the db.


### PR DESCRIPTION
## Description

Creates a way to force merge a case record modified on the server when the client syncs.

Disables the metadata diff type because it may be too aggressive.

---

[What is the business, user experience or technical problem? What is the motivation or context? Any Dependencies required for the change? e.g `tangy-forms` version etc]
[List the issues fixed and any other relevant issues]

- Fixes #2441 

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---

After modifying the case record, add `canonicalTimestamp` to the document:

```
"canonicalTimestamp":1603854576785

```

## Potential problem

Are there cases where the Editor version is *not* the winner when Couchdb does the merge?