### PR TITLE
Allow valid characters in mysql passwords (e.g. %)

### DIFF
--- a/server/src/modules/boot-module.js
+++ b/server/src/modules/boot-module.js
@@ -1,0 +1,19 @@
+const tangyModules = require('./index.js')()
+
+module.exports = async function bootModule(moduleName) {
+  const module = tangyModules.modules.find(module => module.name === moduleName)
+  if (module) {
+    if (module.hooks && module.hooks.boot) {
+      await module.hooks.boot()
+      return {
+        message: `${moduleName} booted.`
+      }
+    } else {
+      return {
+        message: `${moduleName} is enabled but note that ${moduleName} module does not have an boot hook so this command did nothing.`
+      }
+    }
+  } else {
+    throw new Error('Error: You must first enable that module via T_MODULES.')
+  }
+}

--- a/server/src/modules/mysql/MultipleTangerineToMySQL.py
+++ b/server/src/modules/mysql/MultipleTangerineToMySQL.py
@@ -416,7 +416,7 @@ def main_job():
 
 
 #read in the configuration file
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(interpolation=None)
 pathName = os.path.join(os.getcwd(), 'data', 'setting2.ini')
 print('Config file: ' + pathName)
 config.read(pathName)

--- a/server/src/modules/mysql/TangerineToMySQL.py
+++ b/server/src/modules/mysql/TangerineToMySQL.py
@@ -407,7 +407,7 @@ def scheduled_job():
     s.enter(60*int(interval), 1, scheduled_job)
 
 # Read in the configuration file.
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(interpolation=None)
 pathName = sys.argv[1]
 config.read(pathName)
 config.sections()

--- a/server/src/scripts/boot-module.js
+++ b/server/src/scripts/boot-module.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const bootModule = require('../modules/boot-module.js')
+if (process.argv[2] === '--help') {
+  console.log('Usage:')
+  console.log('   boot-module <moduleName>')
+  process.exit()
+}
+bootModule(process.argv[2])


### PR DESCRIPTION
Mysql passwords allow the special characters: ' ~ ! @ # $ % ^ & * ( ) _ - + = { } [ ] / < > , . ; ? '. The Tangerine to MySQL parser code needs to allow these in passwords. Setting the configparser module parameter 'interpolation=None' allows these characters to be used.