### PR TITLE
When rebasing, if the Issue's CaseEvent or EventForm is no longer on the Case due to being removed or Data Conflict, add it back in the proposed changes to the Case.

### DIFF
--- a/editor/src/app/case/services/case.service.ts
+++ b/editor/src/app/case/services/case.service.ts
@@ -613,6 +613,37 @@ class CaseService {
     const issue = new Issue(await this.tangyFormService.getResponse(issueId))
     const caseInstance = await this.tangyFormService.getResponse(issue.caseId)
     const response = await this.tangyFormService.getResponse(issue.formResponseId)
+    // If the Event or Event Form related to issue are not longer in the caseInstance, restore them.
+    // This may be due to either the Event or Event Form being removed, or a Data Conflict where this Event or Event Form is in the losing revision.
+    let currentEvent = caseInstance.events.find(event => event.id === issue.eventId)
+    if (!currentEvent) {
+      if (await this.hasProposedChange(issueId)) {
+        const proposedRevisionIssueEvent = await this.getProposedChange(issueId)
+        const theMissingCaseEvent = proposedRevisionIssueEvent.caseInstance.events.find(event => event.id === issue.eventId)
+        caseInstance.events.push(theMissingCaseEvent)
+      } else {
+        const baseEvent = [...issue.events].reverse().find(event => event.type === IssueEventType.Open || event.type === IssueEventType.Rebase)
+        const theMissingCaseEvent = baseEvent.data.caseInstance.events.find(event => event.id === issue.eventId)
+        caseInstance.events.push(theMissingCaseEvent)
+      }
+      currentEvent = caseInstance.events.find(event => event.id === issue.eventId)
+    }
+    let currentEventForm = currentEvent.find(eventForm => eventForm.id === issue.eventFormId)
+    if (!currentEventForm) {
+      if (await this.hasProposedChange(issueId)) {
+        const proposedRevisionIssueEvent = await this.getProposedChange(issueId)
+        const theMissingEventForm = proposedRevisionIssueEvent.caseInstance
+          .events.find(event => event.id === issue.eventId)
+          .eventForms.find(eventForm => eventForm.id === issue.eventFormId)
+        currentEvent.eventForms.push(theMissingEventForm)
+      } else {
+        const baseEvent = [...issue.events].reverse().find(event => event.type === IssueEventType.Open || event.type === IssueEventType.Rebase)
+        const theMissingEventForm = baseEvent.data.caseInstance
+          .events.find(event => event.id === issue.eventId)
+          .eventForms.find(eventForm => eventForm.id === issue.eventFormId)
+        currentEvent.eventForms.push(theMissingEventForm)
+      }
+    }
     issue.events.push(<IssueEvent>{
       id: UUID(),
       type: IssueEventType.Rebase,


### PR DESCRIPTION

## Description
Sometimes an Issue may point to a CaseEvent or EventForm that may no longer exist on current Case. This can happen because the CaseEvent or EventForm is removed from the Case, or due to a Data Conflict. The issue component will recognize a rebase is needed because a change in the Case has occurred since the Issue was opened, but when rebasing it does not bring back the CaseEvent or EventForm which results in a blank screen when the user goes to propose a change. 



## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

This PR adds logic to the rebase method that if the CaseEvent or EventForm does not exist on the Case, then take that CaseEvent or EventForm out of the stashed Case from when the Issue was created and add it to the rebased Case data in the Issue. This does not modify the current Case, it just makes this addition of the CaseEvent or EventForm part of the proposed change for merging. Because when you then propose a change to the Form Response the Case with the restored CaseEvent or EventForm is loaded, the program does not crash and the user is able to user the Form Response proposal mechanism.

## Limitations and Trade-offs
If the missing Case Event or Event Form is missing due to a Data Conflict, this does not mark that conflict as resolved and there may be additional data in the conflict rev that needs to be restored. This would at least restore some of data lost in conflict while any remaining data that needs to be restored is out of the scope of the issue this PR is trying to solve.

## Screenshots/Videos
To do.

## Tests
Will demonstrate in the demo video.

## Notices, Regressions, Breaking Changes
None.

## TODOS/enhancements
* [ ] Create demo video.
