### PR TITLE
Add support for injecting custom logic into client search index via custom-search.js

### DIFF
--- a/client/src/app/shared/_services/create-search-index.ts
+++ b/client/src/app/shared/_services/create-search-index.ts
@@ -1,4 +1,4 @@
-export const createSearchIndex = async (db, formsInfo) => {
+export const createSearchIndex = async (db, formsInfo, customSearchJs = '') => {
   const variablesToIndexByFormId = formsInfo.reduce((variablesToIndexByFormId, formInfo) => {
     return formInfo.searchSettings?.shouldIndex
       ? {
@@ -9,6 +9,7 @@ export const createSearchIndex = async (db, formsInfo) => {
   }, {})
   const map = `
     function(doc) {
+      ${customSearchJs}
       const variablesToIndexByFormId = ${JSON.stringify(variablesToIndexByFormId)}
       if (
         doc.collection === 'TangyFormResponse' &&

--- a/client/src/app/shared/_services/search.service.ts
+++ b/client/src/app/shared/_services/search.service.ts
@@ -2,6 +2,7 @@ import { createSearchIndex } from './create-search-index';
 import { Injectable } from '@angular/core';
 import { UserService } from './user.service';
 import { TangyFormsInfoService } from 'src/app/tangy-forms/tangy-forms-info-service';
+import { HttpClient } from '@angular/common/http';
 
 export class SearchDoc {
   _id: string
@@ -20,6 +21,7 @@ export class SearchService {
 
   constructor(
     private readonly userService:UserService,
+    private readonly http:HttpClient,
     private readonly formsInfoService:TangyFormsInfoService
   ) { }
 
@@ -30,8 +32,14 @@ export class SearchService {
     } else {
       db = await this.userService.getUserDatabase(username)
     }
+    let customSearchJs = ''
+    try {
+      customSearchJs = await this.http.get('./assets/custom-search.js', {responseType: 'text'}).toPromise()
+    } catch (err) {
+      // No custom-search.js, no problem.
+    }
     const formsInfo = await this.formsInfoService.getFormsInfo()
-    await createSearchIndex(db, formsInfo) 
+    await createSearchIndex(db, formsInfo, customSearchJs) 
   }
 
   async search(username:string, phrase:string, limit = 50, skip = 0):Promise<Array<SearchDoc>> {


### PR DESCRIPTION
Need something tricky like a compound variable searchable? This PR adds ability to inject custom logic into the indexing of the search index.

For example, to make a compound variable of first and last name searchable, place the following in a group's `client/custom-search.js`:

```javascript
if (doc.type === 'case' && doc.form.id === 'case-type-1') {
  const firstName = doc.items[0].inputs.find(input => input.name === 'firstName').value
  const lastName = doc.items[0].inputs.find(input => input.name === 'lastName').value
  emit(`${firstName} ${lastName}`, true)
}
```
