### PR TITLE
Sort by lastModified in the client case search

### DIFF
--- a/client/src/app/shared/_services/search.service.ts
+++ b/client/src/app/shared/_services/search.service.ts
@@ -75,11 +75,15 @@ export class SearchService {
       }
     })
     // Deduplicate the search results since the same case may match on multiple variables.
-    return searchResults.reduce((uniqueResults, result) => {
+    let uniqueResults = searchResults.reduce((uniqueResults, result) => {
       return uniqueResults.find(x => x._id === result._id)
         ? uniqueResults
         : [ ...uniqueResults, result ]
     }, [])
+
+    return uniqueResults.sort(function (a, b) {
+        return b.lastModified - a.lastModified;
+      })
   }
 
 }


### PR DESCRIPTION
For this update results from the query in the client case search (the case-home) are sorted by lastModified with the most recently changed item first. This aims to improve search, but may not be sufficient and should be tested more thoroughly.