### PR TITLE
Fix print metadata for some forms

### DIFF
--- a/editor/src/app/groups/print-form-as-table/print-form-as-table.component.ts
+++ b/editor/src/app/groups/print-form-as-table/print-form-as-table.component.ts
@@ -28,11 +28,8 @@ export class PrintFormAsTableComponent implements OnInit {
     const myForm = forms.find(e => e['id'] === formId);
     const formHtml = await this.http.get(`/editor/${groupId}/content/${myForm.id}/form.html`, { responseType: 'text' }).toPromise();
     const container = this.container.nativeElement;
-    const appConfig = await this.appConfigService.getAppConfig(groupId);
-    const appConfigCategories = appConfig.categories;
-    const categories = JSON.stringify(appConfigCategories);
     container.innerHTML = `
-    <tangy-form-editor style="margin:15px; display:none;" categories ='${categories}' print>${formHtml}</tangy-form-editor>
+      ${formHtml}
     `;
     this.meta = (container.querySelector('tangy-form')).getMeta();
   }


### PR DESCRIPTION
On some forms, printing as a table is failing because there is no tangy-form element. I debugged this and see the tangy-form markup is getting applied but because it's being injected into a tangy-form-editor, tangy-form-editor is consuming it and then removing it. I'm surprised this works for some forms, from quick tests it seems like tangy-form-editor doesn't always remove the inner tangy-form which is actually a bug in tangy-form-editor. 

The fix for this is to skip injecting the tangy-form into a tangy-form-editor and just put the tangy-form markup in the invisible container. @evansdianga Do you see any problem with this approach?