### PR TITLE
Android large heap docker base v3.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with docker-tangerine-base-image, which provides the core Tangerine apps.
-FROM tangerine/docker-tangerine-base-image:v3.7.3-rc-4
+FROM tangerine/docker-tangerine-base-image:v3.7.3
 
 # Never ask for confirmations
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with docker-tangerine-base-image, which provides the core Tangerine apps.
-FROM tangerine/docker-tangerine-base-image:v3.7.1
+FROM tangerine/docker-tangerine-base-image:v3.7.3-rc-4
 
 # Never ask for confirmations
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
## Description

---

Updates the docker-tangerine-base-image to v3.7.3, which adds `android:largeHeap="true"` attribute to the configuration to enable the use of more memory.

- Fixes #2574
- 
## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)
