### PR TITLE
fix(csv): show csv dataset download url only when the file zip file exists on disk

### DIFF
--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
@@ -1,6 +1,10 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 <div *ngIf="datasetDetail" class="tangy-full-width">
-    <p><strong>{{'File Name'|translate}}</strong>: <a class="tangy-foreground-secondary" [href]="datasetDetail.downloadUrl">{{datasetDetail.fileName}}</a></p>
+    <p><strong>{{'File Name'|translate}}</strong>: 
+      <span *ngIf="!datasetDetail.complete">{{datasetDetail.fileName}}</span>
+      <a *ngIf="datasetDetail.complete&& datasetDetail.fileExists" 
+          class="tangy-foreground-secondary" [href]="datasetDetail.downloadUrl">{{datasetDetail.fileName}}</a>
+    </p>
     <p><strong>{{'Include PII'|translate}}</strong>: {{datasetDetail.includePii}}</p>
     <p><strong>{{"Status"|translate}}:</strong> {{datasetDetail.complete? 'Complete':'In Progress' |translate}}</p>
     <p><strong>{{'Month'|translate}}:</strong> {{datasetDetail.month?datasetDetail.month: '*'}}</p>
@@ -29,7 +33,7 @@
     <ng-container matColumnDef="outputPath">
       <th mat-header-cell *matHeaderCellDef>{{'Download File'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">
-        <a [disabled]="dataSet.inProgress" mat-icon-button [href]="datasetDetail.baseUrl+ dataSet.outputPath">
+        <a *ngIf="dataSet.complete" mat-icon-button [href]="datasetDetail.baseUrl+ dataSet.outputPath">
           <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
         </a>
       </td>

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -44,7 +44,7 @@
         {{ "Download File" | translate }}
       </th>
       <td mat-cell *matCellDef="let dataSet">
-        <a [disabled]="!dataSet.complete" mat-icon-button [href]="dataSet.downloadUrl">
+        <a *ngIf="dataSet.complete&&dataSet.fileExists" mat-icon-button [href]="dataSet.downloadUrl">
           <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
         </a>
       </td>

--- a/server/src/routes/group-csv.js
+++ b/server/src/routes/group-csv.js
@@ -111,12 +111,15 @@ const listCSVDataSets = async (req, res) => {
     const http = await getUser1HttpInterface()
     const data = result.docs.map(async e => {
       let complete = false;
+      let fileExists = false;
       try {
         complete = (await http.get(e.stateUrl)).data.complete
+        fileExists = await fs.pathExists(`/csv/${e.fileName}`)
       } catch (error) {
         complete = false
+        fileExists = false
       }
-      return ({ ...e, complete, numberOfDocs })
+      return ({ ...e, complete, fileExists, numberOfDocs })
     })
     res.send(await Promise.all(data))
   } catch (error) {


### PR DESCRIPTION

## Description

---
Users should not see a link to download a `zip` file of a csv dataset when the file does not exist on disk

- Fixes #2902 

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

Check for the existence of the file based on the path stored in the DB and show or hide the download option based on the value

## Limitations and Trade-offs

[Optional. What are the limitations of the proposed solution? What are the potential edge cases that one should be aware of? What are some of the tradeoffs? What are some of the approaches considered and not used? Why were they not used? ]

## Security considerations



