### PR TITLE
Show down sync doc count given device sync settings

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "generate-form-json": "./src/scripts/generate-form-json/bin.js",
     "extract-pii-variables": "./src/scripts/extract-pii-variables/bin.js",
     "generate-location-level-indexes": "./src/scripts/generate-location-level-indexes/bin.js",
+    "update-down-sync-doc-count-by-location-id-index": "./src/scripts/update-down-sync-doc-count-by-location-id-index.js",
     "generate-indexes": "./src/scripts/generate-indexes/bin.js",
     "push-all-groups-views": "./src/scripts/push-all-groups-views.js",
     "index-all-groups-views": "./src/scripts/index-all-groups-views.js",

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -181,6 +181,7 @@ app.get('/api/:groupId/responses/:limit?/:skip?', isAuthenticated, require('./ro
 app.get('/app/:groupId/response-variable-value/:responseId/:variableName', isAuthenticated, require('./routes/group-response-variable-value.js'))
 app.get('/api/:groupId/responsesByFormId/:formId/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-form-id.js'))
 app.get('/api/:groupId/responsesByMonthAndFormId/:keys/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-month-and-form-id.js'))
+app.get('/api/:groupId/docCountByLocationId/:locationId', isAuthenticated, require('./routes/group-doc-count-by-location-id.js'))
 // Support for API working with group pathed cookie :). We should do this for others because our group cookies can't access /api/.
 app.get('/app/:groupId/responsesByMonthAndFormId/:keys/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-month-and-form-id.js'))
 

--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -181,7 +181,8 @@ app.get('/api/:groupId/responses/:limit?/:skip?', isAuthenticated, require('./ro
 app.get('/app/:groupId/response-variable-value/:responseId/:variableName', isAuthenticated, require('./routes/group-response-variable-value.js'))
 app.get('/api/:groupId/responsesByFormId/:formId/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-form-id.js'))
 app.get('/api/:groupId/responsesByMonthAndFormId/:keys/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-month-and-form-id.js'))
-app.get('/api/:groupId/docCountByLocationId/:locationId', isAuthenticated, require('./routes/group-doc-count-by-location-id.js'))
+app.get('/app/:groupId/docCountByLocationId/:locationId', isAuthenticated, require('./routes/group-doc-count-by-location-id.js'))
+app.get('/app/:groupId/downSyncDocCountByLocationId/:locationId', isAuthenticated, require('./routes/group-down-sync-doc-count-by-location-id.js'))
 // Support for API working with group pathed cookie :). We should do this for others because our group cookies can't access /api/.
 app.get('/app/:groupId/responsesByMonthAndFormId/:keys/:limit?/:skip?', isAuthenticated, require('./routes/group-responses-by-month-and-form-id.js'))
 

--- a/server/src/group-views.js
+++ b/server/src/group-views.js
@@ -2,6 +2,18 @@ const emit = _ => { }
 
 module.exports = {}
 
+module.exports.docCountByLocationId = {
+  view: function(doc) {
+    if (doc.location) {
+      Object.getOwnPropertyNames(doc.location).forEach(function(locationLevel) {
+        // Emit location's ID and add one.
+        emit(doc.location[locationLevel], 1)
+      })
+    }
+  },
+  reduce: '_sum'
+}
+
 module.exports.responsesByFormId = function(doc) {
   if (doc.form && doc.form.id) {
     return emit(doc.form.id, true)

--- a/server/src/routes/group-doc-count-by-location-id.js
+++ b/server/src/routes/group-doc-count-by-location-id.js
@@ -1,0 +1,18 @@
+const DB = require('../db.js')
+const clog = require('tangy-log').clog
+const log = require('tangy-log').log
+
+module.exports = async (req, res) => {
+  try {
+    const groupDb = new DB(req.params.groupId)
+    let options = {keys: [ req.params.locationId ], reduce: true, group: true}
+    const results = await groupDb.query('docCountByLocationId', options);
+    const count = results.rows[0]
+        ? results.rows[0].value
+        : 0
+    res.send(count)
+  } catch (error) {
+    log.error(error);
+    res.status(500).send(error);
+  }
+}

--- a/server/src/routes/group-down-sync-doc-count-by-location-id.js
+++ b/server/src/routes/group-down-sync-doc-count-by-location-id.js
@@ -1,0 +1,21 @@
+const DB = require('../db.js')
+const clog = require('tangy-log').clog
+const log = require('tangy-log').log
+
+const updateDownSyncDocCountByLocationId = require('../scripts/update-down-sync-doc-count-by-location-id-index.js').updateDownSyncDocCountByLocationId
+
+module.exports = async (req, res) => {
+  try {
+    await updateDownSyncDocCountByLocationId(req.params.groupId)
+    const groupDb = new DB(req.params.groupId)
+    let options = {keys: [ req.params.locationId ], reduce: true, group: true}
+    const results = await groupDb.query('downSyncDocCountByLocationId', options);
+    const count = results.rows[0]
+        ? results.rows[0].value
+        : 0
+    res.send(`${count}`)
+  } catch (error) {
+    log.error(error);
+    res.status(500).send(error);
+  }
+}

--- a/server/src/scripts/info.sh
+++ b/server/src/scripts/info.sh
@@ -23,6 +23,7 @@ echo "translations-update      (Update translation files in all group content fo
 echo "import-v2-assessment     (Migrate an Assessment from a Tangerine v2 server to a Tangerine v3 Form)"
 echo "generate-ssh-keys        (Generates new SSH keys for creating groups from remote and private content sets)"
 echo "update-group-search-index(Required to run when forms.json search settings change in a group)"
+echo "update-down-sync-doc-count-by-location-id-index (If forms.json couchdbSyncSetting.pull changes, this needs to be run)"
 echo "mysql-report             (Report on the data migration process to mysql)"
 echo ""
 echo "Add --help option to any command for command specific documentation."

--- a/server/src/scripts/update-down-sync-doc-count-by-location-id-index.js
+++ b/server/src/scripts/update-down-sync-doc-count-by-location-id-index.js
@@ -1,12 +1,21 @@
 #!/usr/bin/env node
 
 const fs = require('fs-extra')
+const groupsList = require('../groups-list.js')
 const DB = require('../db.js')
 
 async function updateDownSyncDocCountByLocationId (GROUP_ID) {
-  console.log('')
-  console.log(`Updating search index for group ${GROUP_ID}`)
-  console.log('')
+  if (GROUP_ID === '*') {
+    for (let groupId of groupIds) {
+      await updateGroup(groupId)
+    }
+  } else {
+    await updateGroup(GROUP_ID)
+  }
+}
+
+async function updateGroup(GROUP_ID) {
+  console.log(`Updating down sync doc count by location index for group ${GROUP_ID}`)
   const formsInfo = await fs.readJSON(`/tangerine/groups/${GROUP_ID}/client/forms.json`) 
   const db = DB(GROUP_ID)
   const formIdsToDownSync = formsInfo.reduce((formIdsToDownSync, formInfo) => {
@@ -71,6 +80,7 @@ async function updateDownSyncDocCountByLocationId (GROUP_ID) {
 if (process.argv[2] === '--help') {
   console.log('Usage:')
   console.log('update-down-sync-doc-count-by-location-id-index <groupId>')
+  console.log('update-down-sync-doc-count-by-location-id-index \'*\'')
   process.exit()
 }
 

--- a/server/src/scripts/update-down-sync-doc-count-by-location-id-index.js
+++ b/server/src/scripts/update-down-sync-doc-count-by-location-id-index.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+const fs = require('fs-extra')
+const DB = require('../db.js')
+
+async function updateDownSyncDocCountByLocationId (GROUP_ID) {
+  console.log('')
+  console.log(`Updating search index for group ${GROUP_ID}`)
+  console.log('')
+  const formsInfo = await fs.readJSON(`/tangerine/groups/${GROUP_ID}/client/forms.json`) 
+  const db = DB(GROUP_ID)
+  const formIdsToDownSync = formsInfo.reduce((formIdsToDownSync, formInfo) => {
+    return formInfo.couchdbSyncSettings && formInfo.couchdbSyncSettings.enabled === true && formInfo.couchdbSyncSettings.pull === true
+      ? [
+        ...formIdsToDownSync,
+        formInfo.id
+      ]
+      : formIdsToDownSync
+  }, [])
+
+  let map = `function(doc) {
+    var formIdsToDownSync = ${JSON.stringify(formIdsToDownSync)}
+    if (
+      (
+        doc.collection === 'TangyFormResponse' &&
+        doc.form &&
+        doc.form.id &&
+        typeof doc.location === 'object' &&
+        formIdsToDownSync.indexOf(doc.form.id) !== -1
+      ) ||
+      (
+        doc.collection === 'Issue' &&
+        typeof doc.location === 'object'
+      )
+    ) {
+      Object.getOwnPropertyNames(doc.location).forEach(function(locationLevel) {
+        // Emit location's ID and add one.
+        emit(doc.location[locationLevel], 1)
+      })
+    }
+  }`
+  const updatedDesignDoc = {
+    _id: '_design/downSyncDocCountByLocationId',
+    views: {
+      'downSyncDocCountByLocationId': {
+        map,
+        reduce: '_sum'
+      }
+    }
+  }
+  let existingDesignDoc = null
+  try {
+    existingDesignDoc = await db.get('_design/downSyncDocCountByLocationId')
+    updatedDesignDoc['_rev'] = existingDesignDoc._rev
+  } 
+  catch (e) {
+    console.error(e)
+  }
+  try {
+    if (!existingDesignDoc || (existingDesignDoc && existingDesignDoc.views.downSyncDocCountByLocationId.map !== updatedDesignDoc.views.downSyncDocCountByLocationId.map)) {
+      await db.put(updatedDesignDoc)
+    }
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+/*
+ * CLI support
+ */
+if (process.argv[2] === '--help') {
+  console.log('Usage:')
+  console.log('update-down-sync-doc-count-by-location-id-index <groupId>')
+  process.exit()
+}
+
+if (process.argv[1].includes('update-down-sync-doc-count-by-location-id-index')) {
+  const GROUP_ID = process.argv[2]
+  updateDownSyncDocCountByLocationId(GROUP_ID)
+}
+
+/*
+ * Module support
+ */
+module.exports = { updateDownSyncDocCountByLocationId }


### PR DESCRIPTION
When setting up devices or assign new sync areas for a device, it's important to know how large of an initial sync is going to happen for that device or devices. This PR adds a "Caculate Down-sync Size" button to the Device form that will sum the number of docs that would down-sync for each location the device is configured to sync to. Behind the scenes there is a new `update-down-sync-doc-count-by-location-id-index` CLI/function that updates a downSyncDocCountByLocationId view that is unique to that group given couchdb sync settings in that group's forms.json. `update-down-sync-doc-count-by-location-id-index` is similar in pattern to `update-group-search-index` which takes some config in `forms.json` and templates out a custom map function for that group. Each time the corresponding route in express for `downSyncDocCountByLocationId` is called, the update function runs but only actually updates the design doc if the templated map function is different from the one currently in the design doc as to avoid unnecessary re-indexing of that view.

<img width="579" alt="Screen Shot 2021-08-04 at 2 52 43 PM" src="https://user-images.githubusercontent.com/156575/128239083-d542d81f-73b4-4bb6-83d6-c353dd85ba86.png">
