### PR TITLE
Use filter instead of splice to remove participant from case in API

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -566,13 +566,9 @@ class CaseService {
     const currCaseId = this.case._id
 
     await this.load(sourceCaseId)
-    const sourceCase = this.case
-    const sourceParticipantIdx = sourceCase.participants.findIndex(sourceParticipant =>
-      sourceParticipant.id === sourceParticipantId)
-    if (sourceParticipantIdx > -1) {
-      sourceCase.participants.splice(sourceParticipantIdx)
-      await this.save()
-    }
+    this.case.participants = this.case.participants.filter(sourceParticipant =>
+        sourceParticipant.id === sourceParticipantId)
+    await this.save()
 
     await this.load(currCaseId)
   }


### PR DESCRIPTION
The deleteParticipantInAnotherCase API was using splice which removed everything after the index. Instead we will filter out the participant to be removed.