### PR TITLE
Bug Fix: Make sync use the initialBatchSize if isFirstSync is true

### DIFF
--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -92,7 +92,7 @@ export class SyncCouchdbService {
     this.batchSize = appConfig.batchSize || this.batchSize
     this.initialBatchSize = appConfig.initialBatchSize || this.initialBatchSize
     this.writeBatchSize = appConfig.writeBatchSize || this.writeBatchSize
-    let batchSize = fullSync === SyncDirection.pull 
+    let batchSize = (isFirstSync || fullSync === SyncDirection.pull)
       ? this.initialBatchSize
       : this.batchSize
     let replicationStatus:ReplicationStatus


### PR DESCRIPTION
## Description

Pack-porting this fix by @esurface :

The current version of sync ignores the initialBatchSize app-config parameter. This check in fixes that.
