### PR TITLE
UI improvements archiving

### DIFF
--- a/editor/src/app/groups/group-releases/group-releases.component.html
+++ b/editor/src/app/groups/group-releases/group-releases.component.html
@@ -17,14 +17,14 @@
             <tr>
               <th>Release Type</th>
               <th>Generate</th>
-              <th>List</th>
+              <th *ngIf="T_ARCHIVE_APKS_TO_DISK">List</th>
             </tr>
             <tr>
               <td>Test</td>
               <td class="tangy-foreground-secondary link" routerLink="release-apk-test">
                 <iron-icon icon="assignment-late"></iron-icon> {{'Generate Test Release'|translate}}
               </td>
-              <td class="tangy-foreground-secondary link archives" routerLink="historical-releases-apk-test">
+              <td *ngIf="T_ARCHIVE_APKS_TO_DISK" class="tangy-foreground-secondary link archives" routerLink="historical-releases-apk-test">
                  <iron-icon icon="archive"></iron-icon> {{'Download Test Releases'|translate}}
               </td>
             </tr>
@@ -33,7 +33,7 @@
               <td class="tangy-foreground-secondary link" routerLink="release-apk-live">
                 <iron-icon icon="assignment-turned-in"></iron-icon> {{'Generate Live Release'|translate}}
               </td>
-              <td class="tangy-foreground-secondary link archives" routerLink="historical-releases-apk-live">
+              <td *ngIf="T_ARCHIVE_APKS_TO_DISK" class="tangy-foreground-secondary link archives" routerLink="historical-releases-apk-live">
                 <iron-icon icon="archive"></iron-icon> {{'Download Live Releases'|translate}}
               </td>
             </tr>
@@ -53,14 +53,14 @@
             <tr>
               <th>Release Type</th>
               <th>Generate</th>
-              <th>List</th>
+              <th *ngIf="T_ARCHIVE_PWAS_TO_DISK">List</th>
             </tr>
             <tr>
               <td>Test</td>
               <td class="tangy-foreground-secondary link" routerLink="release-pwa-test">
                 <iron-icon icon="assignment-late"></iron-icon> {{'Generate Test Release'|translate}}
               </td>
-              <td class="tangy-foreground-secondary link archives" routerLink="historical-releases-pwa-test">
+              <td *ngIf="T_ARCHIVE_PWAS_TO_DISK" class="tangy-foreground-secondary link archives" routerLink="historical-releases-pwa-test">
                  <iron-icon icon="list"></iron-icon> {{'View Test Releases'|translate}}
               </td>
             </tr>
@@ -69,7 +69,7 @@
               <td class="tangy-foreground-secondary link" routerLink="release-pwa-live">
                 <iron-icon icon="assignment-turned-in"></iron-icon> {{'Generate Live Release'|translate}}
               </td>
-              <td class="tangy-foreground-secondary link archives" routerLink="historical-releases-pwa-live">
+              <td *ngIf="T_ARCHIVE_PWAS_TO_DISK" class="tangy-foreground-secondary link archives" routerLink="historical-releases-pwa-live">
                  <iron-icon icon="list"></iron-icon> {{'View Live Releases'|translate}}
               </td>
             </tr>

--- a/editor/src/app/groups/group-releases/group-releases.component.ts
+++ b/editor/src/app/groups/group-releases/group-releases.component.ts
@@ -1,6 +1,8 @@
 import { Breadcrumb } from './../../shared/_components/breadcrumb/breadcrumb.component';
 import { _TRANSLATE } from 'src/app/shared/_services/translation-marker';
 import { Component, OnInit, Input } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { TangyErrorHandler } from '../../shared/_services/tangy-error-handler.service';
 
 @Component({
   selector: 'app-group-releases',
@@ -13,16 +15,31 @@ export class GroupReleasesComponent implements OnInit {
   breadcrumbs:Array<Breadcrumb> = []
  
   @Input() groupId:string
+  T_ARCHIVE_APKS_TO_DISK;;
+  T_ARCHIVE_PWAS_TO_DISK;;
+  constructor(private httpClient: HttpClient, private errorHandler: TangyErrorHandler) { }
 
-  constructor() { }
-
-  ngOnInit() {
+  async ngOnInit() {
     this.breadcrumbs = [
       <Breadcrumb>{
         label: _TRANSLATE('Releases'),
         url: 'releases'
       }
     ]
+
+    try {
+      const result: any = await this.httpClient.get('/configuration/archiveToDisk').toPromise();
+      if(result.T_ARCHIVE_APKS_TO_DISK && result.T_ARCHIVE_APKS_TO_DISK==="true"){
+        this.T_ARCHIVE_APKS_TO_DISK = true;
+      }
+      if(result.T_ARCHIVE_PWAS_TO_DISK && result.T_ARCHIVE_PWAS_TO_DISK==="true"){
+        this.T_ARCHIVE_PWAS_TO_DISK = true;
+      } 
+    } catch (error) {
+      if (typeof error.status === 'undefined') {
+        this.errorHandler.handleError(_TRANSLATE('Could Not Contact Server.'));
+      }
+    }
   }
 
 }

--- a/server/src/config-utils.js
+++ b/server/src/config-utils.js
@@ -1,0 +1,13 @@
+const archiveToDiskConfig = async (req, res)=>{
+    try {
+        const {T_ARCHIVE_PWAS_TO_DISK, T_ARCHIVE_APKS_TO_DISK} = process.env
+        res.send({ statusCode: 200, T_ARCHIVE_APKS_TO_DISK, T_ARCHIVE_PWAS_TO_DISK });
+    } catch (error) {
+        console.error()
+        res.sendStatus(500)
+    }
+}
+
+module.exports = {
+    archiveToDiskConfig
+}

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -56,6 +56,7 @@ const {AppContext} = require("../../editor/src/app/app-context.enum");
 const PACKAGENAME = "org.rti.tangerine"
 const APPNAME = "Tangerine"
 const { releaseAPK, releasePWA, releaseOnlineSurveyApp, unreleaseOnlineSurveyApp, commitFilesToVersionControl } = require('./releases.js');
+const {archiveToDiskConfig} = require('./config-utils.js')
 
 setInterval(commitFilesToVersionControl, 60000)
 module.exports = async function expressAppBootstrap(app) {
@@ -146,6 +147,12 @@ app.patch('/users/restore/:username', isAuthenticated, permit(['can_edit_users']
 app.delete('/users/delete/:username', isAuthenticated, permit(['can_edit_users']), deleteUser);
 app.put('/users/update/:username', isAuthenticated, permit(['can_edit_users']), updateUser);
 app.get('/users/groupPermissionsByGroupName/:groupName', isAuthenticated, getUserGroupPermissionsByGroupName);
+/**
+ * Get Config value
+ */
+
+ app.get('/configuration/archiveToDisk', isAuthenticated, archiveToDiskConfig);
+
 
 /**
  * Online survey routes


### PR DESCRIPTION
## Description

---

Only show the links to historical releases when `T_ARCHIVE_PWAS_TO_DISK` and `T_ARCHIVE_APKS_TO_DISK` in the `config.sh` are set to `true` 

- Fixes #2608

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

Conditionally show or hide parts of the DOM based on the values in `config.sh`

