### PR TITLE
Deactivate Participant API

### DIFF
--- a/client/src/app/case/classes/case-participant.class.ts
+++ b/client/src/app/case/classes/case-participant.class.ts
@@ -1,6 +1,7 @@
 interface CaseParticipant {
   id:string
   caseRoleId:string
+  inactive:boolean
   data:any  
 }
 

--- a/client/src/app/case/components/event-forms-for-participant/event-forms-for-participant.component.html
+++ b/client/src/app/case/components/event-forms-for-participant/event-forms-for-participant.component.html
@@ -1,5 +1,5 @@
 <div class="form-cards"
-    *ngIf="participantInfo.caseEventHasEventFormsForParticipantsRole"
+    *ngIf="participantInfo.caseEventHasEventFormsForParticipantsRole && ((participantInfo.eventFormsParticipantCanCreate && participantInfo.eventFormsParticipantCanCreate.length > 0) || participantInfo.eventFormInfos.length > 0)"
 >
   <h2 [innerHTML]="participantInfo.renderedListItem|unsanitizeHtml"></h2>
   <div 

--- a/client/src/app/case/components/event-forms-for-participant/event-forms-for-participant.component.ts
+++ b/client/src/app/case/components/event-forms-for-participant/event-forms-for-participant.component.ts
@@ -121,9 +121,11 @@ export class EventFormsForParticipantComponent implements OnInit {
       renderedListItem,
       newFormLink: `/case/event/form-add/${this.caseService.case._id}/${this.caseEvent.id}/${participant.id}`,
       caseEventHasEventFormsForParticipantsRole: this.caseEventDefinition.eventFormDefinitions.some(eventDef => eventDef.forCaseRole === participant.caseRoleId),
-      eventFormsParticipantCanCreate: this.eventFormsParticipantCanCreate(participant.id),
+      eventFormsParticipantCanCreate: participant.inactive
+        ? []
+        : this.eventFormsParticipantCanCreate(participant.id),
       eventFormInfos: this.caseEvent.eventForms.reduce((eventFormInfos, eventForm) => {
-        return eventForm.participantId === participant.id
+        return eventForm.participantId === participant.id && (!participant.inactive || eventForm.formResponseId)
           ? [...eventFormInfos, <EventFormInfo>{
             eventForm,
             eventFormDefinition: this


### PR DESCRIPTION
## Description
Sometimes in the lifetime of a Case we'll want to deactivate a Participant so that any forms without data entry are no longer required or shown.

## Type of Change
- New feature (non-breaking change which adds functionality)

## Proposed Solution
```
T.case.activateParticipant(participantId)
T.case.deactivateParticipant(participantId)
```

## Limitations and Trade-offs
Perhaps we need a way to fully remove a participant sometimes. That would be a different API.

## Screenshots/Videos
Demo: https://youtu.be/Ulh-yCqfbFA


## Tests
See the video for how to test using the Case Module content set.

## Notices, Regressions, Breaking Changes
None.

## TODOS/enhancements
This could use unit tests.