### PR TITLE
Fix to allow for running on m1 Macs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install global node dependencies
+# set unsafe-perm true allows it to work on ARM Macs(M1)
+RUN npm config set unsafe-perm true
 RUN npm install -g nodemon uuid
-
+RUN npm config set unsafe-perm false
 # T_USER1 is the username of the first user you will log in as. It is also the super user that has all permissions. 
 ENV T_USER1 user1
 ENV T_USER1_PASSWORD password


### PR DESCRIPTION
## Description

---
Running `develop.sh` script fails on Apple Silicon Macs, See below
<img width="1215" alt="Screenshot 2021-02-22 at 17 21 55" src="https://user-images.githubusercontent.com/6088118/109136581-536f3300-7769-11eb-938d-215dda99bdd6.png">

<img width="1057" alt="Screenshot 2021-02-25 at 12 58 49" src="https://user-images.githubusercontent.com/6088118/109136493-3b97af00-7769-11eb-88c8-9f717df76c75.png">

## Type of Change

- New feature (non-breaking change which adds functionality)



## Proposed Solution

---

When installing global modules run the command `npm config set unsafe-perm true` then disable it by `npm config set unsafe-perm true`
[Explanatory Blog Post Here](https://geedew.com/What-does-unsafe-perm-in-npm-actually-do/)

