### PR TITLE
Set default password policy in all content sets

### DIFF
--- a/content-sets/case-module-starter/client/app-config.defaults.json
+++ b/content-sets/case-module-starter/client/app-config.defaults.json
@@ -6,6 +6,8 @@
    "modules" : [
       "csv"
    ],
+   "passwordPolicy":"(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}",
+   "passwordRecipe":"Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters", 
    "showQueries" : true,
    "showIssues": true,
    "uploadUnlockedFormReponses" : false,

--- a/content-sets/case-module/client/app-config.defaults.json
+++ b/content-sets/case-module/client/app-config.defaults.json
@@ -6,6 +6,8 @@
    "modules" : [
       "csv"
    ],
+   "passwordPolicy":"(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}",
+   "passwordRecipe":"Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters",
    "showQueries" : true,
    "showIssues": true,
    "uploadUnlockedFormReponses" : false,

--- a/content-sets/custom-app/client/app-config.defaults.json
+++ b/content-sets/custom-app/client/app-config.defaults.json
@@ -6,6 +6,8 @@
    "modules" : [
       "csv"
    ],
+   "passwordPolicy":"(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}",
+   "passwordRecipe":"Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters",
    "showQueries" : true,
    "uploadUnlockedFormReponses" : false,
    "securityQuestionText" : "What is your year of birth?",

--- a/content-sets/data-conflict-tools/client/app-config.defaults.json
+++ b/content-sets/data-conflict-tools/client/app-config.defaults.json
@@ -5,6 +5,8 @@
   "hideProfile": false,
   "registrationRequiresServerUser": false,
   "listUsernamesOnLoginScreen": true,
+  "passwordPolicy":"(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}",
+  "passwordRecipe":"Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters",
   "serverUrl": "http://localhost/",
   "uploadUnlockedFormReponses": false,
   "groupName": "",

--- a/content-sets/default/client/app-config.defaults.json
+++ b/content-sets/default/client/app-config.defaults.json
@@ -5,6 +5,8 @@
   "hideProfile": false,
   "registrationRequiresServerUser": false,
   "listUsernamesOnLoginScreen": true,
+  "passwordPolicy":"(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}",
+  "passwordRecipe":"Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters",
   "serverUrl": "http://localhost/",
   "uploadUnlockedFormReponses": false,
   "groupName": "",

--- a/content-sets/teach/client/app-config.defaults.json
+++ b/content-sets/teach/client/app-config.defaults.json
@@ -5,6 +5,8 @@
   "hideProfile": false,
   "registrationRequiresServerUser": false,
   "listUsernamesOnLoginScreen": true,
+  "passwordPolicy":"(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}",
+  "passwordRecipe":"Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters",
   "serverUrl": "http://localhost/",
   "uploadUnlockedFormReponses": true,
   "groupName": "",


### PR DESCRIPTION
Because setting a password policy requires editing JSON and can be easy to overlook, set a sensible default.