### PR TITLE
Silence geoposition logs

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -345,7 +345,7 @@ export class AppComponent implements OnInit {
           timestamp: position.timestamp
         };
         localStorage.setItem('gpsQueue', JSON.stringify(x));
-      } else { console.debug(position); }
+      }
     },
       (err) => { },
       options);

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -345,7 +345,7 @@ export class AppComponent implements OnInit {
           timestamp: position.timestamp
         };
         localStorage.setItem('gpsQueue', JSON.stringify(x));
-      } else { console.log(position); }
+      } else { console.debug(position); }
     },
       (err) => { },
       options);


### PR DESCRIPTION
The geoposition logs going to the default log level are super annoying when debugging in dev tools. This moves them to the debug level. We should remove the log statement if they are not needed. 