### PR TITLE
Add Case API for updating the Participant Case Role and Auto-populating forms

### DIFF
--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -543,7 +543,7 @@ class CaseService {
    * Participant API
    */
 
-  createParticipant(caseRoleId = ''):CaseParticipant {
+  createParticipant(caseRoleId = ''): CaseParticipant {
     const id = UUID()
     const data = {}
     const caseParticipant = <CaseParticipant>{
@@ -552,25 +552,7 @@ class CaseService {
       inactive: false,
       data
     }
-    this.case.participants.push(caseParticipant)
-    for (let caseEvent of this.case.events) {
-      const caseEventDefinition = this
-        .caseDefinition
-        .eventDefinitions
-        .find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
-      for (let eventFormDefinition of caseEventDefinition.eventFormDefinitions) {
-        if (
-          eventFormDefinition.forCaseRole.split(',').map(e=>e.trim()).includes(caseRoleId)
-          && 
-          (
-            eventFormDefinition.autoPopulate || 
-            (eventFormDefinition.autoPopulate === undefined && eventFormDefinition.required === true)
-          )
-        ) {
-          this.createEventForm(caseEvent.id, eventFormDefinition.id, caseParticipant.id)
-        }
-      }
-    }
+    this.addParticipant(caseParticipant)
     return caseParticipant
   }
 
@@ -585,6 +567,18 @@ class CaseService {
 
   addParticipant(caseParticipant:CaseParticipant) {
     this.case.participants.push(caseParticipant)
+    this.updateParticipantEventForms(caseParticipant)
+  }
+
+  setParticipantCaseRole(participantId: string, caseRoleId: string) {
+    let caseParticipant = this.case.participants.find(participant => participant.id === participantId)
+    if (caseParticipant) {
+      caseParticipant.caseRoleId = caseRoleId
+      this.updateParticipantEventForms(caseParticipant)
+    }
+  }
+
+  updateParticipantEventForms(caseParticipant: CaseParticipant) {
     for (let caseEvent of this.case.events) {
       const caseEventDefinition = this
         .caseDefinition
@@ -592,10 +586,10 @@ class CaseService {
         .find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
       for (let eventFormDefinition of caseEventDefinition.eventFormDefinitions) {
         if (
-          eventFormDefinition.forCaseRole.split(',').map(e=>e.trim()).includes(caseParticipant.caseRoleId)
-          && 
+          eventFormDefinition.forCaseRole.split(',').map(e => e.trim()).includes(caseParticipant.caseRoleId)
+          &&
           (
-            eventFormDefinition.autoPopulate || 
+            eventFormDefinition.autoPopulate ||
             (eventFormDefinition.autoPopulate === undefined && eventFormDefinition.required === true)
           )
         ) {

--- a/server/src/modules/mysql/TangerineToMySQL.py
+++ b/server/src/modules/mysql/TangerineToMySQL.py
@@ -126,10 +126,10 @@ def convert_participant(resp_dict):
         #     3) Then the database doesn't exist! Just insert it.
         try:
             #delete the Participant if it already exists in table so we can add the new one
-            qry = "SELECT * FROM " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId+"'"
+            qry = "SELECT * FROM " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId + "' AND CaseID='" + caseId + "'"
             cursor.execute(qry)
             if cursor.rowcount >= 1:
-                cursor.execute("Delete from " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId+"'")
+                cursor.execute("Delete from " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId + "' AND CaseID='" + caseId + "'")
                 mysql_connection.commit()
             # this will fail if there is a new column
             mysql_connection.commit()

--- a/server/src/modules/mysql/TangerineToMySQL.py
+++ b/server/src/modules/mysql/TangerineToMySQL.py
@@ -126,10 +126,11 @@ def convert_participant(resp_dict):
         #     3) Then the database doesn't exist! Just insert it.
         try:
             #delete the Participant if it already exists in table so we can add the new one
-            qry = "SELECT * FROM " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId+"'"
+            qry_pred = "{}.participant WHERE ParticipantID='{}' AND CaseID='{}'".format(mysqlDatabaseName, participantId, caseId)
+            qry = "SELECT * FROM {}".format(qry_pred)
             cursor.execute(qry)
             if cursor.rowcount >= 1:
-                cursor.execute("Delete from " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId+"'")
+                cursor.execute("Delete from {}".format(qry_pred))
                 mysql_connection.commit()
             # this will fail if there is a new column
             mysql_connection.commit()

--- a/server/src/modules/mysql/TangerineToMySQL.py
+++ b/server/src/modules/mysql/TangerineToMySQL.py
@@ -126,11 +126,10 @@ def convert_participant(resp_dict):
         #     3) Then the database doesn't exist! Just insert it.
         try:
             #delete the Participant if it already exists in table so we can add the new one
-            qry_pred = "{}.participant WHERE ParticipantID='{}' AND CaseID='{}'".format(mysqlDatabaseName, participantId, caseId)
-            qry = "SELECT * FROM {}".format(qry_pred)
+            qry = "SELECT * FROM " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId+"'"
             cursor.execute(qry)
             if cursor.rowcount >= 1:
-                cursor.execute("Delete from {}".format(qry_pred))
+                cursor.execute("Delete from " + mysqlDatabaseName + ".participant where ParticipantID='" + participantId+"'")
                 mysql_connection.commit()
             # this will fail if there is a new column
             mysql_connection.commit()

--- a/server/src/modules/mysql/index.js
+++ b/server/src/modules/mysql/index.js
@@ -8,6 +8,7 @@ const exec = util.promisify(require('child_process').exec)
 const { spawn } = require('child_process');
 const fsCore = require('fs');
 const readFile = util.promisify(fsCore.readFile);
+import { v4 as UUID } from 'uuid';
 
 /* Enable this if you want to run commands manually when debugging.
 const exec = async function(cmd) {
@@ -64,14 +65,14 @@ module.exports = {
           if (doc.type === 'case') {
             // output case
             await saveFlatResponse(doc, locationList, targetDb, sanitized);
-            let numInf = getItemValue(doc, 'numinf')
+            let numInf = getItemValue(doc, 'numinf') // Why is this here --- this is very site specific to ARC, no?
             let participant_id = getItemValue(doc, 'participant_id')
 
             // output participants
             for (const participant of doc.participants) {
               await pushResponse({
                 ...participant,
-                _id: participant.id,
+                _id: UUID(),
                 caseId: doc._id,
                 numInf: participant.participant_id === participant_id ? numInf : '',
                 type: "participant"

--- a/server/src/modules/mysql/index.js
+++ b/server/src/modules/mysql/index.js
@@ -8,7 +8,7 @@ const exec = util.promisify(require('child_process').exec)
 const { spawn } = require('child_process');
 const fsCore = require('fs');
 const readFile = util.promisify(fsCore.readFile);
-import { v4 as UUID } from 'uuid';
+const { v4: uuidv4 } = require('uuid');
 
 /* Enable this if you want to run commands manually when debugging.
 const exec = async function(cmd) {
@@ -72,7 +72,7 @@ module.exports = {
             for (const participant of doc.participants) {
               await pushResponse({
                 ...participant,
-                _id: UUID(),
+                _id: uuidv4(),
                 caseId: doc._id,
                 numInf: participant.participant_id === participant_id ? numInf : '',
                 type: "participant"


### PR DESCRIPTION
**Use Case**

Studies following participants over time may chose to change the Case Role, for example when a participants turns a certain age.  The case role can be updated programmatically, but the event forms assigned to that role are not currently auto-populated.

This adds two new APIs, one for setting the participant case role `setParticipantCaseRole` and another for updating the event forms `updateParticipantEventForms`. 

The `setParticipantCaseRole` function changes the case role and then runs `updateParticipantEventForms` to populate any forms marked as such for the role.  It does not currently deal with removing any forms that were only meant for the previous role.

The `updateParticipantEventForms` is a convenience function that consolidates the code run in two other functions in the Participant API.