### PR TITLE
Ensure first sync is complete before data collection

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -26,6 +26,7 @@ import { AppConfig } from './shared/_classes/app-config.class';
 import { AppConfigService } from './shared/_services/app-config.service';
 import { SearchService } from './shared/_services/search.service';
 import { Get } from 'tangy-form/helpers.js'
+import { FIRST_SYNC_STATUS } from './device/components/device-sync/device-sync.component';
 
 const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true), milliseconds))
 
@@ -138,7 +139,6 @@ export class AppComponent implements OnInit {
     if (!this.installed) {
       await this.install();
     }
-
     await this.checkPermissions();
     // Initialize services.
     await this.deviceService.initialize()
@@ -178,7 +178,11 @@ export class AppComponent implements OnInit {
     }
     this.ready = true;
 
-    // Lastly, navigate to update page if an update is running.
+    // Warn if device has not been properly synced on first try.
+    if (await this.variableService.get('FIRST_SYNC_STATUS') === FIRST_SYNC_STATUS.IN_PROGRESS) {
+      alert("Warning: This device has not successfully completed the first sync. Please connect to the Internet and log in as Device Admin to try again.")
+    }
+    // Navigate to update page if an update is running.
     if (await this.variableService.get(VAR_UPDATE_IS_RUNNING)) {
       this.router.navigate(['/update']);
     }

--- a/client/src/app/core/auth/login/login.component.ts
+++ b/client/src/app/core/auth/login/login.component.ts
@@ -12,6 +12,7 @@ import { AppConfigService } from '../../../shared/_services/app-config.service';
 import { UserService } from '../../../shared/_services/user.service';
 import { _TRANSLATE } from '../../../shared/translation-marker';
 import { VARIABLE_FINISH_UPDATE_ON_LOGIN } from '../../update/update/update.component';
+import { FIRST_SYNC_STATUS } from 'src/app/device/components/device-sync/device-sync.component';
 
 @Component({
   selector: 'app-login',

--- a/client/src/app/device/components/device-resync/device-resync.component.html
+++ b/client/src/app/device/components/device-resync/device-resync.component.html
@@ -1,0 +1,2 @@
+<app-device-sync #stepDeviceSync>
+</app-device-sync>

--- a/client/src/app/device/components/device-resync/device-resync.component.ts
+++ b/client/src/app/device/components/device-resync/device-resync.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { UserService } from 'src/app/shared/_services/user.service';
+import { DeviceSyncComponent } from '../device-sync/device-sync.component';
+
+@Component({
+  selector: 'app-device-resync',
+  templateUrl: './device-resync.component.html',
+  styleUrls: ['./device-resync.component.css']
+})
+export class DeviceResyncComponent implements OnInit {
+
+  @ViewChild('stepDeviceSync', {static: true}) stepDeviceSync:DeviceSyncComponent
+  
+  constructor(
+    private userService:UserService,
+    private routerService:Router
+  ) { }
+
+  ngOnInit(): void {
+    if (this.userService.isLoggedIn()) {
+      this.stepDeviceSync.done$.subscribe(async (value) => {
+        await this.userService.logout()
+        this.routerService.navigate([''])
+      })
+      this.stepDeviceSync.sync()
+    } else {
+      this.routerService.navigate(['login'])
+    }
+
+  }
+
+}

--- a/client/src/app/device/device-routing.module.ts
+++ b/client/src/app/device/device-routing.module.ts
@@ -2,12 +2,19 @@ import { DeviceSetupComponent } from './components/device-setup/device-setup.com
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import {RestoreBackupComponent} from "./components/restore-backup/restore-backup.component";
+import { DeviceResyncComponent } from './components/device-resync/device-resync.component';
 
 
-const routes: Routes = [{
-  path: 'device-setup',
-  component: DeviceSetupComponent
-  },{
+const routes: Routes = [
+  {
+    path: 'device-setup',
+    component: DeviceSetupComponent
+  },
+  {
+    path: 'device-resync',
+    component: DeviceResyncComponent 
+  },
+  {
     path: 'restore-backup',
     component: RestoreBackupComponent
   }

--- a/client/src/app/device/device.module.ts
+++ b/client/src/app/device/device.module.ts
@@ -14,6 +14,7 @@ import { RouterModule } from '@angular/router';
 import {MatTabsModule} from "@angular/material/tabs";
 import {MatCardModule} from "@angular/material/card";
 import { RestoreBackupComponent } from './components/restore-backup/restore-backup.component';
+import { DeviceResyncComponent } from './components/device-resync/device-resync.component';
 
 @NgModule({
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -23,7 +24,8 @@ import { RestoreBackupComponent } from './components/restore-backup/restore-back
     DeviceLanguageComponent,
     DeviceSyncComponent,
     DevicePasswordComponent,
-    RestoreBackupComponent
+    RestoreBackupComponent,
+    DeviceResyncComponent
   ],
   imports: [
     CommonModule,

--- a/client/src/app/shared/_guards/login-guard.service.ts
+++ b/client/src/app/shared/_guards/login-guard.service.ts
@@ -3,6 +3,8 @@ import { DeviceService } from './../../device/services/device.service';
 import { AppConfigService } from './../_services/app-config.service';
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { VariableService } from '../_services/variable.service';
+import { FIRST_SYNC_STATUS } from 'src/app/device/components/device-sync/device-sync.component';
 
 @Injectable()
 export class LoginGuard implements CanActivate {
@@ -10,28 +12,33 @@ export class LoginGuard implements CanActivate {
     private router: Router,
     private userService: UserService,
     private deviceService:DeviceService,
+    private variableService:VariableService,
     private appConfigService:AppConfigService
   ) { }
 
   async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    if (this.userService.isLoggedIn()) {
-      return true;
-    }
-    //  else if (!this.authenticationService.isLoggedIn() && this.authenticationService.isNoPasswordMode()) {
-    //   this.router.navigate(['/login-nopassword'], { queryParams: { returnUrl: state.url } });
-    //   return true;
-    // }
     const appConfig = await this.appConfigService.getAppConfig()
-    if (appConfig.syncProtocol === '2') {
-      const deviceIsRegistered = await this.deviceService.isRegistered()
-      if (deviceIsRegistered) {
-        this.router.navigate(['login'], { queryParams: { returnUrl: state.url } });
+    if (this.userService.isLoggedIn()) {
+      if (appConfig.syncProtocol === '2') {
+        if (await this.variableService.get('FIRST_SYNC_STATUS') === FIRST_SYNC_STATUS.IN_PROGRESS) {
+          this.router.navigate(['device-resync']);
+        } else {
+          return true
+        }
       } else {
-        this.router.navigate(['device-setup'], { queryParams: { returnUrl: state.url } });
+        return true;
       }
-      
     } else {
-      this.router.navigate(['login'], { queryParams: { returnUrl: state.url } });
+      if (appConfig.syncProtocol === '2') {
+        const deviceIsRegistered = await this.deviceService.isRegistered()
+        if (deviceIsRegistered) {
+          this.router.navigate(['login'], { queryParams: { returnUrl: state.url } });
+        } else {
+          this.router.navigate(['device-setup'], { queryParams: { returnUrl: state.url } });
+        }
+      } else {
+        this.router.navigate(['login'], { queryParams: { returnUrl: state.url } });
+      }
     }
     return false;
   }

--- a/docs/system-administrator/install-on-aws.md
+++ b/docs/system-administrator/install-on-aws.md
@@ -49,10 +49,65 @@ Create and Configure an Elastic Load Balancer (ELB):
 - Now proceed to your Load Balancers dashboard, click on your load balancer, click on the Instances tab, and now wait for your EC2 instance to be listed as "InService". 
 - Configure your domain's DNS to point to this load balancer by clicking on the load balancer's Description tab and using the "DNS name" given to configure your Domain's DNS. 
 
-## Login
+
+## SSH Login to Server
 Once your server is created, login with your key:
 ```` 
  ssh -i ~/.ssh/iyour_key -l ubuntu <your EC2 instance's IP address>
 ````
 
-Now you may continue to step 2 in the installation instructions.
+Now you may continue to step 2 in the installation instructions of Tangerine's README.md, then pick back up here.
+
+
+## Configure Logs
+Send logs to AWS CloudWatch for building alarms and saving disk space.
+
+1. Create IAM user with programattic access and AWSAppSyncPushToCloudWatchLogs policy. Keep open credentials screen for reference.
+2. Install aws-cli with `sudo apt-get install awscli`.
+3. `aws configure` and give the credentials for the IAM user.
+4. Go to `AWS Console -> IAM -> Access Management -> Roles -> Create Role`, create a role called `aws-cloudwatch-logs` with an attached policy of `AWSOpsWorksCloudWatchLogs`. 
+5. Go to `AWS Console -> EC2 -> Instances -> <select your instance> -> Actions -> Security -> Modify IAM role` and add the `aws-cloudwatch-logs` role to the EC2 instance.
+6. Go to `AWS Console -> CloudWatch -> Logs -> Actions -> Create log group`.
+7. Create the Log Group named after the instance name (ie. example-v3). 
+8. Write the configuration to `/etc/docker/daemon.json`. Change `awslogs-region` to the "less specific" region name (eu-central-1 as opposed to eu-central-1b) and replace `example-v3` in `tag` and `awslogs-group` to reflect the EC2 instance name. 
+9. Then run `systemctl restart docker`. If containers were already running, you may need to recreate them for settings to take hold. For Tangerine, that just means running `./start.sh` again.
+10. After setting up Tangerine, navigate in your browser to `AWS Console -> CloudWatch -> Logs` and select your instance's log group. There you will find two streams, one for the tangerine container the other for couchdb container using the "tag" pattern you configured in `daemon.json`.
+
+```
+{
+	"log-driver": "awslogs",
+	"log-opts": {
+		"awslogs-region": "eu-central-1",
+		"awslogs-group": "example-",
+		"tag": "example-{{.Name}}"
+	}
+}
+```
+
+
+## Configure Alarm
+With Docker logs being sent to AWS CloudWatch, you can configure an alarm to detect if Tangerine is down. The following directions explain how to send an automated email if a Tangerine heartbeat log message is not heard for 15 minutes. 
+
+- Navigate in your browser to `AWS Console -> CloudWatch -> Logs`.
+- Open your server's log group.
+- Open the stream for Tangerine. If your tag pattern in `/etc/docker/daemon.json` is `example-{{.Name}}`, then your stream name will be `example-tangerine`.
+- In the `Filter events` text box, type `heartbeat` and press enter. This will filter the logs to all heartbeat messages.
+- With the filter still applied, click the "Create Metric Filter" button.
+- Fill out "Metric" form as follows:
+    - Filter name: heartbeat
+    - Filter pattern: heartbeat
+    - Metric namespace: tangerine
+    - Metric name: heartbeat
+    - Metric value: 1
+    - Default value: 0
+    - Unit: _leave blank_
+- Fill out "Notification" form as follows:
+    - Alarm state trigger: In alarm
+    - Select an SNS topic: Create new topic
+    - Create a new topic...: `<server name>-tangerine-heartbeat`
+    - Email endpoints that will receive the notification...: `<your email address>`
+- Click "Create Topic" button, then "Next" button.
+- Fill out "Name and description" form as follows then click "Next" button:
+    - Alarm name: `<server name>-tangerine-heartbeat`
+- Now on the "Preview and create" screen, click "Create Alarm"
+- Check your email to confirm subscription to SNS Topic.

--- a/docs/system-administrator/tangerine-nginx-ssl.md
+++ b/docs/system-administrator/tangerine-nginx-ssl.md
@@ -74,7 +74,6 @@ server {
 server {
 server_name DOMAIN.ORG
 client_max_body_size 0;
-;
 
         location / {
                 # First attempt to serve request as file, then

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,5 +1,32 @@
 # What's new 
 
+## v3.17.11
+- Added support for custom update scripts for each group. Add either a before-custom-updates.js or after-custom-updates.js to the root of your content depending on when you wish the script to run. Script needs to return a Promise. See Issue [2741](https://github.com/Tangerine-Community/Tangerine/issues/2741) for script example. PR: [#2742](https://github.com/Tangerine-Community/Tangerine/pull/2742)
+- Add support for filtering PII variables on Case Participant data and Event Form data in Synapse caches. List the variable names in your group's content folder `reporting-config.json`. For example: `{ "pii": ["foo_variable"] }`. This config was previously stored in the groups database.
+- Fixed bug that prevented rewind sync from working.
+
+__Server upgrade instructions__
+
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+
+```
+cd tangerine
+# Check the size of the data folder.
+du -sh data
+# Check disk for free space. Ensure there is at least 10GB + size of the data folder amount of free space in order to perform the upgrade.
+df -h
+# Turn off tangerine and database.
+docker stop tangerine couchdb
+# Create a backup of the data folder.
+cp -r data ../data-backup-$(date "+%F-%T")
+# Fetch the updates.
+git fetch origin
+git checkout v3.17.11
+./start.sh v3.17.11
+# Remove Tangerine's previous version Docker Image.
+docker rmi tangerine/tangerine:v3.17.10
+```
+
 ## v3.17.10
 - Skip optimizing sync-queue, sync-conflicts, and tangy-form views after Sync Protocol 2 sync completes.
 - Using `T.case.load()` in a form? This release fixes a bug where EventForm.formResponseId would be not set when submitting forms in cases where a form has loaded a different case and then the save case back again thus detaching the memory reference being previously set.


### PR DESCRIPTION

## Description
It's currently possible to bypass the first sync and start collecting data by clicking the Tangerine icon, restarting the app, and losing power during a long sync. If that happens, and you have downloaded 350,000 changes onto your device, on subsequent sync your device will try to upload 350,050 changes as opposed to just 50. This PR ensures that no data may be collected on a device until the first sync has completed.


## Type of Change
- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
This PR adds a check in the Login Guard of the app to check if the first sync has completed. If not, then it forwards them to the component for the first sync again.

## Limitations and Trade-offs
I'm not sure in what situation it might be helpful to collect data without a successful first sync, but it could exist.

## Screenshots/Videos
https://youtu.be/dIF-sIHNdOQ

## Tests
See the video.

## Notices, Regressions, Breaking Changes
None.
