### PR TITLE
Allow valid characters in mysql passwords (e.g. %)

### DIFF
--- a/docs/system-administrator/mysql-module.md
+++ b/docs/system-administrator/mysql-module.md
@@ -4,6 +4,8 @@
 
 Important! If __reenabling__ the mysql module, remove the mysql folder: `rm -r data/mysql`
 
+Note: Upgrading an older version of Tangerine may require running `docker exec tangerine push-all-groups-views` after to enable indexes used for mysql
+
 ### Step 1
 Ensure the variables from the `MySQL` section in config.defaults.sh are in your customized `config.sh` file. 
 

--- a/docs/system-administrator/mysql-module.md
+++ b/docs/system-administrator/mysql-module.md
@@ -4,8 +4,6 @@
 
 Important! If __reenabling__ the mysql module, remove the mysql folder: `rm -r data/mysql`
 
-Note: Upgrading an older version of Tangerine may require running `docker exec tangerine push-all-groups-views` after to enable indexes used for mysql
-
 ### Step 1
 Ensure the variables from the `MySQL` section in config.defaults.sh are in your customized `config.sh` file. 
 
@@ -26,6 +24,8 @@ Run the start script to load in new configuration. Do this even if your server i
 ```
 ./start.sh <version>
 ```
+
+Note: Upgrading an older version of Tangerine may require running `docker exec tangerine push-all-groups-views` after to enable indexes used for mysql
 
 ### Step 5
 Clear reporting cache to start generating a MySQL database for each group.

--- a/docs/system-administrator/tangerine-nginx-ssl.md
+++ b/docs/system-administrator/tangerine-nginx-ssl.md
@@ -26,7 +26,6 @@ docker exec -it nginx bash
  apt-get update
  apt-get install certbot python-certbot-nginx
  apt-get install vim
- apt-get install cron
 ```
 
 Now execute and follow the promtps for cerbot. It will fail but that's ok
@@ -44,7 +43,7 @@ server {
     listen       80;
     listen  [::]:80;
     server_name  _;
-    client_max_body_size 100M;
+    client_max_body_size 0;
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 
@@ -74,6 +73,7 @@ server {
 
 server {
 server_name DOMAIN.ORG
+client_max_body_size 0;
 ;
 
         location / {
@@ -119,9 +119,11 @@ Reload the config
 service nginx reload
 ```
 
+Exit the docker container and add the below entry to the root's crontab
 Add this like to cron (crontab -e)
 ```
-0 8 * * * certbot renew --post-hook "service nginx reload"
+crontab -e
+0 8 * * * docker exec -it certbot renew --post-hook "service nginx reload"
 ```
 
 

--- a/docs/system-administrator/tangerine-nginx-ssl.md
+++ b/docs/system-administrator/tangerine-nginx-ssl.md
@@ -123,7 +123,7 @@ Exit the docker container and add the below entry to the root's crontab
 Add this like to cron (crontab -e)
 ```
 crontab -e
-0 8 * * * docker exec -it certbot renew --post-hook "service nginx reload"
+0 8 * * * docker exec -it nginx certbot renew --post-hook "service nginx reload"
 ```
 
 

--- a/server/src/modules/mysql/MultipleTangerineToMySQL.py
+++ b/server/src/modules/mysql/MultipleTangerineToMySQL.py
@@ -416,7 +416,7 @@ def main_job():
 
 
 #read in the configuration file
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(interpolation=None)
 pathName = os.path.join(os.getcwd(), 'data', 'setting2.ini')
 print('Config file: ' + pathName)
 config.read(pathName)

--- a/server/src/modules/mysql/TangerineToMySQL.py
+++ b/server/src/modules/mysql/TangerineToMySQL.py
@@ -407,7 +407,7 @@ def scheduled_job():
     s.enter(60*int(interval), 1, scheduled_job)
 
 # Read in the configuration file.
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(interpolation=None)
 pathName = sys.argv[1]
 config.read(pathName)
 config.sections()


### PR DESCRIPTION
Mysql passwords allow the special characters: ' ~ ! @ # $ % ^ & * ( ) _ - + = { } [ ] / < > , . ; ? '. The Tangerine to MySQL parser code needs to allow these in passwords. Setting the configparser module parameter 'interpolation=None' allows these characters to be used.