### PR TITLE
Add AppConfig.filterCaseEventScheduleByDeviceAssignedLocation to allow filtering of Case Event Schedule by Device's Assigned Location

### DIFF
--- a/client/src/app/case-home/components/case-event-schedule/case-event-schedule.component.ts
+++ b/client/src/app/case-home/components/case-event-schedule/case-event-schedule.component.ts
@@ -114,7 +114,7 @@ export class CaseEventScheduleComponent implements OnInit {
       const deviceInfo = await this.deviceService.getDevice()
       const lowestLevelOfLocation = deviceInfo.assignedLocation.value[deviceInfo.assignedLocation.value.length-1]
       const caseIdsThatMatchDeviceAssignedLocation = cases
-        .filter(caseInstance => caseInstance.location[lowestLevelOfLocation.level] === lowestLevelOfLocation.value)
+        .filter(caseInstance => caseInstance['location'][lowestLevelOfLocation.level] === lowestLevelOfLocation.value)
         .map(caseInstance => caseInstance._id)
       caseEvents = caseEvents.filter(caseEvent => caseIdsThatMatchDeviceAssignedLocation.includes(caseEvent.caseId))
     }

--- a/client/src/app/case-home/components/case-event-schedule/case-event-schedule.component.ts
+++ b/client/src/app/case-home/components/case-event-schedule/case-event-schedule.component.ts
@@ -1,3 +1,4 @@
+import { DeviceService } from './../../../device/services/device.service';
 import { TangyFormResponse } from './../../../tangy-forms/tangy-form-response.class';
 import { FormInfo } from './../../../tangy-forms/classes/form-info.class';
 import { CaseDefinition } from 'src/app/case/classes/case-definition.class';
@@ -54,6 +55,7 @@ export class CaseEventScheduleComponent implements OnInit {
     private userService:UserService,
     private formsInfoService:TangyFormsInfoService,
     private caseService:CaseService,
+    private deviceService:DeviceService,
     private ref: ChangeDetectorRef
   ) {
     ref.detach()
@@ -98,6 +100,7 @@ export class CaseEventScheduleComponent implements OnInit {
   async render(caseEvents:Array<CaseEvent>) {
     // Get an array of unique cases found related to the events.
     const userDb = await this.userService.getUserDatabase(this.userService.getCurrentUser())
+    const appConfig = await this.appConfigService.getAppConfig()
     const cases:Array<TangyFormResponse> = []
     const uniqueCaseIds = caseEvents.reduce((uniqueCaseIds, caseEventInstance) => {
       return uniqueCaseIds.indexOf(caseEventInstance.caseId) === -1
@@ -106,6 +109,14 @@ export class CaseEventScheduleComponent implements OnInit {
     }, [])
     for (const caseId of uniqueCaseIds) {
       cases.push(await userDb.get(caseId))
+    }
+    if (appConfig.filterCaseEventScheduleByDeviceAssignedLocation) {
+      const deviceInfo = await this.deviceService.getDevice()
+      const lowestLevelOfLocation = deviceInfo.assignedLocation.value[deviceInfo.assignedLocation.value.length-1]
+      const caseIdsThatMatchDeviceAssignedLocation = cases
+        .filter(caseInstance => caseInstance.location[lowestLevelOfLocation.level] === lowestLevelOfLocation.value)
+        .map(caseInstance => caseInstance._id)
+      caseEvents = caseEvents.filter(caseEvent => caseIdsThatMatchDeviceAssignedLocation.includes(caseEvent.caseId))
     }
     // Keept track of days of week seen. When we detect a new day, add a dateLabel and dateNumber.
     let daysOfWeekSeen = []

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -31,6 +31,7 @@ export class AppConfig {
   autoMergeConflicts:boolean
   useEthiopianCalendar:boolean
   attachHistoryToDocs:boolean = false
+  filterCaseEventScheduleByDeviceAssignedLocation:boolean = false
   disableGpsWarming:boolean
   indexViewsOnlyOnFirstSync:boolean = false
   batchSize:number


### PR DESCRIPTION
## Description
Medical facilities viewing their schedule currently see all events on the schedule for all data they have. This creates confusion as users expect to see just the schedule for their location.

Demo: https://youtu.be/Ulh-yCqfbFA

## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution
Add AppConfig.filterCaseEventScheduleByDeviceAssignedLocation to allow filtering of Case Event Schedule by Device's Assigned Location.

## Limitations and Trade-offs
This PR still results in loading all events given timespan from all known locations in memory, than filters. This could be refactored to filter at the database query level. It also might be nice to have UI to switch between filters of all known events vs. event for the assigned location. This is MVP.

## Todo 
* [ ] Document AppConfig.filterCaseEventScheduleByDeviceAssignedLocation