### PR TITLE
Restrict access to events by permissions when query by date

### DIFF
--- a/client/src/app/case/services/cases.service.ts
+++ b/client/src/app/case/services/cases.service.ts
@@ -2,6 +2,7 @@ import { UserService } from './../../shared/_services/user.service';
 import { Injectable } from '@angular/core';
 import { CaseService } from './case.service';
 import { CaseEvent } from '../classes/case-event.class';
+import { CaseEventOperation } from '../classes/case-event-definition.class';
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +21,10 @@ export class CasesService {
     for (let row of queryResults.rows) {
       await this.caseService.load(row.value.caseId)
       let caseEvent = this.caseService.case.events.find(event => event.id === row.value.eventId)
-      caseEvents.push(caseEvent)
+      const eventDefinition = this.caseService.caseDefinition.eventDefinitions.find(ed => ed.id === caseEvent.caseEventDefinitionId)
+      if (this.caseService.hasCaseEventPermission(CaseEventOperation.READ, eventDefinition)) {
+        caseEvents.push(caseEvent)
+      }
     }
     return caseEvents
   }


### PR DESCRIPTION
## Description

When permissions were implemented, they were only enforced inside of a Case. This PR now also applies those permissions when query for events in date ranges, as it is used on the calendar view.

- Fixes #2931

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
Use permission API in the API for getting events by date range.

## Limitations and Trade-offs
We could consider implementing permissions at a lower layer. It could happen in CaseService.load() so that events users don't have permissions for, they don't even appear in the events array. How to enforce that from database queries would be trickier so it may just be best to use the permissions API when accessing this data after the fact.
