### PR TITLE
Update date carousel with fix for clicking the today button

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "bcryptjs": "^2.4.3",
     "core-js": "^2.5.4",
     "crypto-js": "^3.1.9-1",
-    "date-carousel": "^5.2.0",
+    "date-carousel": "^5.2.1",
     "fast-json-patch": "^3.0.0-1",
     "fs-extra": "^6.0.1",
     "js-uuid": "0.0.6",


### PR DESCRIPTION
The date-carousel component for the Schedule View has a bug in it. I fixed it in version 5.2.1 of that package. This pull request updates that package in Tangerine.