### PR TITLE
Feature/2872 create media directory if does not exist on media upload

### DIFF
--- a/server/src/routes/group-media-upload.js
+++ b/server/src/routes/group-media-upload.js
@@ -4,9 +4,15 @@ const log = require('tangy-log').log
 const util = require('util')
 const readDir = util.promisify(require('fs').readdir)
 const stat = util.promisify(require('fs').stat)
+const access = util.promisify(require('fs').access)
 const exec = util.promisify(require('child_process').exec)
 
 module.exports = async (req, res) => {
+  try {
+    await access(`/tangerine/client/content/groups/${req.params.group}/media`)
+  } catch (e) {
+    await exec(`mkdir /tangerine/client/content/groups/${req.params.group}/media`)
+  }
   for (let file of req.files) {
     await exec(`mv ${file.path} /tangerine/client/content/groups/${req.params.group}/media/${file.originalname.replace(/(\s+)/g, '\\$1')}`)
   }


### PR DESCRIPTION
## Description
Not all content sets have a media directory, so if uploading media, make sure to create the media directory so uploading doesn't fail.

- Fixes #2872

## Type of Change


- Bug fix (non-breaking change which fixes an issue)
