### PR TITLE
Ensure only one Curriculum Doc per Student per Class

### DIFF
--- a/client/src/app/class/_services/dashboard.service.ts
+++ b/client/src/app/class/_services/dashboard.service.ts
@@ -80,6 +80,17 @@ export class DashboardService {
     return cleanData;
   }
 
+  async getCurriculumResponse(classId, curriculumId, studentId) {
+    this.db = await this.getUserDB();
+    const curriculumResponsesForClass = (await this.db.query('tangy-class/responsesByClassIdCurriculumId', {
+        key: [classId, curriculumId],
+        include_docs: true
+      }))
+      .rows
+      .map(row => row.doc)
+    return curriculumResponsesForClass.find(response => response.metadata.studentRegistrationDoc.id === studentId)
+  }
+
   clean = function(obj, deleteValue) {
     for (let i = 0; i < obj.length; i++) {
       if (obj[i] == deleteValue) {

--- a/client/src/app/class/dashboard/dashboard.component.ts
+++ b/client/src/app/class/dashboard/dashboard.component.ts
@@ -326,7 +326,7 @@ export class DashboardComponent implements OnInit {
   }
 
   /** Populate the querystring with the form info. */
-  selectCheckbox(column, itemId) {
+  async selectCheckbox(column, itemId) {
     // let el = this.selection.select(row);
     // this.selection.toggle(column)
     const formsArray = Object.values(column.forms);
@@ -338,8 +338,9 @@ export class DashboardComponent implements OnInit {
     const src = selectedForm['src'];
     const title = selectedForm['title'];
     let responseId = null;
-    if (selectedForm['response']) {
-      responseId = selectedForm['response']['_id'];
+    const curriculumResponse = await this.dashboardService.getCurriculumResponse(classId, curriculum, studentId)
+    if (curriculumResponse) {
+      responseId = curriculumResponse._id
     }
     this.router.navigate(['class-form'], { queryParams:
         { formId: selectedFormId,


### PR DESCRIPTION
For some reason in some content sets using Teach, when selecting a subtask for a student in a curriculum, if there is already a curriculum doc for that student a new curriculum doc will be created. We only need one curriculum doc per student per class. This PR ensures we check in the database for that existing curriculum doc for the studen/class combo.