### PR TITLE
Onopen and close events for case and event defs

### DIFF
--- a/client/src/app/case/classes/case-definition.class.ts
+++ b/client/src/app/case/classes/case-definition.class.ts
@@ -22,6 +22,8 @@ class CaseDefinition {
   templateScheduleListItemIcon?:string
   templateScheduleListItemPrimary?:string
   templateScheduleListItemSecondary?:string
+  onCaseOpen?:string
+  onCaseClose?:string
   constructor(init:any) {
     Object.assign(this, init);
     /*

--- a/client/src/app/case/classes/event-form-definition.class.ts
+++ b/client/src/app/case/classes/event-form-definition.class.ts
@@ -23,6 +23,9 @@ export class EventFormDefinition {
   allowDeleteIfFormNotCompleted?:string
   allowDeleteIfFormNotStarted?:string
 
+  onEventOpen?:string
+  onEventClose?:string
+
   constructor() {
   }
 }

--- a/client/src/app/case/components/case/case.component.ts
+++ b/client/src/app/case/components/case/case.component.ts
@@ -1,6 +1,6 @@
 import { CaseEventOperation } from './../../classes/case-event-definition.class';
 import { UserService } from 'src/app/shared/_services/user.service';
-import { Component, AfterContentInit, ChangeDetectorRef } from '@angular/core';
+import { Component, AfterContentInit, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CaseService } from '../../services/case.service'
 import { CaseEventDefinition } from '../../classes/case-event-definition.class';
@@ -17,7 +17,7 @@ class CaseEventInfo {
   templateUrl: './case.component.html',
   styleUrls: ['./case.component.css']
 })
-export class CaseComponent implements AfterContentInit {
+export class CaseComponent implements AfterContentInit, OnDestroy {
 
   private ready = false
   userRoles:Array<string>
@@ -42,7 +42,6 @@ export class CaseComponent implements AfterContentInit {
     this.window = window
     this.caseService = caseService
   }
-
   async ngAfterContentInit() {
     this.userRoles = await this.userService.getRoles()
     const caseId = window.location.hash.split('/')[2]
@@ -52,6 +51,7 @@ export class CaseComponent implements AfterContentInit {
     // }
     this.caseService.setContext()
     this.window.caseService = this.caseService
+    this.onCaseOpen()
     this.calculateTemplateData()
     this.ready = true
   }
@@ -105,7 +105,13 @@ export class CaseComponent implements AfterContentInit {
     this.caseService.openCaseConfirmed = true
     this.ref.detectChanges()
   }
+  onCaseOpen(){
+    eval(this.caseService.caseDefinition.onCaseOpen)
+  }
 
+  ngOnDestroy(){
+    eval(this.caseService.caseDefinition.onCaseClose)
+  }
   async onSubmit() {
     if (this.selectedNewEventType !== '') {
       const newDate = moment(this.inputSelectedDate, 'YYYY-MM-DD').unix()*1000

--- a/client/src/app/case/components/event-form/event-form.component.ts
+++ b/client/src/app/case/components/event-form/event-form.component.ts
@@ -1,7 +1,7 @@
 import { TangyFormResponseModel } from 'tangy-form/tangy-form-response-model.js';
 import { TangyFormsPlayerComponent } from './../../../tangy-forms/tangy-forms-player/tangy-forms-player.component';
 import { FormInfo } from 'src/app/tangy-forms/classes/form-info.class';
-import { Component, OnInit, ViewChild, ElementRef, AfterContentInit, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CaseService } from '../../services/case.service'
 import { EventForm } from '../../classes/event-form.class';
@@ -15,7 +15,7 @@ const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true),
   templateUrl: './event-form.component.html',
   styleUrls: ['./event-form.component.css']
 })
-export class EventFormComponent implements OnInit {
+export class EventFormComponent implements OnInit, OnDestroy {
 
   caseEvent: CaseEvent
   caseEventDefinition: CaseEventDefinition
@@ -76,7 +76,7 @@ export class EventFormComponent implements OnInit {
         .eventFormDefinitions
         .find(eventFormDefinition => eventFormDefinition.id === this.eventForm.eventFormDefinitionId)
       this.formId = this.eventFormDefinition.formId
-
+      this.onEventOpen()
       this.formResponseId = this.eventForm.formResponseId || ''
       this.formPlayer.formId = this.formId
       this.formPlayer.formResponseId = this.formResponseId
@@ -93,7 +93,6 @@ export class EventFormComponent implements OnInit {
       this.caseService.onChangeLocation$.subscribe(location => {
         this.formPlayer.location = this.caseService.case.location
       })
-
       this.formPlayer.$saved.subscribe(async () => {
         if (this.isWrappingUp) return
         if (!this.formResponseId && this.formPlayer.response && this.formPlayer.response.items && this.formPlayer.response.items[0] && this.formPlayer.response.items[0].inputs && this.formPlayer.response.items[0].inputs.length > 0) {
@@ -137,6 +136,13 @@ export class EventFormComponent implements OnInit {
     })
   }
   
+  onEventOpen(){
+    eval(this.eventFormDefinition.onEventOpen)
+  }
+
+  ngOnDestroy(){
+    eval(this.eventFormDefinition.onEventClose)
+  }
   eventFormRedirect() {
     window.location.hash = window['eventFormRedirect']
     // Reset the event form redirect so it doesn't become permanent.


### PR DESCRIPTION
## Description

Copying this PR: https://github.com/Tangerine-Community/Tangerine/pull/2696

---
Users should be able to define custom functions or valid JavaScript expressions that will be called when an event is opened and when an event is closed.

The user will define custom functions in the eventFormDefinitions for the specific event. The user provides the function name and the arguments, if any, to be run for the corresponding close or open event.

The user then defines the function implementation in the `custom-scripts.js` in the content directory. The functions are attached to the global window object.

**Example**

1. Define the function to be run within the case definition json file
  ```json
  ...
   {
        "id": "event-form-definition-id",
        "formId": "form1",
        "forCaseRole": "role2",
        "name": "My event",
        "autoPopulate": true,
        "required": true,
        "repeatable": false,
        "allowDeleteIfFormNotCompleted": false,
        "allowDeleteIfFormNotStarted": false,
        "onEventOpen":"openEvent(T.case.case)",
        "onEventClose":"closeEvent(T.case.case)"
      },
    ...
  ```
  In this instance, we have defined the functions for both events.
  Notice also the argument passed in each instance, which is the
  globally available `T.case.case` object. The argument is optional and
  the `T.case.case` in this instance is for demonstration purposes.

2. Provide and implementation for the functions referenced within the case definition json file. The implementation is in the
`custom-scripts.js` file within the assets directory. Notice how we attach the functions to global window object.

The `caseInstance` parameter corresponds to the `T.case.case` argument that was passed in step 1. above.
We can supply any argument provided it is available in the current execution scope.

```js
...
  window['openEvent'] = (caseInstance)=>{
      console.log(caseInstance)
  }
  window['closeEvent'] = (caseInstance)=>{
      console.log(caseInstance)
  }
...
```
Users should be able to define custom functions or valid JavaScript expressions that will be called when a case is opened and when a case is closed.

The user will define custom functions in the case definition file for the specific case. The user provides the function name and the arguments, if any, to be run for the corresponding close or open event.

The user then defines the function implementation in the `custom-scripts.js` in the content directory. The functions are attached to the global window object.

**Example**

1. Define the function to be run within the case definition json file
  ```json
  ...
   "onCaseOpen":"openCase(T.case.case)",
   "onCaseClose":"closeCase(T.case.case)",
    ...
  ```
  In this instance, we have defined the functions for both events.
 Notice also the argument passed in each instance, which is the globally available `T.case.case` object. The argument is optional and the `T.case.case` in this instance is for demonstration purposes.

2. Provide and implementation for the functions referenced within the case definition json file. The implementation is in the
`custom-scripts.js` file within the assets directory. Notice how we attach the functions to global window object.

The `caseInstance` parameter corresponds to the `T.case.case` argument that was passed in step 1. above.
We can supply any argument provided it is available in the current execution scope.

```js
...
  window['openCase'] = (caseInstance)=>{
      console.log(caseInstance)
  }
  window['closeCase'] = (caseInstance)=>{
      console.log(caseInstance)
  }
...
```

- Fixes #IssueNumber

## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---

Within the life-cycle hooks for the component, read and eval the corresponding entry in the case definition file



