### PR TITLE
Using pouch-replication-stream for exporting databases

### DIFF
--- a/client/src/app/core/export-data/export-data/export-data.component.css
+++ b/client/src/app/core/export-data/export-data/export-data.component.css
@@ -7,3 +7,21 @@ mat-card {
   font-size: 24px;
   font-weight: 400;
 }
+
+.status {
+  margin-top: 2em;
+  font-size: large;
+}
+
+.error {
+  text-align: center;
+  margin-top: 2em;
+  color: red;
+  font-size: large;
+}
+
+label {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 10px;
+}

--- a/client/src/app/core/export-data/export-data/export-data.component.html
+++ b/client/src/app/core/export-data/export-data/export-data.component.html
@@ -4,15 +4,18 @@
       <div class="container">
         <mat-card>
           <div class="mat-card-header-text">
-            Export Backup
+            {{'Export Backup'|translate}}
           </div>
           <mat-card-content class="card-content">
-            <p>Export Data creates a backup of all of your records and saves it to your device.</p>
+            <p>{{'Export Data creates a backup of all of your records and saves it to your device.'|translate}}</p>
+            <p>{{'Backup directory'|translate}} : {{backupDir}}</p>
           </mat-card-content>
           <mat-card-actions class="card-actions">
             <button color="primary" mat-raised-button (click)="exportAllRecords()">{{'EXPORT DATA FOR ALL USERS'|translate}}</button>
           </mat-card-actions>
         </mat-card>
+        <div [innerHTML]="statusMessage" class="status"></div>
+        <div [innerHTML]="errorMessage" class="error"></div>
       </div>
     </ng-template>
   </mat-tab>

--- a/client/src/app/core/export-data/export-data/export-data.component.ts
+++ b/client/src/app/core/export-data/export-data/export-data.component.ts
@@ -86,7 +86,7 @@ export class ExportDataComponent implements OnInit {
           // const currentUser = this.userService.getCurrentUser();
           const now = new Date();
           const fileName =
-            `${dbName}-${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}.json`;
+            `${dbName}_${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}.json`;
           if (this.window.isCordovaApp) {
             document.addEventListener('deviceready', () => {
               this.window.resolveLocalFileSystemURL(cordova.file.externalDataDirectory, (directoryEntry) => {

--- a/client/src/app/core/export-data/export-data/export-data.component.ts
+++ b/client/src/app/core/export-data/export-data/export-data.component.ts
@@ -19,7 +19,10 @@ declare const cordova: any;
 export class ExportDataComponent implements OnInit {
 
   window:any;
-
+  statusMessage: string
+  errorMessage: string
+  backupDir: string = 'Documents/Tangerine/backups/'
+  
   constructor(
     private userService: UserService,
     private syncingService: SyncingService,
@@ -29,23 +32,46 @@ export class ExportDataComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.statusMessage = ''
+    this.errorMessage = ''
+    
+    if (this.window.isCordovaApp) {
+      this.backupDir = 'Documents/Tangerine/backups/'
+    } else {
+      this.backupDir = `${_TRANSLATE('Click button to start download to desired directory.')} `
+    }
+    
+    if (this.window.isCordovaApp) {
+      this.window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory + 'Documents', (directoryEntry) => {
+        directoryEntry.getDirectory('Tangerine', { create: true }, (dirEntry) => {
+          dirEntry.getDirectory('backups', { create: true }, (subDirEntry) => {
+          }, onErrorGetDir);
+          dirEntry.getDirectory('restore', { create: true }, (subDirEntry) => {
+          }, onErrorGetDir);
+        }, onErrorGetDir);
+      })
+    }
   }
   
   async exportAllRecords() {
+    this.statusMessage = ''
+    this.errorMessage = ''
     const appConfig = await this.appConfigService.getAppConfig()
     const dbNames = [SHARED_USER_DATABASE_NAME, SHARED_USER_DATABASE_INDEX_NAME, USERS_DATABASE_NAME, LOCKBOX_DATABASE_NAME, VARIABLES_DATABASE_NAME]
+    // APK's that use in-app encryption
     if (window['isCordovaApp'] && appConfig.syncProtocol === '2' && !window['turnOffAppLevelEncryption']) {
+      const backupLocation = cordova.file.externalRootDirectory + this.backupDir;
       for (const dbName of dbNames) {
         // copy the database
         console.log(`copying ${dbName} db over to the user accessible fs`)
         // tslint:disable-next-line:max-line-length
         this.window.resolveLocalFileSystemURL(cordova.file.applicationStorageDirectory + 'databases/' + dbName, (fileEntry) => {
-          this.window.resolveLocalFileSystemURL(cordova.file.externalDataDirectory, function (directory) {
-            fileEntry.copyTo(directory, dbName, function() {
+          this.window.resolveLocalFileSystemURL(backupLocation, (directory) => {
+            fileEntry.copyTo(directory, dbName, () => {
                 console.log('DB Copied!');
-                alert(`${_TRANSLATE('File Stored At')} ${cordova.file.externalDataDirectory}${dbName}`);
-              },
-              function(e) {
+                // alert(`${_TRANSLATE('File Stored At')} ${cordova.file.externalDataDirectory}${dbName}`);
+                this.statusMessage += `<p>${_TRANSLATE('DB Copied to ')} ${cordova.file.externalDataDirectory}${dbName}</p>`
+              }, (e) => {
                 console.log('Unable to copy DB');
                 alert(`${_TRANSLATE('Write Failed: ')}` + e.toString());
               });
@@ -53,6 +79,7 @@ export class ExportDataComponent implements OnInit {
         }, null);
       }
     } else {
+      // APK's or PWA's that do not use in-app encryption - have turnOffAppLevelEncryption:true in app-config.json
       for (let index = 0; index < dbNames.length; index++) {
         const stream = new window['Memorystream']
         let data = '';
@@ -65,38 +92,61 @@ export class ExportDataComponent implements OnInit {
         const db = DB(dbName)
         try {
           await db.dump(stream)
-          console.log('Successfully dumped : ' + dbName);
+          console.log('Successfully exported : ' + dbName);
+          this.statusMessage += `<p>${_TRANSLATE('Successfully exported database ')} ${dbName}</p>`
           const file = new Blob([data], {type: 'application/json'});
           // const currentUser = this.userService.getCurrentUser();
           const now = new Date();
           const fileName =
             `${dbName}_${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}.json`;
-          
           if (this.window.isCordovaApp) {
+            const backupLocation = cordova.file.externalRootDirectory + this.backupDir;
             document.addEventListener('deviceready', () => {
-              this.window.resolveLocalFileSystemURL(cordova.file.externalDataDirectory, (directoryEntry) => {
+              this.window.resolveLocalFileSystemURL(backupLocation, (directoryEntry) => {
                 directoryEntry.getFile(fileName, {create: true}, (fileEntry) => {
                   fileEntry.createWriter((fileWriter) => {
                     fileWriter.onwriteend = (data) => {
-                      alert(`${_TRANSLATE('File Stored At')} ${cordova.file.externalDataDirectory}${fileName}`);
+                      this.statusMessage += `<p>${_TRANSLATE('File Stored At')} ${backupLocation}${dbName}</p>`
                     };
                     fileWriter.onerror = (e) => {
                       alert(`${_TRANSLATE('Write Failed')}` + e.toString());
+                      this.errorMessage += `<p>${_TRANSLATE('Write Failed')}` + e.toString() + "</p>"
                     };
                     fileWriter.write(data);
                   });
                 });
+              }, (e) => {
+                console.log("Error: " + e)
+                let errorMessage
+                if (e && e.code && e.code === 1) {
+                  errorMessage = "File or directory not found."
+                } else {
+                  errorMessage = e
+                }
+                this.errorMessage += `<p>${_TRANSLATE('Error exporting file: ')} ${fileName} ${_TRANSLATE(' at backup location: ')} ${backupLocation}  ${_TRANSLATE(' Error: ')} ${errorMessage}</p>`
               });
             }, false);
           } else {
             downloadData(file, fileName, 'application/json');
           }
         } catch (e) {
-          console.log("Error dumping data: " + e)
+          console.log("Error: " + e)
+          this.errorMessage += `<p>${_TRANSLATE('Error: ')} ${JSON.stringify(e)}</p>`
         }
       }
     }
   }
+}
+
+function onErrorGetDir(e) {
+    console.log("Error: " + e)
+    let errorMessage
+    if (e && e.code && e.code === 1) {
+      errorMessage = "File or directory not found."
+    } else {
+      errorMessage = e
+    }
+    this.errorMessage += `<p>${_TRANSLATE('Error creating directory. Error: ')} ${errorMessage}</p>`
 }
 
 function downloadData(content, fileName, type) {

--- a/client/src/app/device/components/restore-backup/restore-backup.component.css
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.css
@@ -19,3 +19,9 @@ mat-card {
   color: red;
   font-size: large;
 }
+
+label {
+  font-weight: bold;
+  display: block;
+  margin-bottom: 10px;
+}

--- a/client/src/app/device/components/restore-backup/restore-backup.component.css
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.css
@@ -25,3 +25,8 @@ label {
   display: block;
   margin-bottom: 10px;
 }
+
+.doneMessage {
+  color:green; 
+  font-size:x-large
+}

--- a/client/src/app/device/components/restore-backup/restore-backup.component.html
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.html
@@ -10,6 +10,14 @@
             <p>Restore Backup copies backup databases to the Tangerine application.</p>
             <p>Press the button below and view the log of the process. Wait for all the files to be copied. When it is complete, it will display
               "Please exit the app and restart."</p>
+            <div *ngIf showDirectoryDialog>
+              <label for="folder">Select folder</label>
+              <input type="file" id="folder" webkitdirectory multiple (change)="fileChangeEvent($event.target.files)"/>
+              <h2>Selected Files</h2>
+              <ul>
+              </ul>
+            </div>
+            
           </mat-card-content>
           <mat-card-actions class="card-actions">
             <button color="primary" mat-raised-button (click)="importBackups()">{{'RESTORE BACKUP'|translate}}</button>

--- a/client/src/app/device/components/restore-backup/restore-backup.component.html
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.html
@@ -10,12 +10,9 @@
             <p>Restore Backup copies backup databases to the Tangerine application.</p>
             <p>Press the button below and view the log of the process. Wait for all the files to be copied. When it is complete, it will display
               "Please exit the app and restart."</p>
-            <div *ngIf showDirectoryDialog>
+            <div *ngIf="showDirectoryDialog">
               <label for="folder">Select folder</label>
               <input type="file" id="folder" webkitdirectory multiple (change)="fileChangeEvent($event.target.files)"/>
-              <h2>Selected Files</h2>
-              <ul>
-              </ul>
             </div>
             
           </mat-card-content>

--- a/client/src/app/device/components/restore-backup/restore-backup.component.html
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.html
@@ -4,21 +4,21 @@
       <div class="container">
         <mat-card>
           <div class="mat-card-header-text">
-            Restore Backup
+            {{'Restore Backup'|translate}}
           </div>
           <mat-card-content class="card-content">
-            <p>This feature copies backup databases to the Tangerine application.</p>
-            <p>Instructions:</p>
+            <p>{{'This feature copies backup databases to the Tangerine application.'|translate}}</p>
+            <p>{{'Instructions:'|translate}}</p>
             <ul>
-              <li>If APK (running on a tablet): Place files in the "Download/restore" directory. Press the button below to start the restore process.</li>
-              <li>If PWA (running on a computer and/or in a web browser): Press the button below and choose the directory where the backup files are stored. This will start the restore process.</li>
-              <li>View the log of the process. Wait for all the files to be copied. When it is complete, it will display
-                "Please exit the app and restart."</li>
-              <li>Close the application completely and re-open.</li>
+              <li>{{'If APK (running on a tablet): Place files in the "Documents/Tangerine/restore" directory. Press the button below to start the restore process.'|translate}}</li>
+              <li>{{'If PWA (running on a computer and/or in a web browser): Press the button below and choose the directory where the backup files are stored. This will start the restore process.'|translate}}</li>
+              <li>{{'View the log of the process. Wait for all the files to be copied. When it is complete, it will display
+                "Please exit the app and restart."'|translate}}</li>
+              <li>{{'Close the application completely and re-open.'|translate}}</li>
             </ul>
             
             <div *ngIf="showDirectoryDialog">
-              <label for="folder">Select folder</label>
+              <label for="folder">{{'Select folder'|translate}}</label>
               <input type="file" id="folder" webkitdirectory multiple (change)="restoreBackups($event.target.files)"/>
             </div>
             
@@ -27,7 +27,6 @@
             <button color="primary" mat-raised-button (click)="importBackups()">{{'RESTORE BACKUP'|translate}}</button>
           </mat-card-actions>
         </mat-card>
-<!--          <div [innerHTML]="statusMessage | safeHtml" class="status"></div>-->
           <div [innerHTML]="statusMessage" class="status"></div>
           <div class="error">{{errorMessage}}</div>
       </div>

--- a/client/src/app/device/components/restore-backup/restore-backup.component.html
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.html
@@ -7,12 +7,19 @@
             Restore Backup
           </div>
           <mat-card-content class="card-content">
-            <p>Restore Backup copies backup databases to the Tangerine application.</p>
-            <p>Press the button below and view the log of the process. Wait for all the files to be copied. When it is complete, it will display
-              "Please exit the app and restart."</p>
+            <p>This feature copies backup databases to the Tangerine application.</p>
+            <p>Instructions:</p>
+            <ul>
+              <li>If APK (running on a tablet): Place files in the "Download/restore" directory. Press the button below to start the restore process.</li>
+              <li>If PWA (running on a computer and/or in a web browser): Press the button below and choose the directory where the backup files are stored. This will start the restore process.</li>
+              <li>View the log of the process. Wait for all the files to be copied. When it is complete, it will display
+                "Please exit the app and restart."</li>
+              <li>Close the application completely and re-open.</li>
+            </ul>
+            
             <div *ngIf="showDirectoryDialog">
               <label for="folder">Select folder</label>
-              <input type="file" id="folder" webkitdirectory multiple (change)="fileChangeEvent($event.target.files)"/>
+              <input type="file" id="folder" webkitdirectory multiple (change)="restoreBackups($event.target.files)"/>
             </div>
             
           </mat-card-content>

--- a/client/src/app/device/components/restore-backup/restore-backup.component.ts
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.ts
@@ -23,12 +23,23 @@ export class RestoreBackupComponent implements OnInit {
   success: boolean
   showDirectoryDialog: boolean
   dbNames = [SHARED_USER_DATABASE_NAME, SHARED_USER_DATABASE_INDEX_NAME, USERS_DATABASE_NAME, LOCKBOX_DATABASE_NAME, VARIABLES_DATABASE_NAME]
-
+  restoreDir: string = 'Documents/Tangerine/restore/'
+  
   ngOnInit(): void {
-    console.log("RestoreBackupComponent init")
+    // console.log("RestoreBackupComponent init")
     this.statusMessage = ''
     this.errorMessage = ''
     this.success = false
+    if (this.window.isCordovaApp) {
+      this.window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory + 'Documents', (directoryEntry) => {
+        directoryEntry.getDirectory('Tangerine', { create: true }, (dirEntry) => {
+          dirEntry.getDirectory('backups', { create: true }, (subDirEntry) => {
+          }, this.onErrorGetDir);
+          dirEntry.getDirectory('restore', { create: true }, (subDirEntry) => {
+          }, this.onErrorGetDir);
+        }, this.onErrorGetDir);
+      })
+    }
   }
 
   async importBackups() {
@@ -44,72 +55,49 @@ export class RestoreBackupComponent implements OnInit {
       for (let index = 0; index < this.dbNames.length; index++) {
         const dbName = this.dbNames[index]
         // copy the database
-        const restoreLocation = cordova.file.externalRootDirectory + 'Download/restore/' + dbName;
+        const restoreLocation = cordova.file.externalRootDirectory + 'Documents/Tangerine/restore/' + dbName;
+        const databasesLocation = cordova.file.applicationStorageDirectory + 'databases/';
         this.window.resolveLocalFileSystemURL(restoreLocation, (fileEntry) => {
-          const databasesLocation = cordova.file.applicationStorageDirectory + 'databases/';
           this.window.resolveLocalFileSystemURL(databasesLocation, (directory) => {
             fileEntry.copyTo(directory, dbName, () => {
               this.success = true
               console.log(`${dbName} copied!`);
               // alert(`${_TRANSLATE('File Stored At')} ${cordova.file.applicationStorageDirectory}/databases/${dbName}`);
-              this.statusMessage += `<p>File stored at ${directory.fullPath}${dbName}</p>`
+              this.statusMessage += `<p>${_TRANSLATE('File restored from ')} ${directory.fullPath}${dbName}}</p>`
               copiedDbs.push(dbName)
               if (copiedDbs.length === len) {
-                this.statusMessage += `<p>Please exit the app and restart.</p>`
+                this.statusMessage += `<p>${_TRANSLATE('Please exit the app and restart.')}</p>`
               }
               },
               function(e) {
                 this.success = false
                 console.log('Unable to copy DB' + dbName);
-                this.errorMessage += '<p>Error with db: ' + dbName + ' Message: ' + JSON.stringify(e) + '</p>'
+                this.errorMessage += `<p>${_TRANSLATE('Error restoring db ')} : ${dbName} to restoreLocation:  ${restoreLocation} Message: ${JSON.stringify(e)}</p>`
               });
           }, (e) => {
             this.success = false
             console.log("Error: " + e)
-            this.errorMessage += '<p>Error with db: ' + dbName + ' at databasesLocation: ' + databasesLocation + ' Message: ' + JSON.stringify(e) + '</p>'
+            this.errorMessage += `<p>${_TRANSLATE('Error restoring db ')} : ${dbName} to restoreLocation:  ${restoreLocation} Message: ${JSON.stringify(e)}</p>`
           });
         }, (e) => {
           this.success = false
           console.log("Error: " + e)
-          this.errorMessage += '<p>Error with db: ' + dbName + ' at restoreLocation: ' + restoreLocation + ' Message: ' + JSON.stringify(e) + '</p>'
+          this.errorMessage += `<p>${_TRANSLATE('Error restoring db ')} : ${dbName} to restoreLocation:  ${restoreLocation} Message: ${JSON.stringify(e)}</p>`
         });
       }
     } else {
       if (this.window.isCordovaApp) {
-        // for (let index = 0; index < this.dbNames.length; index++) {
-        //   let restoreFile, payload
-        //   const dbName = this.dbNames[index]
-        //     restoreFile = cordova.file.externalRootDirectory + 'Download/restore/' + dbName;
-        //     this.window.resolveLocalFileSystemURL(restoreFile, (fileEntry) => {
-        //       // decrypt it!
-        //       payload = fileEntry
-        //     }, (e) => {
-        //       this.success = false
-        //       console.log("Error: " + e)
-        //       this.errorMessage += '<p>Error with db: ' + dbName + ' fetching restoreFile: ' + restoreFile + ' Message: ' + JSON.stringify(e) + '</p>'
-        //     });
-        //
-        //   const stream = new window['Memorystream']
-        //   stream.end(payload);
-        //   // copy the database
-        //   console.log(`Restoring ${dbName} db`)
-        //   const db = DB(dbName)
-        // }
-        const path = cordova.file.externalRootDirectory + 'Download/restore/'
+        const path = cordova.file.externalRootDirectory + 'Documents/Tangerine/restore/'
         window['resolveLocalFileSystemURL'](path, (fileSystem) => {
             const reader = fileSystem.createReader();
             reader.readEntries(
               async (entries) => {
                 console.log(entries);
-                // let fileNames = []
-                // entries.forEach(function(entry) {
-                //   fileNames.push(entry.name)
-                // });
                 try {
                   await this.restoreBackups(entries)
                 } catch (e) {
                   console.log(e);
-                  this.errorMessage += '<p>Error restoring backup. Message: ' + e + '</p>'
+                  this.errorMessage += `<p>${_TRANSLATE('Error restoring backup')} Message: ${JSON.stringify(e)}</p>`
                 }
               },
               function (err) {
@@ -130,40 +118,38 @@ export class RestoreBackupComponent implements OnInit {
     let copiedDbs = []
     const len = this.dbNames.length
     for (var i = 0; i < files.length; i++) {
-      const promisify = function (funcToPromisify) {
-        return new Promise(function (resolve, reject) {
-            funcToPromisify(resolve, reject);
-          }
-        );
-      };
+      const promisify = (f) =>
+        (...a) => new Promise ((res, rej) => f (...a, res, rej))
       let entry = files[i]
       console.log("processing " + entry.name)
+      this.statusMessage += "<p>" + _TRANSLATE("Processing ") + entry.name + "</p>"
       const fileNameArray = entry.name.split('_')
       const dbName = fileNameArray[0]
       // const stream = fileObject.stream();
       if (this.window.isCordovaApp) {
-        const fileObj = await promisify(entry.file.bind(entry))
-        const reader = new FileReader();
-        reader.onloadend = async (event) => {
-          const result = event.target.result;
-          const stream = new window['Memorystream']
-          stream.end(result);
-          console.log(`Loading data into ${dbName}`)
-          const db = DB(dbName)
-          try {
-            await db.load(stream)
-            // await tempDb.replicate.to(db)
-            this.statusMessage += `<p>${dbName} restored</p>`
-            copiedDbs.push(dbName)
-            if (copiedDbs.length === len) {
-              this.statusMessage += `<p>Please exit the app and restart.</p>`
+        await promisify(entry.file(async (file) => {
+          const reader = new FileReader();
+          reader.onloadend = async (event) => {
+            const result = event.target.result;
+            const stream = new window['Memorystream']
+            stream.end(result);
+            // copy the database
+            console.log(`Restoring ${dbName} db`)
+            const db = DB(dbName)
+            try {
+              await db.load(stream)
+              this.statusMessage += `<p>${dbName} ${_TRANSLATE("restored")}</p>`
+              copiedDbs.push(dbName)
+              if (copiedDbs.length === len) {
+                this.statusMessage += `<p>&nbsp;</p>\n<p class="doneMessage">${_TRANSLATE("Restore complete: Please exit the app and restart.")}</p>`
+              }
+            } catch (e) {
+              console.log("Error loading db: " + e)
+              this.errorMessage += '<p>' + _TRANSLATE("Error restoring backup database. Message: ") + JSON.stringify(e) + '</p>'
             }
-          } catch (e) {
-            console.log("Error loading db: " + e)
-            this.errorMessage += '<p>Error restoring backup database. Message: ' + JSON.stringify(e) + '</p>'
           }
-        }
-        reader.readAsText(<Blob>fileObj);
+          await reader.readAsText(file);
+        }))
       } else {
         const reader = new FileReader();
         reader.addEventListener('load', async (event) => {
@@ -175,18 +161,30 @@ export class RestoreBackupComponent implements OnInit {
           const db = DB(dbName)
           try {
             await db.load(stream)
-            this.statusMessage += `<p>${dbName} restored</p>`
+            this.statusMessage += `<p>${dbName} ${_TRANSLATE("restored")}</p>`
             copiedDbs.push(dbName)
             if (copiedDbs.length === len) {
-              this.statusMessage += `<p>Please exit the app and restart.</p>`
+              this.statusMessage += `<p>${_TRANSLATE("Please exit the app and restart.")}</p>`
             }
           } catch (e) {
             console.log("Error loading db: " + e)
-            this.errorMessage += '<p>Error restoring backup database. Message: ' + JSON.stringify(e) + '</p>'
+            this.errorMessage += '<p>' + _TRANSLATE("Error restoring backup database. Message: ") + JSON.stringify(e) + '</p>'
           }
         });
         await reader.readAsText(entry);
       }
     }
   }
+
+  onErrorGetDir(e) {
+    console.log("Error: " + e)
+    let errorMessage
+    if (e && e.code && e.code === 1) {
+      errorMessage = "File or directory not found."
+    } else {
+      errorMessage = e
+    }
+    this.errorMessage += `<p>${_TRANSLATE('Error creating directory. Error: ')} ${errorMessage}</p>`
+  }
+  
 }

--- a/docs/system-administrator/restore-from-encrypted-backup.md
+++ b/docs/system-administrator/restore-from-encrypted-backup.md
@@ -2,7 +2,7 @@
 
 ## Backing up
 
-Ask user to go to Export Data and press "Export Data for all Users". It wiil display an alert after each database backup is saved. The backup files will be saved in the `Android/data/org.rti.tangerine/files` directory. Use [Android File transfer tool](https://www.android.com/filetransfer/) to transfer the files. Save *all* of the database backup files.
+Ask user to go to Export Data and press "Export Data for all Users". It will display an alert after each database backup is saved. The backup files will be saved in the `Android/data/org.rti.tangerine/files` directory. Use [Android File transfer tool](https://www.android.com/filetransfer/) to transfer the files. Save *all* of the database backup files.
 
 ![backup-files-listing](./assets/backup-files-listing.png )
 
@@ -14,7 +14,7 @@ Connect the tablet to the pc with a USB cable. Use Android File transfer or Sams
 
 ![restore-files-listing](./assets/restore-files-listing.png )
 
-Install the Tangerine app on the tablet.  From the language dropdown screen, click a link marked `Restore database`. 
+Install the Tangerine app on the tablet.  DO NOT do the initial device setup (language selection/enter admin password/etc); instead, press the "Restore backup" button to start the restore process. 
 
 ![Restore backup button](./assets/tangy-restore-backup-button_sm.jpg )
 

--- a/server/src/modules/mysql/TangerineToMySQL.py
+++ b/server/src/modules/mysql/TangerineToMySQL.py
@@ -397,9 +397,8 @@ def main_job():
               with open(sys.argv[1], 'w') as configfile:
                   config.write(configfile)
     except Exception as error:
-            # log("Unexpected exception...  Previous change processed successfully: "  + lastSequence)
             log("Unexpected exception while processing changes. Previous change processed successfully: "  + lastSequence)
-            log("Unexpected error: " + error)
+            log("Unexpected error: {}".format(error.message))
             # raise
     # Finish.
     end_time = timeit.default_timer()


### PR DESCRIPTION
when app-level encryption is turned off.

## Description

Enables export of all databases from a device that has been configured to NOT use app-level encryption.

Added new appConfig.json param: dbBackupSplitNumberFiles. Increase the appConfig.json parameter `dbBackupSplitNumberFiles` (default: 50) if your database is large to avoid crashes while backing up and/or restoring.

- Fixes #2778 

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

Uses pouch-replication-stream

