### PR TITLE
Case Service API: activateParticipant and deactivateParticipant shoul…

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -606,7 +606,7 @@ class CaseService {
     }
   }
 
-  deactivateParticipant(participantId:string) {
+  async deactivateParticipant(participantId:string) {
     this.case = {
       ...this.case,
       participants: this.case.participants.map(participant => {


### PR DESCRIPTION
In the case service API, `activateParticipant` is asynchronous but `deactivateParticipant` is synchronous. The code is identical except setting `inactive` to `true` vs `false`.   They should both be one or the other