### PR TITLE
Added storageAvailable to replicationStatus in sync

### DIFF
--- a/client/src/app/core/update/update/updates.ts
+++ b/client/src/app/core/update/update/updates.ts
@@ -398,8 +398,8 @@ export const updates = [
       await variableService.set('previousDeviceSyncLocations', device.syncLocations)
       await variableService.set('ran-update-v3.19.0', 'true')
       console.log('Adding support for archived flags in search index...')
-      await T.search.createIndex()
-      await T.search.search(userService.getCurrentUser(), '', 1, 0)
+      await window['T'].search.createIndex()
+      await window['T'].search.search(userService.getCurrentUser(), '', 1, 0)
     }
   }
 ]

--- a/client/src/app/sync/classes/replication-status.class.ts
+++ b/client/src/app/sync/classes/replication-status.class.ts
@@ -39,4 +39,5 @@ export class ReplicationStatus {
   fullSync: string;
   compareDocsDirection: string;
   deletedArchivedDocs: number;
+  storageAvailable: number;
 }

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -127,6 +127,15 @@ export class SyncService {
     const diff = end.diff(start)
     const duration = moment.duration(diff).as('milliseconds')
     // const durationUTC = moment.utc(duration).format('HH:mm:ss')
+    let storageAvailable;
+
+    if (window['isCordovaApp']) {
+      window['cordova'].exec(function(result) {
+        storageAvailable = result
+      }, function(error) {
+        console.log("Error: " + error)
+      }, "File", "getFreeDiskSpace", []);
+    }
 
     try {
       // reset pullConflicts - we don't want to send these stats.
@@ -134,6 +143,7 @@ export class SyncService {
       this.replicationStatus.syncCouchdbServiceStartTime = this.syncCouchdbServiceStartTime
       this.replicationStatus.syncCouchdbServiceEndime = this.syncCouchdbServiceEndime
       this.replicationStatus.syncCouchdbServiceDuration = duration
+      this.replicationStatus.storageAvailable = storageAvailable
       await this.addDeviceSyncMetadata();
 
       this.syncMessage$.next({

--- a/editor/src/app/groups/group-devices/group-devices.component.css
+++ b/editor/src/app/groups/group-devices/group-devices.component.css
@@ -77,3 +77,9 @@ th, td {
 .red-icon svg {
   fill: red;
 }
+
+.error {
+  color: red;
+  font-size: larger;
+  font-weight: bold;
+}

--- a/editor/src/app/groups/group-devices/group-devices.component.html
+++ b/editor/src/app/groups/group-devices/group-devices.component.html
@@ -11,10 +11,12 @@
 </div>
 <div class="table-container">
   <div class="table-legend">
+    <div *ngIf="displayLowStorageWarning" class="error">Device(s) reporting low storage space!</div>
     <p>Scroll to the right to see additional fields. Some of the information in this table are reported from the most recent tablet sync. Detailed information about some of these fields:</p>
     <ul>
       <li>All Docs on Tablet: All records on the tablet.</li>
       <li>Form Responses on Tablet for Location: This is a subset of "All Docs on Tablet." All tablets in the same location should have the same number of form responses if they are up-to-date on sync.</li>
+      <li>Storage Available on Device (GB): This value will display in red if the tablet has low storage space. This threshold is currently set to {{storageAvailableErrorThreshhold}} GB.</li>
       <li>Network Statistics: This value is an estimated value reported from the client app's browser instance; it is not the result of a network query at the time of sync. Consider it as a general indicator of network quality. </li>
     </ul>
   </div>
@@ -86,6 +88,12 @@
         <th mat-header-cell *matHeaderCellDef> Form Responses on Tablet for Location </th>
         <td mat-cell *matCellDef="let element">
           {{element.localDocsForLocation}}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="storageAvailable">
+        <th mat-header-cell *matHeaderCellDef> Storage Available on Device (GB) </th>
+        <td mat-cell *matCellDef="let element">
+          <span [className]="element.isStorageThresholdExceeded ? 'error' : ''">{{element.storageAvailable}}</span>
         </td>
       </ng-container>
       <ng-container matColumnDef="network">

--- a/editor/src/app/sync/replication-status.class.ts
+++ b/editor/src/app/sync/replication-status.class.ts
@@ -38,4 +38,5 @@ export class ReplicationStatus {
   fullSync: string;
   compareDocsDirection: string;
   deletedArchivedDocs: number;
+  storageAvailable: number;
 }


### PR DESCRIPTION
Displaying this value in group devices listing.

## Description

---

Enables tablets to report available storage scape and also enables admins to monitor when storage space is too low.

- Fixes #2779

## Type of Change

[Please delete irrelevant options]

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

Uses a function provided from the Cordova API.

## Limitations and Trade-offs

Not available for PWA's. 

Since Cordova is supporting a browser context in addition to Android and IOS, it may be possible to make this work on PWA's.

## Screenshots/Videos

See Screenshots in the issue.
