### PR TITLE
Add response-variable-value API with support for returning jpeg and png base64 values as files

### DIFF
--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -169,6 +169,7 @@ app.get('/api/modules', isAuthenticated, require('./routes/modules.js'))
 app.post('/api/:groupId/upload-check', hasUploadToken, require('./routes/group-upload-check.js'))
 app.post('/api/:groupId/upload', hasUploadToken, require('./routes/group-upload.js'))
 app.get('/api/:groupId/responses/:limit?/:skip?', isAuthenticated, require('./routes/group-responses.js'))
+app.get('/app/:groupId/response-variable-value/:responseId/:variableName', isAuthenticated, require('./routes/group-response-variable-value.js'))
 app.get('/api/:groupId/responsesByFormId/:formId/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-form-id.js'))
 app.get('/api/:groupId/responsesByMonthAndFormId/:keys/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-month-and-form-id.js'))
 // Support for API working with group pathed cookie :). We should do this for others because our group cookies can't access /api/.

--- a/server/src/routes/group-response-variable-value.js
+++ b/server/src/routes/group-response-variable-value.js
@@ -1,0 +1,40 @@
+const DB = require('../db.js')
+const clog = require('tangy-log').clog
+const log = require('tangy-log').log
+
+module.exports = async (req, res) => {
+  try {
+    const groupDb = new DB(req.params.groupId)
+    const responseId = req.params.responseId
+    const variableName = req.params.variableName
+    const doc = await groupDb.get(responseId);
+    const inputs = doc.items.reduce((inputs, item) => {
+      return Array.isArray(item.inputs)
+        ? [
+          ...inputs,
+          ...item.inputs
+        ]
+        : inputs
+    }, [])
+    const value = inputs.find(i => i.name === variableName)
+      ? inputs.find(i => i.name === variableName).value
+      : 'undefined'
+    if (value.includes('data:image/jpeg')) {
+      res.type('jpeg')
+      const data = value.replace('data:image/jpeg;base64,', '')
+      const buffer = Buffer.from(data, 'base64')
+      return res.send(buffer)
+    } else if (value.includes('data:image/png')) {
+      res.type('png')
+      const data = value.replace('data:image/png;base64,', '')
+      const buffer = Buffer.from(data, 'base64')
+      return res.send(buffer)
+    } else {
+      res.send(value)
+    }
+  } catch (error) {
+    console.error(error)
+    log.error(error);
+    res.status(500).send(error);
+  }
+}


### PR DESCRIPTION
This PR adds a response-variable-value API with support for returning jpeg and png base64 values as files and refactors CSV output for TANGY-SIGNATURE and TANGY-PHOTO-CAPTURE to use these URLs. The URLs are behind standard Tangerine server auth.

PR for #2706.

<img width="2193" alt="Screen Shot 2021-05-13 at 4 21 36 PM" src="https://user-images.githubusercontent.com/156575/118183241-dff3ce00-b407-11eb-88d1-11e795b48e40.png">
