### PR TITLE
Allow opening of form in editor when src path does not match id of the form

### DIFF
--- a/editor/src/app/ng-tangy-form-editor/ng-tangy-form-editor/ng-tangy-form-editor.component.ts
+++ b/editor/src/app/ng-tangy-form-editor/ng-tangy-form-editor/ng-tangy-form-editor.component.ts
@@ -46,7 +46,9 @@ export class NgTangyFormEditorComponent implements OnInit {
     this.groupId = pathArray[2];
     let groupName = this.groupId;
     this.groupName = groupName;
-    let formHtml = await this.http.get(`/editor/${this.groupId}/content/${this.formId}/form.html`, {responseType: 'text'}).toPromise()
+    let formJson = <any>await this.http.get(`./assets/forms.json`).toPromise()
+    const formSrc = formJson.find(formInfo => formInfo.id === this.formId).src
+    let formHtml = await this.http.get(formSrc, {responseType: 'text'}).toPromise()
 
     const serverConfig = await this.serverConfigService.getServerConfig()
     const appConfig = await this.appConfigService.getAppConfig(groupName);


### PR DESCRIPTION
For a long time the form editor has a hard coded assumption about the path of the form.html file for a form. This assumption was that form.html is a file in a folder the same name as the id of the form. That's not always the case. This PR does a lookup in forms.json what the src property for the form is.