### PR TITLE
Release/v3.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.14.4
+- __Bugfix__
+  - To fix a problem with app updates, downgraded docker-tangerine-base-image to v3.6.0. This will cause issues w/ p2p sync.
+  
 ## v3.14.3
 - __Bugfix__
   - Auto-merged conflicts overwrite "canonical" change made on Editor server [#2441](https://github.com/Tangerine-Community/Tangerine/issues/2441) - Prevents tablets from overwriting documents from Editor in special cases. After modifying the case record, add canonicalTimestamp to the document: `"canonicalTimestamp":1603854576785`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with docker-tangerine-base-image, which provides the core Tangerine apps.
-FROM tangerine/docker-tangerine-base-image:v3.7.1
+FROM tangerine/docker-tangerine-base-image:v3.6.0
 
 # Never ask for confirmations
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
## Description

Fix bug w/ app updates

- Fixes #IssueNumber

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

downgrade of docker image to 3.6.0

## Limitations and Trade-offs

p2p sync will not work consistently.

