### PR TITLE
Add location context to loaded case

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -1,6 +1,6 @@
 import { CaseEventOperation, CaseEventPermissions } from './../classes/case-event-definition.class';
 import { UserService } from 'src/app/shared/_services/user.service';
-import { AppConfigService } from 'src/app/shared/_services/app-config.service';
+import { AppConfigService, LocationNode } from 'src/app/shared/_services/app-config.service';
 import { EventFormDefinition, EventFormOperation } from './../classes/event-form-definition.class';
 import { Subject } from 'rxjs';
 import { NotificationStatus, Notification, NotificationType } from './../classes/notification.class';
@@ -34,6 +34,7 @@ class CaseService {
 
   _case:Case
   caseDefinition:CaseDefinition
+  location:Array<LocationNode>
 
   // Opening a case confirmation semaphore.
   openCaseConfirmed = false
@@ -202,6 +203,8 @@ class CaseService {
     // Note the order of setting caseDefinition before case matters because the setter for case expects caseDefinition to be the current one.
     this.caseDefinition = (await this.caseDefinitionsService.load())
       .find(caseDefinition => caseDefinition.id === caseInstance.caseDefinitionId)
+    const flatLocationList = await this.appConfigService.getFlatLocationList()
+    this.location = Object.keys(caseInstance.location).map(level => flatLocationList.locations.find(node => node.id === caseInstance.location[level]))
     this.case = caseInstance
   }
 

--- a/client/src/app/shared/_services/app-config.service.ts
+++ b/client/src/app/shared/_services/app-config.service.ts
@@ -1,30 +1,62 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { AppConfig } from '../_classes/app-config.class';
+import { Loc } from 'tangy-form/util/loc.js'
+
+export interface LocationNode {
+  id:string
+  level:string
+  label:string
+  data:any
+}
+
+export interface LocationList {
+  locations:any
+  locationsLevels:Array<string>
+  metadata:any
+}
+
+export interface FlatLocationList {
+  locations:Array<LocationNode>
+  locationsLevels:Array<string>
+  metadata:any
+}
 
 @Injectable()
 export class AppConfigService {
+
   config:AppConfig
-  locationList:any
+  locationList:LocationList
+  flatLocationList:FlatLocationList
+
   constructor(
     private http: HttpClient
   ) { }
+
   async getAppConfig():Promise<AppConfig> {
     this.config = this.config ? this.config : <AppConfig>await this.http.get('./assets/app-config.json').toPromise();
     return this.config;
   }
+
   public async getDefaultURL() {
     const result:any = await this.getAppConfig();
     return result.homeUrl;
   }
+
   public async syncProtocol2Enabled() {
     const config = await this.getAppConfig()
     return config.syncProtocol === '2' ? true : false
   }
+
   async getLocationList():Promise<any> {
-    this.locationList = this.locationList ? this.locationList : await this.http.get('./assets/location-list.json').toPromise();
+    this.locationList = this.locationList ? this.locationList : <LocationList>await this.http.get('./assets/location-list.json').toPromise();
     return this.locationList;
   }
 
+  async getFlatLocationList() {
+    this.locationList = this.locationList || <LocationList>await this.http.get('./assets/location-list.json').toPromise();
+    this.flatLocationList = this.flatLocationList || <FlatLocationList>Loc.flatten(JSON.parse(JSON.stringify(this.locationList)))
+    return this.flatLocationList
+  }
 
 }

--- a/editor/src/app/case/services/case.service.ts
+++ b/editor/src/app/case/services/case.service.ts
@@ -1,4 +1,4 @@
-import { AppConfigService } from './../../shared/_services/app-config.service';
+import { AppConfigService, LocationNode } from './../../shared/_services/app-config.service';
 import { EventFormDefinition } from './../classes/event-form-definition.class';
 import { Subject } from 'rxjs';
 import { NotificationStatus, Notification, NotificationType } from './../classes/notification.class';
@@ -30,6 +30,8 @@ class CaseService {
 
   _case:Case
   caseDefinition:CaseDefinition
+  location:Array<LocationNode>
+
   openCaseConfirmed = false
   queryCaseEventDefinitionId: any
   queryEventFormDefinitionId: any
@@ -190,6 +192,8 @@ class CaseService {
     // Note the order of setting caseDefinition before case matters because the setter for case expects caseDefinition to be the current one.
     this.caseDefinition = (await this.caseDefinitionsService.load())
       .find(caseDefinition => caseDefinition.id === caseInstance.caseDefinitionId)
+    const flatLocationList = await this.appConfigService.getFlatLocationList()
+    this.location = Object.keys(caseInstance.location).map(level => flatLocationList.locations.find(node => node.id === caseInstance.location[level]))
     this.case = caseInstance
   }
 

--- a/editor/src/app/shared/_services/app-config.service.ts
+++ b/editor/src/app/shared/_services/app-config.service.ts
@@ -1,8 +1,32 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Loc } from 'tangy-form/util/loc.js'
+
+export interface LocationNode {
+  id:string
+  level:string
+  label:string
+  data:any
+}
+
+export interface LocationList {
+  locations:any
+  locationsLevels:Array<string>
+  metadata:any
+}
+
+export interface FlatLocationList {
+  locations:Array<LocationNode>
+  locationsLevels:Array<string>
+  metadata:any
+}
 
 @Injectable()
 export class AppConfigService {
+
+  locationList:LocationList
+  flatLocationList:FlatLocationList
+
   constructor(
     private http: HttpClient
   ) { }
@@ -28,4 +52,16 @@ export class AppConfigService {
       console.error(error);
     }
   }
+
+  async getLocationList():Promise<any> {
+    this.locationList = this.locationList ? this.locationList : <LocationList>await this.http.get('./assets/location-list.json').toPromise();
+    return this.locationList;
+  }
+
+  async getFlatLocationList() {
+    this.locationList = this.locationList || <LocationList>await this.http.get('./assets/location-list.json').toPromise();
+    this.flatLocationList = this.flatLocationList || <FlatLocationList>Loc.flatten(JSON.parse(JSON.stringify(this.locationList)))
+    return this.flatLocationList
+  }
+
 }


### PR DESCRIPTION
When working synchronously in forms, we don't currently have access to the related Location Node data without loading the Location List async and using T.case.case.location to search the hierarchy for the node we want. This PR loads all related Location Nodes into memory at T.case.location when the context of a Case is set. 