### PR TITLE
Replication status improvements

### DIFF
--- a/client/src/app/sync/classes/replication-status.class.ts
+++ b/client/src/app/sync/classes/replication-status.class.ts
@@ -10,6 +10,10 @@ export class ReplicationStatus {
   direction:any
   pullError: any
   pushError: any
-  initialPullLastSeq: any;
-  tangerineVersion: any;
+  initialPullLastSeq: any
+  tangerineVersion: any
+  pushStartTime: any
+  pullStartTime: any
+  pushStopTime: any
+  pullStopTime: any
 }

--- a/client/src/app/sync/classes/replication-status.class.ts
+++ b/client/src/app/sync/classes/replication-status.class.ts
@@ -16,4 +16,6 @@ export class ReplicationStatus {
   pullStartTime: any
   pushStopTime: any
   pullStopTime: any
+  initialDocCount: number // before pulling docs from server.
+  docCount: number
 }

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -228,6 +228,7 @@ export class SyncCouchdbService {
 
     status.pushStartTime = pushStartTime
     status.pushStopTime = pushStopTime
+    status.docCount = docCount
     
     return status;
   }
@@ -235,6 +236,9 @@ export class SyncCouchdbService {
   async pull(userDb, remoteDb, appConfig, syncDetails): Promise<ReplicationStatus> {
     const pullStartTime = new Date().toISOString()
     let pullStopTime
+    let dbInfo = await userDb.db.info()
+    const initialDocCount = dbInfo.doc_count
+    
     let status = <ReplicationStatus>{
       pulled: 0,
       pullConflicts: [],
@@ -425,9 +429,13 @@ export class SyncCouchdbService {
     } else {
       // TODO: Do we store the most recent seq id we tried to sync but didn't find any matches?
     }
-
+    dbInfo = await userDb.db.info()
+    const docCount = dbInfo.doc_count
+    
     status.pullStartTime = pullStartTime
     status.pullStopTime = pullStopTime
+    status.initialDocCount = initialDocCount
+    status.docCount = docCount
     
     return status;
   }


### PR DESCRIPTION
## Description

Adds more metadata to the status of each sync:

- pushStartTime
- pushStopTime
- pullStartTime
- pullStopTime
- initialDocCount - at start of pull
- docCount - at end of push and pull

In the code below, tangerineVersion is empty because dev instance running in develop.sh.

Also note that start_time and end_time are created by the pouchdb lib - I'd disregard that and use the push/pul times instead.

Example from initial device pull:

```json
{"pulled":204,"pullConflicts":[],
"info":{"ok":true,"start_time":"2020-12-30T14:39:11.799Z","docs_read":4,"docs_written":4,
"doc_write_failures":0,"errors":[],
"last_seq":"218-g1AAAAIjeJyV0DEKwjAUBuBgBV0cxUGh4gmSkBgz2Zto0qSUUpNBd72J3kRvojepSVpBC0K7vAc_733DXwIAxnmkwMRYY5VOjM3t8VS6eCCAjKuqKvJILA4uGGmkFYe4ffznXS7dlNtGmAcBMkIYVl2FxAu7HwFJSjNIugp7L5wbYRYEgggSjHYUzNBNcHHLIVevxEGha8JTrXspt1q5e2UVFIlTTuGml_KoladXpp9WqcBpL-VVK1_NMi4h07D9U7wB5BKnmg",
"status":"complete","end_time":"2020-12-30T14:39:13.110Z"},"remaining":0,"direction":"pull",
"initialPullLastSeq":0,
"pullStartTime":"2020-12-30T14:39:01.491Z",
"pullStopTime":"2020-12-30T14:39:13.197Z","initialDocCount":8,"docCount":212,
"tangerineVersion":""}
```

Example from a sync - also has push stop/start times:

```json
{"pulled":0,"pullConflicts":[],
"info":{"ok":true,"start_time":"2020-12-30T14:54:06.696Z","docs_read":0,"docs_written":0,
"doc_write_failures":0,"errors":[],"last_seq":212,"status":"complete","end_time":"2020-12-30T14:54:07.770Z"},"remaining":0,"direction":"push",
"initialPullLastSeq":"218-g1AAAAIjeJyV0DEKwjAUBuBgBV0cxUGh4gmSkBgz2Zto0qSUUpNBd72J3kRvojepSVpBC0K7vAc_733DXwIAxnmkwMRYY5VOjM3t8VS6eCCAjKuqKvJILA4uGGmkFYe4ffznXS7dlNtGmAcBMkIYVl2FxAu7HwFJSjNIugp7L5wbYRYEgggSjHYUzNBNcHHLIVevxEGha8JTrXspt1q5e2UVFIlTTuGml_KoladXpp9WqcBpL-VVK1_NMi4h07D9U7wB5BKnmg",
"pullStartTime":"2020-12-30T14:53:59.515Z",
"pullStopTime":"2020-12-30T14:54:03.395Z","initialDocCount":213,"docCount":213,
"pushed":2,
"pushStartTime":"2020-12-30T14:54:03.455Z",
"initialPushLastSeq":212,
"pushStopTime":"2020-12-30T14:54:07.770Z",
"tangerineVersion":""}
```

