### PR TITLE
Deactivate App.checkStorageUsage if using Sync Protocol 2 and add keepGpsActive setting

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -161,9 +161,13 @@ export class AppComponent implements OnInit {
     });
 
     // Keep GPS chip warm.
-    setInterval(this.getGeolocationPosition, 5000);
-    this.checkStorageUsage();
-    setInterval(this.checkStorageUsage.bind(this), 60 * 1000);
+    if (this.appConfig.keepGpsActive) {
+      setInterval(this.getGeolocationPosition, 5000);
+    }
+    if (this.appConfig.syncProtocol !== '2') {
+      this.checkStorageUsage();
+      setInterval(this.checkStorageUsage.bind(this), 60 * 1000);
+    }
     this.ready = true;
 
     // Lastly, navigate to update page if an update is running.

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -30,6 +30,7 @@ export class AppConfig {
   couchdbPushUsingDocIds:boolean
   autoMergeConflicts:boolean
   attachHistoryToDocs:boolean = false
+  keepGpsActive:boolean
   indexViewsOnlyOnFirstSync:boolean = false
   pushChunkSize:number
   pullChunkSize:number


### PR DESCRIPTION
- App.checkStorageUsage is not compatible with Sync Protocol 2. It depends on SP1 metadata of last synced to decide what to start deleting thus when data starts being deleted on SP2, it may be seemingly random. 
- Many projects don't use GPS and thus have been paying for the battery life consumed by keeping the GPS chip active. This PR adds a `keepGpsActive` setting that makes this feature an opt-in.