### PR TITLE
Add CaseService.delete() API

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -191,7 +191,23 @@ class CaseService {
     await this.save()
   }
 
-  
+  async delete() {
+    const eventForms:Array<EventForm> = this.case.events.reduce((eventForms, event) => {
+      return Array.isArray(event.eventForms)
+        ? [...eventForms, ...event.eventForms]
+        : eventForms
+    }, [])
+    for (let eventForm of eventForms) {
+      if (eventForm.formResponseId) {
+        const formResponse = await this.tangyFormService.getResponse(eventForm.formResponseId)
+        if (formResponse) {
+          await this.tangyFormService.deleteResponse(formResponse)
+        }
+      }
+    }
+    await this.tangyFormService.deleteResponse(this.case)
+  } 
+
   async setCase(caseInstance) {
     // Note the order of setting caseDefinition before case matters because the setter for case expects caseDefinition to be the current one.
     this.caseDefinition = (await this.caseDefinitionsService.load())

--- a/client/src/app/tangy-forms/tangy-form.service.ts
+++ b/client/src/app/tangy-forms/tangy-form.service.ts
@@ -102,6 +102,11 @@ export class TangyFormService {
     }
   }
 
+  async deleteResponse(response) {
+    let db = await this.userService.getUserDatabase(this.userService.getCurrentUser())
+    await db.remove(response)
+  }
+ 
   async getAllResponses() {
     let db = await this.userService.getUserDatabase(this.userService.getCurrentUser())
     return (await db.allDocs({include_docs:true})).rows.map(row => row.doc)

--- a/editor/src/app/case/services/case.service.ts
+++ b/editor/src/app/case/services/case.service.ts
@@ -176,6 +176,23 @@ class CaseService {
     await this.save()
   }
 
+  async delete() {
+    const eventForms:Array<EventForm> = this.case.events.reduce((eventForms, event) => {
+      return Array.isArray(event.eventForms)
+        ? [...eventForms, ...event.eventForms]
+        : eventForms
+    }, [])
+    for (let eventForm of eventForms) {
+      if (eventForm.formResponseId) {
+        const formResponse = await this.tangyFormService.getResponse(eventForm.formResponseId)
+        if (formResponse) {
+          await this.tangyFormService.deleteResponse(formResponse)
+        }
+      }
+    }
+    await this.tangyFormService.deleteResponse(this.case)
+  }
+
   async setCase(caseInstance) {
     // Note the order of setting caseDefinition before case matters because the setter for case expects caseDefinition to be the current one.
     this.caseDefinition = (await this.caseDefinitionsService.load())

--- a/editor/src/app/shared/_classes/user-database.class.ts
+++ b/editor/src/app/shared/_classes/user-database.class.ts
@@ -69,9 +69,12 @@ export class UserDatabase {
   }
 
   async remove(doc) {
-    // This is not implemented...
     const token = localStorage.getItem('token');
-    return await axios.delete(`/api/${this.groupId}`, doc)
+    return await axios.post(`/group-responses/delete/${this.groupId}/${doc._id}`, {}, {
+      headers: {
+        authorization: token
+      }
+    })
   }
 
 }

--- a/editor/src/app/tangy-forms/tangy-form.service.ts
+++ b/editor/src/app/tangy-forms/tangy-form.service.ts
@@ -43,6 +43,10 @@ export class TangyFormService {
     }
   }
 
+  async deleteResponse(response) {
+    await this.db.remove(response)
+  }
+
   async getAllResponses() {
     return []
   }


### PR DESCRIPTION
Sometimes you need to delete a case with all associated form responses. This PR makes a CaseService.delete() method available on both Client and Editor.