### PR TITLE
Fix docker build for ARM-based devices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install global node dependencies
+RUN npm config set unsafe-perm true
 RUN npm install -g nodemon uuid
 
 # T_USER1 is the username of the first user you will log in as. It is also the super user that has all permissions. 

--- a/docs/system-administrator/mysql-module.md
+++ b/docs/system-administrator/mysql-module.md
@@ -4,6 +4,8 @@
 
 Important! If __reenabling__ the mysql module, remove the mysql folder: `rm -r data/mysql`
 
+Note: Upgrading an older version of Tangerine may require running `docker exec tangerine push-all-groups-views` after to enable indexes used for mysql
+
 ### Step 1
 Ensure the variables from the `MySQL` section in config.defaults.sh are in your customized `config.sh` file. 
 

--- a/docs/system-administrator/mysql-module.md
+++ b/docs/system-administrator/mysql-module.md
@@ -4,8 +4,6 @@
 
 Important! If __reenabling__ the mysql module, remove the mysql folder: `rm -r data/mysql`
 
-Note: Upgrading an older version of Tangerine may require running `docker exec tangerine push-all-groups-views` after to enable indexes used for mysql
-
 ### Step 1
 Ensure the variables from the `MySQL` section in config.defaults.sh are in your customized `config.sh` file. 
 
@@ -26,6 +24,8 @@ Run the start script to load in new configuration. Do this even if your server i
 ```
 ./start.sh <version>
 ```
+
+Note: Upgrading an older version of Tangerine may require running `docker exec tangerine push-all-groups-views` after to enable indexes used for mysql
 
 ### Step 5
 Clear reporting cache to start generating a MySQL database for each group.

--- a/docs/system-administrator/tangerine-nginx-ssl.md
+++ b/docs/system-administrator/tangerine-nginx-ssl.md
@@ -26,7 +26,6 @@ docker exec -it nginx bash
  apt-get update
  apt-get install certbot python-certbot-nginx
  apt-get install vim
- apt-get install cron
 ```
 
 Now execute and follow the promtps for cerbot. It will fail but that's ok
@@ -44,7 +43,7 @@ server {
     listen       80;
     listen  [::]:80;
     server_name  _;
-    client_max_body_size 100M;
+    client_max_body_size 0;
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 
@@ -74,6 +73,7 @@ server {
 
 server {
 server_name DOMAIN.ORG
+client_max_body_size 0;
 ;
 
         location / {
@@ -119,9 +119,11 @@ Reload the config
 service nginx reload
 ```
 
+Exit the docker container and add the below entry to the root's crontab
 Add this like to cron (crontab -e)
 ```
-0 8 * * * certbot renew --post-hook "service nginx reload"
+crontab -e
+0 8 * * * docker exec -it certbot renew --post-hook "service nginx reload"
 ```
 
 

--- a/docs/system-administrator/tangerine-nginx-ssl.md
+++ b/docs/system-administrator/tangerine-nginx-ssl.md
@@ -123,7 +123,7 @@ Exit the docker container and add the below entry to the root's crontab
 Add this like to cron (crontab -e)
 ```
 crontab -e
-0 8 * * * docker exec -it certbot renew --post-hook "service nginx reload"
+0 8 * * * docker exec -it nginx certbot renew --post-hook "service nginx reload"
 ```
 
 


### PR DESCRIPTION
## Description

Globally installing nodemon would fail on M1-based Macs (and, as far as I can tell, other aarch64 devices), citing it being unable to find UID 0. This seems to have something to do with a stack size/instruction set limitation, going back to a bug in Node and possibly V8. Setting this NPM config flag resolves the issue.

Error output:

```
 > [ 3/38] RUN npm install -g nodemon uuid:
#6 15.28 /usr/local/bin/nodemon -> /usr/local/lib/node_modules/nodemon/bin/nodemon.js
#6 15.29 /usr/local/bin/uuid -> /usr/local/lib/node_modules/uuid/dist/bin/uuid
#6 15.47
#6 15.47 > nodemon@2.0.7 postinstall /usr/local/lib/node_modules/nodemon
#6 15.47 > node bin/postinstall || exit 0
#6 15.47
#6 16.38 npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/nodemon/node_modules/chokidar/node_modules/fsevents):
#6 16.38 npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
#6 16.38
#6 16.41 npm ERR! code EUIDLOOKUP
#6 16.42 npm ERR! lifecycle could not get uid/gid
#6 16.42 npm ERR! lifecycle [ 'nobody', 0 ]
#6 16.42 npm ERR! lifecycle qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#6 16.43 npm ERR! lifecycle
#6 16.43 npm ERR!
#6 16.43 npm ERR! Failed to look up the user/group for running scripts.
#6 16.43 npm ERR!
#6 16.43 npm ERR! Try again with a different --user or --group settings, or
#6 16.43 npm ERR! run with --unsafe-perm to execute scripts as root.
#6 16.46
#6 16.46 npm ERR! A complete log of this run can be found in:
#6 16.46 npm ERR!     /root/.npm/_logs/2021-04-15T10_03_00_510Z-debug.log
```

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## TODOS/enhancements

- [ ] Document why this needs to be set in the Dockerfile
