### PR TITLE
During release scripts, npm run install-server && npm run build

### DIFF
--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -40,9 +40,10 @@ fi
 # Mark build status early.
 echo '{"processing":true,"step":"Generating APK configuration files"}' > $STATUS_FILE
 
-if [ -d "$RELEASE_DIRECTORY" ]; then
-  # Clear out the Cordova project in $RELEASE_DIRECTORY
-  rm -rf $RELEASE_DIRECTORY
+if [ -f "/tangerine/groups/$GROUP/package.json" ]; then
+  cd "/tangerine/groups/$GROUP/"
+  npm run install-server && npm run build
+  cd /
 fi
 
 # Populate with the Cordova project from $CORDOVA_DIRECTORY

--- a/server/src/scripts/release-apk.sh
+++ b/server/src/scripts/release-apk.sh
@@ -40,6 +40,11 @@ fi
 # Mark build status early.
 echo '{"processing":true,"step":"Generating APK configuration files"}' > $STATUS_FILE
 
+if [ -d "$RELEASE_DIRECTORY" ]; then
+  # Clear out the Cordova project in $RELEASE_DIRECTORY
+  rm -rf $RELEASE_DIRECTORY
+fi
+
 if [ -f "/tangerine/groups/$GROUP/package.json" ]; then
   cd "/tangerine/groups/$GROUP/"
   npm run install-server && npm run build

--- a/server/src/scripts/release-pwa.sh
+++ b/server/src/scripts/release-pwa.sh
@@ -26,6 +26,12 @@ if [ "$2" = "--help" ] || [ "$GROUP" = "" ] || [ "$CONTENT_PATH" = "" ] || [ "$R
   exit
 fi
 
+if [ -f "/tangerine/groups/$GROUP/package.json" ]; then
+  cd "/tangerine/groups/$GROUP/"
+  npm run install-server && npm run build
+  cd /
+fi
+
 cd /tangerine/client
 
 if [ -z "$T_ORIENTATION" ]


### PR DESCRIPTION
This will enable us to create the default group and release it. This is important for the case-module content set as well.