### PR TITLE
Add support for creating Issues in client gui

### DIFF
--- a/client/src/app/case/case-routing.module.ts
+++ b/client/src/app/case/case-routing.module.ts
@@ -1,3 +1,4 @@
+import { NewIssueComponent } from './components/new-issue/new-issue.component';
 import { CaseService } from 'src/app/case/services/case.service';
 import { IssueFormComponent } from './components/issue-form/issue-form.component';
 import { IssueComponent } from './components/issue/issue.component';
@@ -97,6 +98,11 @@ const routes: Routes = [
   { path: 'issue/:issueId/form-revision', component: IssueFormComponent, canActivate: [LoginGuard] },
   { path: 'issue/:issueId/form-revision/:eventId', component: IssueFormComponent, canActivate: [LoginGuard] },
   { path: 'issue/:issueId', component: IssueComponent, canActivate: [LoginGuard] },
+  {
+    path: 'new-issue/:caseId/:eventId/:eventFormId',
+    component: NewIssueComponent,
+    canActivate: [LoginGuard]
+  }
  
  
 ];

--- a/client/src/app/case/case.module.ts
+++ b/client/src/app/case/case.module.ts
@@ -1,3 +1,4 @@
+import { NewIssueComponent } from './components/new-issue/new-issue.component';
 import { CaseDocs } from './case.docs';
 import { DEFAULT_USER_DOCS } from './../shared/_tokens/default-user-docs.token';
 import { IssueFormComponent } from './components/issue-form/issue-form.component';
@@ -62,7 +63,8 @@ import { IssuesComponent } from './components/issues/issues.component';
     EventFormsForParticipantComponent,
     EventFormsForParticipantPageComponent,
     CustomAppComponent,
-    IssuesComponent
+    IssuesComponent,
+    NewIssueComponent
   ]
 })
 export class CaseModule { }

--- a/client/src/app/case/components/event-form/event-form.component.css
+++ b/client/src/app/case/components/event-form/event-form.component.css
@@ -18,3 +18,10 @@
 .event-form-redirect-back-button .icon {
   vertical-align: bottom;
 }
+
+.new-issue-button {
+  position: absolute;
+  top: 69px;
+  right: 15px;
+  color: #fff;
+}

--- a/client/src/app/case/components/event-form/event-form.component.html
+++ b/client/src/app/case/components/event-form/event-form.component.html
@@ -4,6 +4,7 @@
     [caseEventId]="caseEvent.id"
     [eventFormId]="eventForm.id"
 ></app-case-breadcrumb>
+<paper-button *ngIf="loaded && allowCreationOfIssues" class="new-issue-button" (click)="createIssue()"><mwc-icon>playlist_add</mwc-icon> new issue</paper-button>
 <div 
     class="event-form-redirect-back-button"
     *ngIf="hasEventFormRedirect"

--- a/client/src/app/case/components/event-form/event-form.component.ts
+++ b/client/src/app/case/components/event-form/event-form.component.ts
@@ -1,3 +1,4 @@
+import { AppConfigService } from 'src/app/shared/_services/app-config.service';
 import { TangyFormResponseModel } from 'tangy-form/tangy-form-response-model.js';
 import { TangyFormsPlayerComponent } from './../../../tangy-forms/tangy-forms-player/tangy-forms-player.component';
 import { FormInfo } from 'src/app/tangy-forms/classes/form-info.class';
@@ -25,6 +26,7 @@ export class EventFormComponent implements OnInit, OnDestroy {
   formId:string
   templateId:string
   formResponseId:string
+  allowCreationOfIssues:boolean
 
   hasEventFormRedirect = false
   eventFormRedirectUrl = ''
@@ -44,6 +46,7 @@ export class EventFormComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private hostElementRef: ElementRef,
     private router: Router,
+    private appConfigService:AppConfigService,
     private caseService: CaseService,
     private ref: ChangeDetectorRef
   ) {
@@ -120,9 +123,15 @@ export class EventFormComponent implements OnInit, OnDestroy {
           }
         }, 500)
       })
+      const appConfig = await this.appConfigService.getAppConfig()
+      this.allowCreationOfIssues = appConfig.allowCreationOfIssues
       this.loaded = true
       this.ref.detectChanges()
     })
+  }
+
+  createIssue() {
+    this.router.navigate(['new-issue', this.caseService.case._id, this.caseEvent.id, this.eventForm.id])
   }
   
   onEventOpen(){

--- a/client/src/app/case/components/new-issue/new-issue.component.html
+++ b/client/src/app/case/components/new-issue/new-issue.component.html
@@ -1,0 +1,1 @@
+<div #container></div>

--- a/client/src/app/case/components/new-issue/new-issue.component.spec.ts
+++ b/client/src/app/case/components/new-issue/new-issue.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewIssueComponent } from './new-issue.component';
+
+describe('NewIssueComponent', () => {
+  let component: NewIssueComponent;
+  let fixture: ComponentFixture<NewIssueComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NewIssueComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NewIssueComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/case/components/new-issue/new-issue.component.ts
+++ b/client/src/app/case/components/new-issue/new-issue.component.ts
@@ -1,0 +1,54 @@
+import { AppContext } from 'src/app/app-context.enum';
+import { UserService } from 'src/app/shared/_services/user.service';
+import { TangyFormResponseModel } from 'tangy-form/tangy-form-response-model.js';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { CaseService } from '../../services/case.service';
+
+@Component({
+  selector: 'app-new-issue',
+  templateUrl: './new-issue.component.html',
+  styleUrls: ['./new-issue.component.css']
+})
+export class NewIssueComponent implements OnInit {
+
+  @ViewChild('container', { static: true }) container:ElementRef
+
+  constructor(
+    private route:ActivatedRoute,
+    private router:Router,
+    private caseService: CaseService,
+    private userService:UserService
+  ) { }
+
+  ngOnInit() {
+    this.container.nativeElement.innerHTML = `
+      <tangy-form id="form" #form>
+        <tangy-form-item id="new-issue" title="New Issue">
+          <tangy-input name="title" label="Title" inner-label=" "></tangy-input>
+          <tangy-input name="description" label="Description" inner-label=" "></tangy-input>
+        </tangy-form-item>
+      </tangy-form>
+    `
+    this.route.params.subscribe(async params => {
+      const caseId = params.caseId
+      const eventId = params.eventId
+      const eventFormId = params.eventFormId
+      const userName = await this.userService.getCurrentUser()
+      const userId = userName
+      const groupId = window.location.pathname.split('/')[2]
+      this.container.nativeElement.querySelector('tangy-form').addEventListener('submit', async (event) => {
+        event.preventDefault()
+        const response = new TangyFormResponseModel(event.target.response)
+        const title = response.inputsByName.title.value
+        const description = response.inputsByName.description.value
+        const issue = await this.caseService.createIssue(title, description, caseId, eventId, eventFormId, userId, userName, [AppContext.Client])
+        this.router.navigate(['issue', issue._id])
+      })
+
+
+    })
+
+  }
+
+}

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -41,5 +41,6 @@ export class AppConfig {
   calculateLocalDocsForLocation:boolean;
   findSelectorLimit: number;
   compareLimit: number;
+  allowCreationOfIssues:boolean
 }
 


### PR DESCRIPTION
Before this PR, Issues could only be created programatically. Now above every Response for an Event Form, the "New Issue" button creates an Issue for that Event Form just like it does on Editor. This PR makes wether or not this button shows up an opt-in feature with a new `allowCreationOfIssues` boolean in `app-config.json`.

![image](https://user-images.githubusercontent.com/156575/116926453-5e8e8580-ac28-11eb-965f-bbac7bfc98f2.png)
