### PR TITLE
Fix radio button scoring in Teach by only adding the final value of max to the totalMax variable

### DIFF
--- a/client/src/app/class/_services/dashboard.service.ts
+++ b/client/src/app/class/_services/dashboard.service.ts
@@ -217,8 +217,8 @@ export class DashboardService {
               if (optionValue > max) {
                 max = optionValue;
               }
-              totalMax =  totalMax + max;
             });
+            totalMax =  totalMax + max;
           } else  if (input.tagName === 'TANGY-CHECKBOX') {
             if (input.value !== '') {
               value = 1;


### PR DESCRIPTION
…

## Description
When calculating score for radio buttons, the sum of all options has been calculated as the denominator, aka max score. In the following, the option with a value of 4 was selected, 4 was the highest option, yet a score of 4 out of 10 is shown.

<img width="1386" alt="Screen Shot 2021-10-06 at 1 57 02 PM" src="https://user-images.githubusercontent.com/156575/136261253-02b6b77a-e5dc-4793-9d47-4c8e348b81b8.png">

This PR adjusts how max score is calculated to avoid summing up all options, instead just using the largest option as the denominator. 

![image](https://user-images.githubusercontent.com/156575/136261755-e8cc16e5-1ba8-4e0f-a5b3-849e7939e7e6.png)

- Fixes #2947

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)
