### PR TITLE
Expire sync sessions after one week instead of one day.

### DIFF
--- a/server/src/modules/sync/services/sync-session/sync-session-v2.service.ts
+++ b/server/src/modules/sync/services/sync-session/sync-session-v2.service.ts
@@ -57,9 +57,8 @@ export class SyncSessionv2Service {
   }
 
   async expireSyncSessions() {
-    // Expire all sync sessions after 24 hours. This means if a sync session takes longer than
-    // 24 hours then it will be interrupted.
-    const expireLimit = 24*60*60*1000
+    // Expire all sync sessions after 1 week.
+    const expireLimit = 7*24*60*60*1000
     const _usersDb = this.dbService.instantiate(`_users`)
     const expiredSyncSessions = (await _usersDb.allDocs({ include_docs: true }))
       .rows

--- a/server/src/modules/sync/services/sync-session/sync-session.service.ts
+++ b/server/src/modules/sync/services/sync-session/sync-session.service.ts
@@ -45,9 +45,8 @@ export class SyncSessionService {
   }
 
   async expireSyncSessions() {
-    // Expire all sync sessions after 24 hours. This means if a sync session takes longer than
-    // 24 hours then it will be interrupted.
-    const expireLimit = 24*60*60*1000
+    // Expire all sync sessions after 1 week.
+    const expireLimit = 7*24*60*60*1000
     const _usersDb = this.dbService.instantiate(`_users`)
     const expiredSyncSessions = (await _usersDb.allDocs({ include_docs: true }))
       .rows


### PR DESCRIPTION
Sync sessions expire after one day. This could interrupt a long running sync process. This PR extends that expiration to 1 week.