### PR TITLE
use optional chaining to check if parent is defined

### DIFF
--- a/client/src/app/shared/_services/create-search-index.ts
+++ b/client/src/app/shared/_services/create-search-index.ts
@@ -1,6 +1,6 @@
 export const createSearchIndex = async (db, formsInfo) => {
   const variablesToIndexByFormId = formsInfo.reduce((variablesToIndexByFormId, formInfo) => {
-    return formInfo.searchSettings.shouldIndex
+    return formInfo.searchSettings?.shouldIndex
       ? {
         ...variablesToIndexByFormId,
         [formInfo.id]: formInfo.searchSettings.variablesToIndex


### PR DESCRIPTION
## Description

---

Fixes a side issue - mentioned in #2366 - when creating a default content-set.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)


## Proposed Solution

Using the existential operator to test for a parent.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining
