### PR TITLE
Feature/fix broken create device user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -60,7 +60,7 @@ docker rmi tangerine/tangerine:v3.17.11
   
   __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -90,7 +90,7 @@ docker rmi tangerine/tangerine:v3.17.10
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -119,7 +119,7 @@ docker rmi tangerine/tangerine:v3.17.9
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -166,7 +166,7 @@ docker rmi tangerine/tangerine:v3.17.8
   
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -192,7 +192,7 @@ docker rmi tangerine/tangerine:v3.17.7
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -219,7 +219,7 @@ docker rmi tangerine/tangerine:v3.17.6
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -245,7 +245,7 @@ docker rmi tangerine/tangerine:v3.17.5
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -280,7 +280,7 @@ docker rmi tangerine/tangerine:v3.17.4
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -307,7 +307,7 @@ docker rmi tangerine/tangerine:v3.17.3
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -336,7 +336,7 @@ docker rmi tangerine/tangerine:v3.17.2
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -363,7 +363,7 @@ docker rmi tangerine/tangerine:v3.17.1
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -404,7 +404,7 @@ __New Features and Fixes__
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -443,7 +443,7 @@ There is now a content set for developing projects with the Class module enabled
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -487,7 +487,7 @@ __New Features__
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -532,7 +532,7 @@ __Fixes__
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -575,7 +575,7 @@ __Server upgrade instructions__
 
 If you want to enable filtered Case Event Schedule by Device's Assigned Location, add `filterCaseEventScheduleByDeviceAssignedLocation` to your groups' `app-config.json` set to a value of `true`.
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -618,7 +618,7 @@ __Fixes__
 
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -681,7 +681,7 @@ __Fixes__
 - Add missing import of `editor/custom-scripts.js` when using editor so Data Dashboards can have imported JS files.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 
 ```
@@ -722,7 +722,7 @@ docker rmi tangerine/tangerine:v3.15.6
 - Added simple network statistics to the device replicationStatus, which is posted after every sync.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -750,7 +750,7 @@ __New Features and Fixes__
 - The default value of the new config file is set to "ORIGINAL_VALUE" so existing Tangerine instances will not be effected.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 Please add the below line into your config.sh to preserve current behavior (as a workaround for #2564)
 ```
@@ -785,7 +785,7 @@ __New Features and Fixes__
 - Batch size for sync is configurable via `pullSyncOptions` and `pushSyncOptions` variable in a group's app-config.json. Default is 200. If the value is set too high, the application will crash.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -814,7 +814,7 @@ __Fixes__
 - Improve messaging during sync by removing floating change counts and showing the total number of docs in the database after sync.
 
 __Server upgrade instructions__
-Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Serve base64 image data as image files [#2706](https://github.com/Tangerine-Community/Tangerine/issues/2706) PR: [#2725](https://github.com/Tangerine-Community/Tangerine/pull/2725)
 - Add Cycle sequences [1603](https://github.com/Tangerine-Community/Tangerine/issues/1603)
 - Sort by lastModified in the client case search [#2692](https://github.com/Tangerine-Community/Tangerine/pull/2692)
-- Enable assigning multiple roles in forCaseRole in the eventDefinition [#2694](https://github.com/Tangerine-Community/Tangerine/pull/2694/)
+- Enable assigning multiple roles in forCaseRole in the eventFormDefinition [#2694](https://github.com/Tangerine-Community/Tangerine/pull/2694/)
 - Enable defining custom functions or valid JavaScript expressions that will be called when an event is opened and when an event is closed. On open and close events for case and case-events: [#2696](https://github.com/Tangerine-Community/Tangerine/pull/2696/files)
 - Teach-specific strings in Russian for default content-set [#2676](https://github.com/Tangerine-Community/Tangerine/pull/2676)
 - Uploads status such as app version when updating the app [#2756](https://github.com/Tangerine-Community/Tangerine/issues/2756)

--- a/docs/system-administrator/upgrade-checklist.md
+++ b/docs/system-administrator/upgrade-checklist.md
@@ -3,7 +3,7 @@
 ## Test on QA server
 * [ ] Clone production server to QA server.
 * [ ] Update `T_HOSTNAME` in `tangerine/config.sh`.
-* [ ] Run `./starts.sh <currently used version of tangerine>`. This puts the updated config in `config.sh` into the container.
+* [ ] Run `./start.sh <currently used version of tangerine>`. This puts the updated config in `config.sh` into the container.
 * [ ] Update `serverUrl` in all `app-config.json` files for each group in `tangerine/data/group/<your-group-id>/client/app-config.json`. 
 * [ ] Release all APKs and PWAs. This puts all updated app config into the APKs and PWAs.
 * [ ] Install and set up PWA/APKs for groups to test.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -3,13 +3,13 @@
 ## v3.18.0
 
 ### New Features
-- Enable configurable image capture in client [#2695](https://github.com/Tangerine-Community/Tangerine/issues/2695)
+- Enable configurable image capture in client [#2695](https://github.com/Tangerine-Community/Tangerine/issues/2695) 
   - Makes image capture work with a max size attribute - PR: [#218](https://github.com/Tangerine-Community/tangy-form/pull/218)
   - Add photo capture widget [#203](https://github.com/Tangerine-Community/tangy-form-editor/pull/203)
 - Serve base64 image data as image files [#2706](https://github.com/Tangerine-Community/Tangerine/issues/2706) PR: [#2725](https://github.com/Tangerine-Community/Tangerine/pull/2725)
 - Add Cycle sequences [1603](https://github.com/Tangerine-Community/Tangerine/issues/1603)
 - Sort by lastModified in the client case search [#2692](https://github.com/Tangerine-Community/Tangerine/pull/2692)
-- Enable assigning multiple roles in forCaseRole in the eventDefinition [#2694](https://github.com/Tangerine-Community/Tangerine/pull/2694/)
+- Enable assigning multiple roles in forCaseRole in the eventFormDefinition [#2694](https://github.com/Tangerine-Community/Tangerine/pull/2694/)
 - Enable defining custom functions or valid JavaScript expressions that will be called when an event is opened and when an event is closed. On open and close events for case and case-events: [#2696](https://github.com/Tangerine-Community/Tangerine/pull/2696/files)
 - Teach-specific strings in Russian for default content-set [#2676](https://github.com/Tangerine-Community/Tangerine/pull/2676)
 - Uploads status such as app version when updating the app [#2756](https://github.com/Tangerine-Community/Tangerine/issues/2756)
@@ -33,7 +33,7 @@
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -57,10 +57,10 @@ docker rmi tangerine/tangerine:v3.17.11
 - Added support for custom update scripts for each group. Add either a before-custom-updates.js or after-custom-updates.js to the root of your content depending on when you wish the script to run. Script needs to return a Promise. See Issue [2741](https://github.com/Tangerine-Community/Tangerine/issues/2741) for script example. PR: [#2742](https://github.com/Tangerine-Community/Tangerine/pull/2742)
 - Add support for filtering PII variables on Case Participant data and Event Form data in Synapse caches. List the variable names in your group's content folder `reporting-config.json`. For example: `{ "pii": ["foo_variable"] }`. This config was previously stored in the groups database.
 - Fixed bug that prevented rewind sync from working.
+  
+  __Server upgrade instructions__
 
-__Server upgrade instructions__
-
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -90,7 +90,7 @@ docker rmi tangerine/tangerine:v3.17.10
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -111,13 +111,15 @@ docker rmi tangerine/tangerine:v3.17.9
 ```
 
 ## v3.17.9
+
+### New Features and Buffixes
 - Prevent failed calls to `T.case.save()` in forms by avoiding any saves to a case when a form is active. [PR](https://github.com/Tangerine-Community/Tangerine/pull/2704/), [Issue](https://github.com/Tangerine-Community/Tangerine/issues/2700)
 - Enable assigning multiple roles in forCaseRole in the eventDefinition [#2694](https://github.com/Tangerine-Community/Tangerine/pull/2694/) - Cherry-picked commit [3e4938a0a80c57](https://github.com/Tangerine-Community/Tangerine/pull/2694/commits/3e4938a0a80c57c66aa8f4b0eda32b84c85ebe99) only.
 - Enable defining custom functions or valid JavaScript expressions that will be called when an event is opened and when an event is closed. On open and close events for case and case-events: [#2702](https://github.com/Tangerine-Community/Tangerine/pull/2702)
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -164,7 +166,7 @@ docker rmi tangerine/tangerine:v3.17.8
   
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -184,12 +186,13 @@ git checkout v3.17.8
 docker rmi tangerine/tangerine:v3.17.7
 ```
 
+
 ## v3.17.7
 - fix CSV generation issue: [#2681](https://github.com/Tangerine-Community/Tangerine/issues/2681)
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -216,7 +219,7 @@ docker rmi tangerine/tangerine:v3.17.6
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -242,7 +245,7 @@ docker rmi tangerine/tangerine:v3.17.5
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -277,7 +280,7 @@ docker rmi tangerine/tangerine:v3.17.4
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -304,7 +307,7 @@ docker rmi tangerine/tangerine:v3.17.3
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -333,7 +336,7 @@ docker rmi tangerine/tangerine:v3.17.2
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -360,7 +363,7 @@ docker rmi tangerine/tangerine:v3.17.1
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -401,7 +404,7 @@ __New Features and Fixes__
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -440,7 +443,7 @@ There is now a content set for developing projects with the Class module enabled
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -484,7 +487,7 @@ __New Features__
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -529,7 +532,7 @@ __Fixes__
 
 __Server upgrade instructions__
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -572,7 +575,7 @@ __Server upgrade instructions__
 
 If you want to enable filtered Case Event Schedule by Device's Assigned Location, add `filterCaseEventScheduleByDeviceAssignedLocation` to your groups' `app-config.json` set to a value of `true`.
 
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -615,7 +618,7 @@ __Fixes__
 
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -678,7 +681,7 @@ __Fixes__
 - Add missing import of `editor/custom-scripts.js` when using editor so Data Dashboards can have imported JS files.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 
 ```
@@ -719,7 +722,7 @@ docker rmi tangerine/tangerine:v3.15.6
 - Added simple network statistics to the device replicationStatus, which is posted after every sync.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -747,7 +750,7 @@ __New Features and Fixes__
 - The default value of the new config file is set to "ORIGINAL_VALUE" so existing Tangerine instances will not be effected.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 Please add the below line into your config.sh to preserve current behavior (as a workaround for #2564)
 ```
@@ -782,7 +785,7 @@ __New Features and Fixes__
 - Batch size for sync is configurable via `pullSyncOptions` and `pushSyncOptions` variable in a group's app-config.json. Default is 200. If the value is set too high, the application will crash.
 
 __Server upgrade instructions__
-Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine
@@ -811,7 +814,7 @@ __Fixes__
 - Improve messaging during sync by removing floating change counts and showing the total number of docs in the database after sync.
 
 __Server upgrade instructions__
-Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist/) for making sure you test the upgrade safely.
+Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
 
 ```
 cd tangerine

--- a/editor/src/app/groups/group-device-user/group-device-user.component.ts
+++ b/editor/src/app/groups/group-device-user/group-device-user.component.ts
@@ -32,7 +32,8 @@ export class GroupDeviceUserComponent implements OnInit {
           url: `device-users/${params.responseId}` 
         }
       ]
-      this.formPlayer.formResponseId = params.responseId
+      this.formPlayer.formResponseId = params.responseId || ''
+      this.formPlayer.formId = 'user-profile'
       this.formPlayer.preventSubmit = true
       this.formPlayer.render()
       this.formPlayer.$submit.subscribe(async () => {

--- a/editor/src/app/groups/group-device-users/group-device-users.component.html
+++ b/editor/src/app/groups/group-device-users/group-device-users.component.html
@@ -1,4 +1,4 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 <app-responses filterBy="user-profile" hideFilterBy=true [groupId]="groupId" [excludeColumns]="excludeColumns"></app-responses>
-<paper-fab (click)="newDeviceUser()" mat-raised-button icon="add" color="accent" class="action">
+<paper-fab routerLink="new" mat-raised-button icon="add" color="accent" class="action">
 </paper-fab>

--- a/editor/src/app/groups/group-device-users/group-device-users.component.ts
+++ b/editor/src/app/groups/group-device-users/group-device-users.component.ts
@@ -50,16 +50,4 @@ export class GroupDeviceUsersComponent implements OnInit {
     })
   }
 
-  async newDeviceUser() {
-    const data: any = await this.groupsService.getLocationList(this.groupId);
-    if (data.locationsLevels.length === 0) {
-      alert("Before adding users, you must first go to Configure / Location List and create at least one location.")
-    } else {
-      const response = new TangyFormResponseModel()
-      response.form.id = 'user-profile'
-      await this.http.post(`/api/${this.groupId}/${response._id}`, response).toPromise()
-      this.router.navigate([response._id], {relativeTo: this.route})
-    }
-  }
-
 }

--- a/editor/src/app/groups/groups-routing.module.ts
+++ b/editor/src/app/groups/groups-routing.module.ts
@@ -95,6 +95,7 @@ const groupsRoutes: Routes = [
   { path: 'groups/:groupId/deploy', component: GroupDeployComponent, canActivate: [LoginGuard ]},
   { path: 'groups/:groupId/deploy/device-users', component: GroupDeviceUsersComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/onlineSurvey', component: ReleaseOnlineSurveyComponent, canActivate: [LoginGuard ]},
+  { path: 'groups/:groupId/deploy/device-users/new', component: GroupDeviceUserComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/device-users/:responseId', component: GroupDeviceUserComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/devices', component: GroupDevicesComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/deploy/device-sheet', component: GroupDeviceSheetComponent, canActivate: [LoginGuard] },


### PR DESCRIPTION
Creating new device users stopped working in v3.18.0 due to  a change in Tangy Form that expects a form response to have some new properties on the first item. The "GroupDeviceUsers.newDeviceUser()" method of creating a blank form response and resuming it no longer works. Instead, we now load in the user-profile form and let TangyFormsPlayer create a new form response in the usual way a new form response is created.