### PR TITLE
Device User Role access to Case Events and Event Forms

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -105,7 +105,9 @@ export class AppComponent implements OnInit {
   }
   
   async ngOnInit() {
-
+    this.window.isPreviewContext = window.location.hostname === 'localhost'
+      ? true
+      : false
     this.installed = await this.variableService.get('installed') && await this.variableService.get('languageCode')
       ? true
       : false;

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -140,6 +140,7 @@ export class AppComponent implements OnInit {
 
     await this.checkPermissions();
     // Initialize services.
+    await this.deviceService.initialize()
     await this.userService.initialize();
 
     // Get globally exposed config.

--- a/client/src/app/case/classes/case-event-definition.class.ts
+++ b/client/src/app/case/classes/case-event-definition.class.ts
@@ -1,10 +1,19 @@
 import { EventFormDefinition } from './event-form-definition.class'
 
+
+interface CaseEventAccess {
+  create:Array<string>
+  read:Array<string>
+  update:Array<string>
+  delete:Array<string>
+}
+
 class CaseEventDefinition {
 
   id:string
   name:string
   eventFormDefinitions:Array<EventFormDefinition> = []
+  access:CaseEventAccess
   repeatable?:boolean = false
   required?:boolean = false
   templateListItemIcon?:string
@@ -21,4 +30,4 @@ class CaseEventDefinition {
 
 }
 
-export { CaseEventDefinition }
+export { CaseEventDefinition, CaseEventAccess }

--- a/client/src/app/case/classes/case-event-definition.class.ts
+++ b/client/src/app/case/classes/case-event-definition.class.ts
@@ -1,19 +1,13 @@
+import { UserRole } from 'src/app/shared/_services/user.service'
 import { EventFormDefinition } from './event-form-definition.class'
 
-
-interface CaseEventAccess {
-  create:Array<string>
-  read:Array<string>
-  update:Array<string>
-  delete:Array<string>
-}
 
 class CaseEventDefinition {
 
   id:string
   name:string
   eventFormDefinitions:Array<EventFormDefinition> = []
-  access:CaseEventAccess
+  permissions:CaseEventPermissions
   repeatable?:boolean = false
   required?:boolean = false
   templateListItemIcon?:string
@@ -30,4 +24,18 @@ class CaseEventDefinition {
 
 }
 
-export { CaseEventDefinition, CaseEventAccess }
+export enum CaseEventOperation {
+  CREATE = 'create',
+  READ = 'read',
+  UPDATE = 'update',
+  DELETE = 'delete'
+}
+
+export interface CaseEventPermissions {
+  [CaseEventOperation.CREATE]:Array<UserRole>
+  [CaseEventOperation.READ]:Array<UserRole>
+  [CaseEventOperation.UPDATE]:Array<UserRole>
+  [CaseEventOperation.DELETE]:Array<UserRole>
+}
+
+export { CaseEventDefinition }

--- a/client/src/app/case/classes/event-form-definition.class.ts
+++ b/client/src/app/case/classes/event-form-definition.class.ts
@@ -1,8 +1,11 @@
+import { UserRole } from "src/app/shared/_services/user.service"
+
 export class EventFormDefinition {
 
   id:string
   formId:string
   name:string
+  permissions:EventFormPermissions
   // @TODO: roles[string]
   forCaseRole?:string = ''
   // Wether or not multiple EventForm Instances can be created in the same EventForm for the same Participant.
@@ -24,16 +27,16 @@ export class EventFormDefinition {
   }
 }
 
-export enum EventFormAccessOperation {
-  CREATE = 'CREATE',
-  READ = 'READ',
-  UPDATE = 'UPDATE',
-  DELETE = 'DELETE'
+export enum EventFormOperation {
+  CREATE = 'create',
+  READ = 'read',
+  UPDATE = 'update',
+  DELETE = 'delete'
 }
 
-export interface EventFormAccess {
-  create:Array<string>
-  read:Array<string>
-  update:Array<string>
-  delete:Array<string>
+export interface EventFormPermissions {
+  [EventFormOperation.CREATE]:Array<UserRole>
+  [EventFormOperation.READ]:Array<UserRole>
+  [EventFormOperation.UPDATE]:Array<UserRole>
+  [EventFormOperation.DELETE]:Array<UserRole>
 }

--- a/client/src/app/case/classes/event-form-definition.class.ts
+++ b/client/src/app/case/classes/event-form-definition.class.ts
@@ -23,3 +23,17 @@ export class EventFormDefinition {
   constructor() {
   }
 }
+
+export enum EventFormAccessOperation {
+  CREATE = 'CREATE',
+  READ = 'READ',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE'
+}
+
+export interface EventFormAccess {
+  create:Array<string>
+  read:Array<string>
+  update:Array<string>
+  delete:Array<string>
+}

--- a/client/src/app/case/classes/event-form.class.ts
+++ b/client/src/app/case/classes/event-form.class.ts
@@ -3,7 +3,6 @@ class EventForm {
   eventFormDefinitionId:string;
   formResponseId?:string;
   participantId?:string
-  access:EventFormAccess
   complete?:boolean = false
   required?:boolean = false
   caseId?:string;
@@ -19,13 +18,6 @@ class EventForm {
   constructor() {
 
   }
-}
-
-interface EventFormAccess {
-  create:Array<string>
-  read:Array<string>
-  update:Array<string>
-  delete:Array<string>
 }
 
 export { EventForm }

--- a/client/src/app/case/classes/event-form.class.ts
+++ b/client/src/app/case/classes/event-form.class.ts
@@ -3,6 +3,7 @@ class EventForm {
   eventFormDefinitionId:string;
   formResponseId?:string;
   participantId?:string
+  access:EventFormAccess
   complete?:boolean = false
   required?:boolean = false
   caseId?:string;
@@ -18,6 +19,13 @@ class EventForm {
   constructor() {
 
   }
+}
+
+interface EventFormAccess {
+  create:Array<string>
+  read:Array<string>
+  update:Array<string>
+  delete:Array<string>
 }
 
 export { EventForm }

--- a/client/src/app/case/components/case-event-list-item/case-event-list-item.component.css
+++ b/client/src/app/case/components/case-event-list-item/case-event-list-item.component.css
@@ -1,0 +1,3 @@
+:host[disabled] > * {
+    opacity:.5 !important;
+}

--- a/client/src/app/case/components/case/case.component.css
+++ b/client/src/app/case/components/case/case.component.css
@@ -1,5 +1,4 @@
 
-
 .confirm-correct-case-prompt {
     width: 100%;
     margin-top: 15px;

--- a/client/src/app/case/components/case/case.component.html
+++ b/client/src/app/case/components/case/case.component.html
@@ -14,10 +14,21 @@
 <app-case-notifications></app-case-notifications>
 <div class="wrapper">
   <div class="cover-when-not-confirmed" *ngIf="caseService.openCaseConfirmed === false"></div>
-  <div *ngFor="let eventInfo of caseEventsInfo">
+  <div *ngFor="let eventInfo of readableCaseEventsInfo">
     <app-case-event-list-item *ngFor="let caseEvent of eventInfo.caseEvents" [caseEvent]="caseEvent"
       [caseDefinition]="caseService.caseDefinition" [caseEventDefinition]="eventInfo.caseEventDefinition"
       [case]="caseService.case" routerLink="/case/event/{{caseService.case._id}}/{{caseEvent.id}}">
+    </app-case-event-list-item>
+  </div>
+  <div *ngFor="let eventInfo of unreadableCaseEventsInfo">
+    <app-case-event-list-item
+      *ngFor="let caseEvent of eventInfo.caseEvents" 
+      disabled
+      [caseEvent]="caseEvent"
+      [caseDefinition]="caseService.caseDefinition"
+      [caseEventDefinition]="eventInfo.caseEventDefinition"
+      [case]="caseService.case"
+    >
     </app-case-event-list-item>
   </div>
   <div class="icon-list-item event new-event">

--- a/client/src/app/case/components/event-form-add/event-form-add.component.ts
+++ b/client/src/app/case/components/event-form-add/event-form-add.component.ts
@@ -1,4 +1,4 @@
-import { EventFormAccessOperation, EventFormDefinition } from './../../classes/event-form-definition.class';
+import { EventFormDefinition, EventFormOperation } from './../../classes/event-form-definition.class';
 import { Component, OnInit, AfterContentInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CaseService } from '../../services/case.service'
@@ -88,7 +88,7 @@ export class EventFormAddComponent implements AfterContentInit {
       }, [])
     const availableEventFormDefinitions = []
     for (const eventFormDefinition of availableEventFormDefinitionsForParticipant) {
-      if (await this.caseService.hasEventFormAccess(EventFormAccessOperation.CREATE, this.caseEvent.caseEventDefinitionId, eventFormDefinition)) {
+      if (await this.caseService.hasEventFormPermission(EventFormOperation.CREATE, eventFormDefinition)) {
         availableEventFormDefinitions.push(eventFormDefinition)
       }
     }

--- a/client/src/app/case/components/event-form-add/event-form-add.component.ts
+++ b/client/src/app/case/components/event-form-add/event-form-add.component.ts
@@ -1,4 +1,4 @@
-import { EventFormDefinition } from './../../classes/event-form-definition.class';
+import { EventFormAccessOperation, EventFormDefinition } from './../../classes/event-form-definition.class';
 import { Component, OnInit, AfterContentInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CaseService } from '../../services/case.service'
@@ -67,14 +67,14 @@ export class EventFormAddComponent implements AfterContentInit {
           }
         })
       this.selectedParticipant = params.participantId
-      this.calculateAvailableEventFormDefinitionsForParticipant(params.participantId)
+      await this.calculateAvailableEventFormDefinitions(params.participantId)
       this.loaded = true
     })
   }
 
-  calculateAvailableEventFormDefinitionsForParticipant(participantId) {
+  async calculateAvailableEventFormDefinitions(participantId) {
     const participant = this.caseService.case.participants.find(participant => participant.id === participantId)
-    this.availableEventFormDefinitions = this.caseEventDefinition.eventFormDefinitions
+    const availableEventFormDefinitionsForParticipant = this.caseEventDefinition.eventFormDefinitions
       .filter(eventFormDefinition => eventFormDefinition.forCaseRole === participant.caseRoleId)
       .reduce((availableEventFormDefinitions, eventFormDefinition) => {
         const eventFormDefinitionHasForm = this.caseEvent.eventForms
@@ -86,6 +86,13 @@ export class EventFormAddComponent implements AfterContentInit {
           ? [...availableEventFormDefinitions, eventFormDefinition]
           : availableEventFormDefinitions
       }, [])
+    const availableEventFormDefinitions = []
+    for (const eventFormDefinition of availableEventFormDefinitionsForParticipant) {
+      if (await this.caseService.hasEventFormAccess(EventFormAccessOperation.CREATE, this.caseEvent.caseEventDefinitionId, eventFormDefinition)) {
+        availableEventFormDefinitions.push(eventFormDefinition)
+      }
+    }
+    this.availableEventFormDefinitions = availableEventFormDefinitions
   }
 
   onFormSelect(formId) {

--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.css
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.css
@@ -1,9 +1,10 @@
 .required {
     border-left: red solid 4px;
 }
-.no-response {
+.disabled {
 	opacity: .5;
 }
+
 .icon-list-item {
 	display: flex;
 	flex-direction: row;

--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.html
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.html
@@ -1,6 +1,6 @@
 
 
-<div *ngIf="this.response || (!this.response && !eventForm.formResponseId)" class="icon-list-item {{eventForm.required ? 'required' : ''}}" >
+<div *ngIf="(this.response || (!this.response && !eventForm.formResponseId)) && !this.hasAccess" class="icon-list-item {{eventForm.required ? 'required' : ''}}" >
 	<mwc-icon routerLink="/case/event/form/{{eventForm.caseId}}/{{eventForm.caseEventId}}/{{eventForm.id}}" [innerHTML]="renderedTemplateListItemIcon" slot="item-icon"></mwc-icon>
 	<div routerLink="/case/event/form/{{eventForm.caseId}}/{{eventForm.caseEventId}}/{{eventForm.id}}">
 		<div [innerHTML]="renderedTemplateListItemPrimary|unsanitizeHtml"></div>
@@ -11,7 +11,7 @@
 		<paper-button (click)="deleteItem()" class="button"><mwc-icon>delete</mwc-icon></paper-button>
 	</span>
 </div>
-<div *ngIf="!this.response && eventForm.formResponseId" class="no-response icon-list-item {{eventForm.required ? 'required' : ''}}" >
+<div *ngIf="(!this.response && eventForm.formResponseId) || this.hasAccess" class="disabled icon-list-item {{eventForm.required ? 'required' : ''}}" >
 	<mwc-icon [innerHTML]="renderedTemplateListItemIcon" slot="item-icon"></mwc-icon>
 	<div>
 		<div [innerHTML]="renderedTemplateListItemPrimary|unsanitizeHtml"></div>

--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.html
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.html
@@ -1,6 +1,6 @@
 
 
-<div *ngIf="(this.response || (!this.response && !eventForm.formResponseId)) && !this.hasAccess" class="icon-list-item {{eventForm.required ? 'required' : ''}}" >
+<div *ngIf="(this.response || (!this.response && !eventForm.formResponseId)) && this.canOpen" class="icon-list-item {{eventForm.required ? 'required' : ''}}" >
 	<mwc-icon routerLink="/case/event/form/{{eventForm.caseId}}/{{eventForm.caseEventId}}/{{eventForm.id}}" [innerHTML]="renderedTemplateListItemIcon" slot="item-icon"></mwc-icon>
 	<div routerLink="/case/event/form/{{eventForm.caseId}}/{{eventForm.caseEventId}}/{{eventForm.id}}">
 		<div [innerHTML]="renderedTemplateListItemPrimary|unsanitizeHtml"></div>
@@ -11,7 +11,7 @@
 		<paper-button (click)="deleteItem()" class="button"><mwc-icon>delete</mwc-icon></paper-button>
 	</span>
 </div>
-<div *ngIf="(!this.response && eventForm.formResponseId) || this.hasAccess" class="disabled icon-list-item {{eventForm.required ? 'required' : ''}}" >
+<div *ngIf="(!this.response && eventForm.formResponseId) || !this.canOpen" class="disabled icon-list-item {{eventForm.required ? 'required' : ''}}" >
 	<mwc-icon [innerHTML]="renderedTemplateListItemIcon" slot="item-icon"></mwc-icon>
 	<div>
 		<div [innerHTML]="renderedTemplateListItemPrimary|unsanitizeHtml"></div>

--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.ts
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.ts
@@ -1,3 +1,5 @@
+import { EventFormsForParticipantComponent } from './../event-forms-for-participant/event-forms-for-participant.component';
+import { UserService } from 'src/app/shared/_services/user.service';
 import { Component, OnInit, Input, ChangeDetectorRef, Output, EventEmitter } from '@angular/core';
 import { CaseEvent } from '../../classes/case-event.class';
 import { Case } from '../../classes/case.class';
@@ -5,7 +7,7 @@ import { CaseEventDefinition } from '../../classes/case-event-definition.class';
 import { _TRANSLATE } from 'src/app/shared/translation-marker';
 import { DatePipe } from '@angular/common';
 import * as moment from 'moment';
-import { EventFormDefinition } from '../../classes/event-form-definition.class';
+import { EventFormAccessOperation, EventFormDefinition } from '../../classes/event-form-definition.class';
 import { EventForm } from '../../classes/event-form.class';
 import { CaseDefinition } from '../../classes/case-definition.class';
 import { TangyFormService } from 'src/app/tangy-forms/tangy-form.service';
@@ -28,6 +30,7 @@ export class EventFormListItemComponent implements OnInit {
   @Input() eventFormDefinition: EventFormDefinition;
   @Input() eventForm: EventForm;
   @Output() formDeleted = new EventEmitter();
+  canOpen:Boolean
 
   defaultTemplateListItemIcon = `\${eventForm.complete ? 'assignment_turned_in' : 'assignment'}`;
   defaultTemplateListItemPrimary = `
@@ -46,16 +49,31 @@ export class EventFormListItemComponent implements OnInit {
   constructor(
     private formService: TangyFormService,
     private ref: ChangeDetectorRef,
+    private userService:UserService,
     private caseService: CaseService
   ) {
     ref.detach();
   }
 
   async ngOnInit() {
-    this.canUserDeleteForms = ((this.eventFormDefinition.allowDeleteIfFormNotCompleted && !this.eventForm.complete)
-    || (this.eventFormDefinition.allowDeleteIfFormNotStarted && !this.eventForm.formResponseId));
     const response = await this.formService.getResponse(this.eventForm.formResponseId);
     this.response = response
+    // Figure out if user can open this EventForm.
+    if (this.eventForm.formResponseId && !this.response) {
+      // There is a form response for this Event Form, but it's not on this device.
+      this.canOpen = false
+    } else if (!this.eventForm.complete) {
+      // The Event Form has not been completed so opening would be an UPDATE operation.
+      this.canOpen = await this.caseService.hasEventFormAccess(EventFormAccessOperation.UPDATE, this.caseEvent.caseEventDefinitionId, this.eventForm.eventFormDefinitionId)
+    } else if (this.eventForm.complete) {
+      // The Event Form has been completed so opening would be a READ operation.
+      this.canOpen = await this.caseService.hasEventFormAccess(EventFormAccessOperation.READ, this.caseEvent.caseEventDefinitionId, this.eventForm.eventFormDefinitionId)
+    }
+    this.canUserDeleteForms = (
+        (this.eventFormDefinition.allowDeleteIfFormNotCompleted && !this.eventForm.complete) ||
+        (this.eventFormDefinition.allowDeleteIfFormNotStarted && !this.eventForm.formResponseId)
+      )  &&
+      await this.caseService.hasEventFormAccess(EventFormAccessOperation.DELETE, this.caseEvent.caseEventDefinitionId, this.eventForm.eventFormDefinitionId)
     const getValue = (variableName) => {
       if (response) {
         const variablesByName = response.items.reduce((variablesByName, item) => {

--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.ts
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.ts
@@ -7,7 +7,7 @@ import { CaseEventDefinition } from '../../classes/case-event-definition.class';
 import { _TRANSLATE } from 'src/app/shared/translation-marker';
 import { DatePipe } from '@angular/common';
 import * as moment from 'moment';
-import { EventFormAccessOperation, EventFormDefinition } from '../../classes/event-form-definition.class';
+import { EventFormDefinition, EventFormOperation } from '../../classes/event-form-definition.class';
 import { EventForm } from '../../classes/event-form.class';
 import { CaseDefinition } from '../../classes/case-definition.class';
 import { TangyFormService } from 'src/app/tangy-forms/tangy-form.service';
@@ -64,16 +64,16 @@ export class EventFormListItemComponent implements OnInit {
       this.canOpen = false
     } else if (!this.eventForm.complete) {
       // The Event Form has not been completed so opening would be an UPDATE operation.
-      this.canOpen = await this.caseService.hasEventFormAccess(EventFormAccessOperation.UPDATE, this.caseEvent.caseEventDefinitionId, this.eventForm.eventFormDefinitionId)
+      this.canOpen = await this.caseService.hasEventFormPermission(EventFormOperation.UPDATE, this.eventFormDefinition)
     } else if (this.eventForm.complete) {
       // The Event Form has been completed so opening would be a READ operation.
-      this.canOpen = await this.caseService.hasEventFormAccess(EventFormAccessOperation.READ, this.caseEvent.caseEventDefinitionId, this.eventForm.eventFormDefinitionId)
+      this.canOpen = await this.caseService.hasEventFormPermission(EventFormOperation.READ, this.eventFormDefinition)
     }
     this.canUserDeleteForms = (
         (this.eventFormDefinition.allowDeleteIfFormNotCompleted && !this.eventForm.complete) ||
         (this.eventFormDefinition.allowDeleteIfFormNotStarted && !this.eventForm.formResponseId)
       )  &&
-      await this.caseService.hasEventFormAccess(EventFormAccessOperation.DELETE, this.caseEvent.caseEventDefinitionId, this.eventForm.eventFormDefinitionId)
+      await this.caseService.hasEventFormPermission(EventFormOperation.DELETE, this.eventFormDefinition)
     const getValue = (variableName) => {
       if (response) {
         const variablesByName = response.items.reduce((variablesByName, item) => {

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -1,6 +1,7 @@
+import { CaseEventOperation, CaseEventPermissions } from './../classes/case-event-definition.class';
 import { UserService } from 'src/app/shared/_services/user.service';
 import { AppConfigService } from 'src/app/shared/_services/app-config.service';
-import { EventFormDefinition, EventFormAccessOperation } from './../classes/event-form-definition.class';
+import { EventFormDefinition, EventFormOperation } from './../classes/event-form-definition.class';
 import { Subject } from 'rxjs';
 import { NotificationStatus, Notification, NotificationType } from './../classes/notification.class';
 import { Issue, IssueStatus, IssueEvent, IssueEventType } from './../classes/issue.class';
@@ -267,16 +268,28 @@ class CaseService {
   /*
    * Role Access API
    */
-  async hasEventFormAccess(operation:EventFormAccessOperation, caseEventDefinitionId:string, eventFormDefinitionId:string) {
-    const deviceUserRole = await this.userService.getRole()
-    // @TODO Write this. But let's refactor to make it so users can have multiple roles.
-    return true
+  hasEventFormPermission(operation:EventFormOperation, eventFormDefinition:EventFormDefinition) {
+    if (
+        !eventFormDefinition.permissions ||
+        !eventFormDefinition.permissions[operation] ||
+        eventFormDefinition.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
+    ) {
+      return true
+    } else {
+      return false
+    }
   }
 
-  async hasCaseEventAccess(operation:EventFormAccessOperation, caseEventDefinitionId:string) {
-    const deviceUserRole = await this.userService.getRole()
-    // @TODO Write this. But let's refactor to make it so users can have multiple roles. Then implement this helper in the CaseComponent Class.
-    return true
+  hasCaseEventPermission(operation:CaseEventOperation, eventDefinition:CaseEventDefinition) {
+    if (
+        !eventDefinition.permissions ||
+        !eventDefinition.permissions[operation] ||
+        eventDefinition.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
+    ) {
+      return true
+    } else {
+      return false
+    }
   }
 
 

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -1,5 +1,6 @@
+import { UserService } from 'src/app/shared/_services/user.service';
 import { AppConfigService } from 'src/app/shared/_services/app-config.service';
-import { EventFormDefinition } from './../classes/event-form-definition.class';
+import { EventFormDefinition, EventFormAccessOperation } from './../classes/event-form-definition.class';
 import { Subject } from 'rxjs';
 import { NotificationStatus, Notification, NotificationType } from './../classes/notification.class';
 import { Issue, IssueStatus, IssueEvent, IssueEventType } from './../classes/issue.class';
@@ -103,6 +104,7 @@ class CaseService {
     private tangyFormService: TangyFormService,
     private caseDefinitionsService: CaseDefinitionsService,
     private deviceService:DeviceService,
+    private userService:UserService,
     private appConfigService:AppConfigService,
     private http:HttpClient
   ) {
@@ -261,6 +263,23 @@ class CaseService {
       ? this.case.items[0].inputs.find(input => input.name === variableName).value
       : undefined
   }
+
+  /*
+   * Role Access API
+   */
+  async hasEventFormAccess(operation:EventFormAccessOperation, caseEventDefinitionId:string, eventFormDefinitionId:string) {
+    const deviceUserRole = await this.userService.getRole()
+    // @TODO Write this. But let's refactor to make it so users can have multiple roles.
+    return true
+  }
+
+  async hasCaseEventAccess(operation:EventFormAccessOperation, caseEventDefinitionId:string) {
+    const deviceUserRole = await this.userService.getRole()
+    // @TODO Write this. But let's refactor to make it so users can have multiple roles. Then implement this helper in the CaseComponent Class.
+    return true
+  }
+
+
 
   /*
    * Case Event API

--- a/client/src/app/shared/_services/user.service.ts
+++ b/client/src/app/shared/_services/user.service.ts
@@ -272,6 +272,14 @@ export class UserService {
     }
   }
 
+  async getRole(username = '') {
+    const userProfile = await this.getUserProfile(username)
+    const roleInput = userProfile.items[0].inputs.find(input => input.name === 'role')
+    return roleInput
+      ? roleInput.value
+      : undefined 
+  }
+
   async create(userSignup:UserSignup):Promise<UserAccount> {
     let userAccount:UserAccount
     if (this.config.syncProtocol === '2') {

--- a/client/src/app/shared/_services/user.service.ts
+++ b/client/src/app/shared/_services/user.service.ts
@@ -219,6 +219,36 @@ export class UserService {
   async createAdmin(password:string, lockBoxContents:LockBoxContents):Promise<UserAccount> {
     // Open the admin's lockBox, copy it, and stash it in the new user's lockBox.
     const userProfile = new TangyFormResponseModel({form:{id:'user-profile'}})
+    userProfile.items = [
+      {
+        id: 'item1',
+        inputs: [
+          {
+            name: 'role',
+            value: 'admin'
+          },
+          {
+            name: 'first_name',
+            value: 'Admin of Device'
+          },
+          {
+            name: 'last_name',
+            value: `Device ID: ${lockBoxContents.device._id}`
+          },
+          {
+            name: 'location',
+            value: Object
+              .getOwnPropertyNames(lockBoxContents.device.assignedLocation)
+              .map(propName => { 
+                return { 
+                  level: propName,
+                  value: lockBoxContents.device.assignedLocation[propName]
+                }
+              })
+          }
+        ]
+      }
+    ]
     const userAccount = new UserAccount({
       _id: 'admin',
       password: this.hashValue(password),
@@ -257,7 +287,22 @@ export class UserService {
       const userLockBoxContents = <LockBoxContents>{...adminLockBox.contents}
       await this.lockBoxService.fillLockBox(userSignup.username, userSignup.password, userLockBoxContents)
       const device = adminLockBox.contents.device
-      const userProfile = new TangyFormResponseModel({form:{id:'user-profile'}})
+      const userProfile = new TangyFormResponseModel({
+        form:{
+          id:'user-profile'
+        },
+        items: [
+          {
+            id: 'item1',
+            inputs: [
+              {
+                name: 'role',
+                value: 'dataCollector'
+              }
+            ]
+          }
+        ]
+      })
       userAccount = new UserAccount({
         _id: userSignup.username,
         password: this.hashValue(userSignup.password),

--- a/client/src/app/user-profile/user-profile.component.ts
+++ b/client/src/app/user-profile/user-profile.component.ts
@@ -43,6 +43,7 @@ export class UserProfileComponent implements AfterContentInit {
       if (!userAccount.initialProfileComplete) {
         await this.userService.saveUserAccount(<UserAccount>{ ...userAccount, initialProfileComplete:true })
       }
+      await this.userService.setCurrentUser(this.userService.getCurrentUser())
       this.router.navigate([this.returnUrl]);
     })
     try {

--- a/content-sets/case-module/client/case-type-1.json
+++ b/content-sets/case-module/client/case-type-1.json
@@ -141,6 +141,185 @@
       ]
     },
     {
+      "id": "admin-create-read",
+      "name": "Admin can create and read, Data Collector has no permission",
+      "permissions": {
+        "create": ["admin"],
+        "read": ["admin"]
+      },
+      "repeatable": true,
+      "required": false,
+      "eventFormDefinitions": [
+         {
+          "id": "event-form-definition-abxo39",
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "name": "Test form",
+          "autoPopulate": true,
+          "required": true,
+          "repeatable": false
+        }        
+      ]
+    },
+    {
+      "id": "admin-create-read--dataCollector-read",
+      "name": "Admin can create and read, Data Collector can read.",
+      "permissions": {
+        "create": ["admin"],
+        "read": ["dataCollector", "admin"]
+      },
+      "repeatable": true,
+      "required": false,
+      "eventFormDefinitions": [
+        {
+          "id": "event-form-definition-abxo39",
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "name": "Test form",
+          "autoPopulate": true,
+          "required": true,
+          "repeatable": false
+        } 
+      ]
+    },
+    {
+      "id": "admin-create--dataCollector-read",
+      "name": "Admin can create, Data Collector can read.",
+      "permissions": {
+        "create": ["admin"],
+        "read": ["dataCollector"]
+      },
+      "repeatable": true,
+      "required": false,
+      "eventFormDefinitions": [
+        {
+          "id": "event-form-definition-abxo39",
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "name": "Test form",
+          "autoPopulate": true,
+          "required": true,
+          "repeatable": false
+        } 
+      ]
+    },
+    {
+      "id": "no-one-create--everyone-read",
+      "name": "No one can create, everyone can read.",
+      "permissions": {
+        "create": []
+      },
+      "repeatable": true,
+      "required": false,
+      "eventFormDefinitions": [
+        {
+          "id": "event-form-definition-abxo39",
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "name": "Test form",
+          "autoPopulate": true,
+          "required": true,
+          "repeatable": false
+        } 
+      ]
+    },
+    {
+      "id": "event-with-device-user-role-based-access-to-event-forms",
+      "name": "Event with DeviceUser Role based access to EventForm(s)",
+      "repeatable": true,
+      "required": false,
+      "eventFormDefinitions": [
+         {
+          "id": "admin-create-read-update-delete--data-collector-none",
+          "name": "Admin can create, read, update, and delete. Data Collector has no permission.",
+          "permissions": {
+            "create": ["admin"],
+            "read": ["admin"],
+            "update": ["admin"],
+            "delete": ["admin"]
+          },
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "allowDeleteIfFormNotCompleted": true,
+          "allowDeleteIfFormNotStarted": true,
+          "autoPopulate": false,
+          "required": true,
+          "repeatable": true 
+        },
+        {
+          "id": "admin-create-read-update-delete--data-collector-update",
+          "name": "Admin can create, read, update, and delete. Data Collector can update.",
+          "permissions": {
+            "create": ["admin"],
+            "read": ["admin"],
+            "update": ["admin", "dataCollector"],
+            "delete": ["admin"]
+          },
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "allowDeleteIfFormNotCompleted": true,
+          "allowDeleteIfFormNotStarted": true,
+          "autoPopulate": false,
+          "required": true,
+          "repeatable": true 
+        },
+        {
+          "id": "no-one-create--everyone-read-update-delete",
+          "name": "No one can create. Everyone can read, update, and delete.",
+          "permissions": {
+            "create": []
+          },
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "allowDeleteIfFormNotCompleted": true,
+          "allowDeleteIfFormNotStarted": true,
+          "autoPopulate": false,
+          "required": true,
+          "repeatable": true 
+        },
+        {
+          "id": "everyone-create-read-update--admin-delete",
+          "name": "Everyone can create, read, and update. Admin can delete.",
+          "permissions": {
+            "delete": ["admin"]
+          },
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "allowDeleteIfFormNotCompleted": true,
+          "allowDeleteIfFormNotStarted": true,
+          "autoPopulate": false,
+          "required": true,
+          "repeatable": true 
+        }
+      ]
+    },
+    {
+      "id": "another-event-with-role-2-forms",
+      "name": "Another event with role 2 forms",
+      "repeatable": true,
+      "required": false,
+      "eventFormDefinitions": [
+        {
+          "id": "event-form-definition-abxo39",
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "name": "Example of an Event Form that DOES NOT auto-populate when a participant is added or the event is created.",
+          "autoPopulate": false,
+          "required": false,
+          "repeatable": false
+        },
+        {
+          "id": "event-form-definition-aieb38",
+          "formId": "test-form",
+          "forCaseRole": "role-2",
+          "name": "Example of an Event Form that DOES auto-populate when a participant is added or the event is created.",
+          "autoPopulate": true,
+          "required": false,
+          "repeatable": false
+        }
+      ]
+    },
+    {
       "id": "change-location-of-case",
       "name": "Change location of case",
       "repeatable": true,

--- a/content-sets/default/client/user-profile/form.html
+++ b/content-sets/default/client/user-profile/form.html
@@ -1,7 +1,7 @@
-<tangy-form id="user-profile" title="User Profile">
+<tangy-form id="user-profile">
   <tangy-form-item id="item1" title="User Profile"
     on-open="
-      if (window.isEditorContext) {
+      if (window.isEditorContext || window.isPreviewContext) {
         inputs.role.removeAttribute('disabled')
       } else {
         inputs.role.setAttribute('disabled', '')

--- a/content-sets/default/client/user-profile/form.html
+++ b/content-sets/default/client/user-profile/form.html
@@ -1,37 +1,19 @@
 <tangy-form id="user-profile" title="User Profile">
-  <tangy-form-item id="item-1" title="User Profile">
-    <template>
-      <tangy-input 
-        error-message="required" 
-        type="text" 
-        name="first_name" 
-        required 
-        label="First name">
-      </tangy-input>
-      <tangy-input 
-        error-message="required" 
-        type="text" 
-        name="last_name" 
-        required 
-        label="Last name">
-      </tangy-input>
-      <tangy-radio-buttons label="Gender" name="gender" required>
-        <option value="female">Female</option>
-        <option value="male">Male</option>
-      </tangy-radio-buttons>
-      <tangy-input 
-        error-message="required" 
-        type="number" 
-        name="phone" 
-        required 
-        label="Phone number">
-      </tangy-input>
-      <tangy-location
-        error-message="required" 
-        name="location" 
-        required 
-        label="Location">
-      </tangy-location>
-    </template>
+  <tangy-form-item id="item1" title="User Profile"
+    on-open="
+      if (window.isEditorContext) {
+        inputs.role.removeAttribute('disabled')
+      } else {
+        inputs.role.setAttribute('disabled', '')
+      }
+    "
+  >
+    <tangy-input name="first_name" type="text" label="First name" required></tangy-input>
+    <tangy-input name="last_name" type="text" label="Last name" required></tangy-input>
+    <tangy-select name="role" label="Role" disabled>
+      <option value="dataCollector">Data Collector</option>
+      <option value="admin">Admin</option>
+    </tangy-select>
+    <tangy-location name="location" label="Assigned location" show-level="region,district,facility"></tangy-location>
   </tangy-form-item>
 </tangy-form>


### PR DESCRIPTION
## Description

Content Developers would like to limit access to Case Events and Event Forms to specific groups of Device Users. 


## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution
This PR adds a new `CaseEventDefinition.access` API and `EventFormDefinition.access` API to allow Content Developers to define which "roles" of Device Users can create and read Case Events/Events Forms and update and delete Event Forms.

## Limitations and Trade-offs
This PR defines access on the CaseEventDefinition and EventFormDefinition level. I can imagine someone will at some point want to be able to override via programmatic API those settings on a per CaseEvent and EventForm instance.

## Screenshots/Videos
- [Demo: Device User role based access to Event Forms](https://youtu.be/T0GfYHw6t6k)
- [Demo: Device user role based permissions for Case Events](https://www.youtube.com/watch?v=5okk6XrrfaA&feature=youtu.be)

## Tests
Follow the video and test content provided.

## Notices, Regressions, Breaking Changes
None. If `CaseEventDefinition.access` and `EventFormDefinition.access` are not defined in the Case Definition, the logic for CRUD works the same as it did before.

## TODOS/enhancements
* [x] Develop the `CaseEventDefinition.access` API.
* [x] Create demonstration of `CaseEventDefinition.access` API.
* [x] Develop the `EventFormDefinition.access` API.
* [x] Create demonstration of the `EventFormDefinition.access` API.
* [ ] Create demonstration of adding Roles to your Content Set's profile. 
