### PR TITLE
Add a "Global Device User" option

### DIFF
--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -42,5 +42,9 @@ export class AppConfig {
   findSelectorLimit: number;
   compareLimit: number;
   allowCreationOfIssues:boolean
+  // By default, User Profiles (AKA Device Users) will sync down to devices given the Sync Settings and then filtered
+  // by assignment when associating accounts on the Device. Setting this to true will ensure all User Profiles are
+  // Synced to all Devices and there will also be no filtering when associating Device Users to Accounts on Devices.
+  disableDeviceUserFilteringByAssignment:boolean 
 }
 

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -31,6 +31,7 @@ export class SyncCouchdbDetails {
   formInfos:Array<FormInfo> = []
   locationQueries:Array<LocationQuery> = []
   deviceSyncLocations:Array<LocationConfig>
+  disableDeviceUserFilteringByAssignment:boolean
 }
 
 @Injectable({
@@ -494,28 +495,38 @@ export class SyncCouchdbService {
     return status;
   }
 
-  getPullSelector(syncDetails) {
+  getPullSelector(syncDetails:SyncCouchdbDetails) {
     const pullSelector = {
       "$or": [
         ...syncDetails.formInfos.reduce(($or, formInfo) => {
           if (formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled && formInfo.couchdbSyncSettings.pull) {
-            $or = [
-              ...$or,
-              ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
-                ? syncDetails.deviceSyncLocations.map(locationConfig => {
-                  // Get last value, that's the focused sync point.
-                  let location = locationConfig.value.slice(-1).pop()
-                  return {
-                    "form.id": formInfo.id,
-                    [`location.${location.level}`]: location.value
-                  }
-                })
-                : [
-                  {
-                    "form.id": formInfo.id
-                  }
-                ]
-            ]
+            if (formInfo.id === 'user-profile' && syncDetails.disableDeviceUserFilteringByAssignment) {
+              // Replicate all user profiles regardless of location.
+              $or = [
+                ...$or,
+                {
+                  'form.id': 'user-profile'
+                }
+              ]
+            } else {
+              $or = [
+                ...$or,
+                ...syncDetails.deviceSyncLocations.length > 0 && formInfo.couchdbSyncSettings.filterByLocation
+                  ? syncDetails.deviceSyncLocations.map(locationConfig => {
+                    // Get last value, that's the focused sync point.
+                    let location = locationConfig.value.slice(-1).pop()
+                    return {
+                      "form.id": formInfo.id,
+                      [`location.${location.level}`]: location.value
+                    }
+                  })
+                  : [
+                    {
+                      "form.id": formInfo.id
+                    }
+                  ]
+              ]
+            }
           }
           return $or
         }, []),

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -89,7 +89,8 @@ export class SyncService {
         deviceId: device._id,
         deviceToken: device.token,
         deviceSyncLocations: device.syncLocations,
-        formInfos
+        formInfos,
+        disableDeviceUserFilteringByAssignment: appConfig.disableDeviceUserFilteringByAssignment
       },
       null,
       isFirstSync,

--- a/client/src/app/user-profile/associate-user-profile/associate-user-profile.component.ts
+++ b/client/src/app/user-profile/associate-user-profile/associate-user-profile.component.ts
@@ -28,12 +28,16 @@ export class AssociateUserProfileComponent implements OnInit {
   ) { }
 
   async ngOnInit() {
+    const appConfig = await this.appConfigService.getAppConfig()
     const deviceInfo = await this.deviceService.getDevice()
     const lowestLevelOfLocation = deviceInfo.assignedLocation.value[deviceInfo.assignedLocation.value.length-1]
-    const userProfiles = await this.tangyFormService.getResponsesByFormId('user-profile')
-    const localUserProfiles = userProfiles.filter(profile => profile.location[lowestLevelOfLocation.level] === lowestLevelOfLocation.value)
+    let userProfiles = await this.tangyFormService.getResponsesByFormId('user-profile')
+    if (!appConfig.disableDeviceUserFilteringByAssignment) {
+      const localUserProfiles = userProfiles.filter(profile => profile.location[lowestLevelOfLocation.level] === lowestLevelOfLocation.value)
+      userProfiles = localUserProfiles
+    }
     const userAccounts = await this.userService.getAllUserAccounts()
-    const availableUserProfiles = localUserProfiles.filter((userProfile) => !userAccounts.find(userAccount => userAccount.userUUID === userProfile._id))
+    const availableUserProfiles = userProfiles.filter((userProfile) => !userAccounts.find(userAccount => userAccount.userUUID === userProfile._id))
     this.container.nativeElement.innerHTML = `
       <tangy-form id="user-profile-select-form">
         <tangy-form-item id="user-profile-select-item">


### PR DESCRIPTION
## Description
Some deployments do not assign Device Users to specific locations, instead they are just one big team and need all their Device Users on every device no matter what the Assignment and Sync Settings is on a Device. 

## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution

## Limitations and Trade-offs
There is an inbetween level where Teams may travel between Sync Zones. This does not cover that use case but will be covered in a future ticket https://github.com/Tangerine-Community/Tangerine/issues/2789

## Screenshots/Videos

---


## Tests


## Notices, Regressions, Breaking Changes
None.

## TODOS/enhancements
