### PR TITLE
Add print options to archived forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ __Fixes__
 - Enables editing of device description. Commit: [#2613](https://github.com/Tangerine-Community/Tangerine/issues/2613)
 
 __Server upgrade instructions__
+If you want to enable filtered Case Event Schedule by Device's Assigned Location, add `filterCaseEventScheduleByDeviceAssignedLocation` to your groups' `app-config.json` set to a value of `true`.
+
 Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __Fixes__
 - Enables editing of device description. Commit: [#2613](https://github.com/Tangerine-Community/Tangerine/issues/2613)
 
 __Server upgrade instructions__
+
 If you want to enable filtered Case Event Schedule by Device's Assigned Location, add `filterCaseEventScheduleByDeviceAssignedLocation` to your groups' `app-config.json` set to a value of `true`.
 
 Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.

--- a/editor/src/app/groups/group-forms/group-forms.component.html
+++ b/editor/src/app/groups/group-forms/group-forms.component.html
@@ -66,7 +66,7 @@
       </a>
     </span>
     <span>
-      <mat-select #test>
+      <mat-select #printActiveForm>
         <mat-option style="width:160px;">
           <a mat-icon-button target="_new" [href]="form.printUrl">{{'Print Content'|translate}}</a>
         </mat-option>
@@ -85,7 +85,7 @@
       </mat-select>
     </span>
     <span>
-      <a mat-icon-button (click)="test.open()">
+      <a mat-icon-button (click)="printActiveForm.open()">
         <i class="material-icons mat-32 tangy-location-list-icon">print</i>
       </a>
     </span>
@@ -169,8 +169,27 @@
       </a>
     </span>
 
-    <span >
-      <a mat-icon-button target="_new" href="{{form.printUrl}}">
+    <span>
+      <mat-select #printInActiveForm>
+        <mat-option style="width:160px;">
+          <a mat-icon-button target="_new" [href]="form.printUrl">{{'Print Content'|translate}}</a>
+        </mat-option>
+        <mat-option style="width:160px; ">
+          <a mat-icon-button target="_new"
+            [href]="groupUrl+'#/groups/'+groupId+'/printFormAsTable/'+form.id">{{'Print Metadata'|translate}}</a>
+        </mat-option>
+        <mat-option style="width:160px; ">
+          <a mat-icon-button target="_new"
+             [href]="groupUrl+'#/groups/'+groupId+'/printStimuliScreen/'+form.id">{{'Print Form Stimuli'|translate}}</a>
+        </mat-option>
+        <mat-option style="width:160px; ">
+          <a mat-icon-button target="_new"
+            [href]="groupUrl+'#/groups/'+groupId+'/printFormBackup/'+form.id">{{'Print Form Backup'|translate}}</a>
+        </mat-option>
+      </mat-select>
+    </span>
+    <span>
+      <a mat-icon-button (click)="printInActiveForm.open()">
         <i class="material-icons mat-32 tangy-location-list-icon">print</i>
       </a>
     </span>


### PR DESCRIPTION
## Description

---

The print option for archived forms should offer equivalent functionality as the one for active forms

- Fixes #1987 

## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution

---

Add the necessary markup and event handlers

## Screenshots/Videos

---
![image](https://user-images.githubusercontent.com/6088118/108846710-eedc9880-75ef-11eb-96a8-17709805aa7b.png)


