### PR TITLE
Fix media library upload in group created from content set by ensurin…

### DIFF
--- a/server/src/scripts/create-group/bin.js
+++ b/server/src/scripts/create-group/bin.js
@@ -76,6 +76,11 @@ async function createGroup() {
     } else if (contentSetVersion === 2) {
       appConfigDefaultsPath = `${groupPath}/client/app-config.defaults.json`
     }
+    try {
+      await exec(`mkdir ${groupPath}/client/media`)
+    } catch (e) {
+      // Content set must have already implemented media folder.
+    }
     const appConfig = await fs.readJson(appConfigDefaultsPath)
     await fs.writeJson(appConfigPath, {
       ...appConfig,


### PR DESCRIPTION
If there is no ./client/media folder in a content set, media upload under Author will fail. This PR automatically creates the ./client/media folder when a new group is being created from a content set.

Related to #2872