### PR TITLE
Add configuration in app-config.json and settings page to use PouchDB last sequence tracking support when syncing

### DIFF
--- a/client/src/app/core/settings/settings/settings.component.ts
+++ b/client/src/app/core/settings/settings/settings.component.ts
@@ -16,6 +16,7 @@ export class SettingsComponent implements AfterContentInit {
   translations:any
   window:any
   languageCode = 'en'
+  usePouchDbLastSequenceTracking = false
   selected = ''
   constructor(
     private http: HttpClient,
@@ -23,11 +24,9 @@ export class SettingsComponent implements AfterContentInit {
     private languagesService:LanguagesService,
   ) { }
 
-  async ngOnInit() {
-    this.languageCode = await this.variableService.get('languageCode')
-  }
-
   async ngAfterContentInit() {
+    this.languageCode = await this.variableService.get('languageCode')
+    this.usePouchDbLastSequenceTracking = await this.variableService.get('usePouchDbLastSequenceTracking')
     this.selected = this.languageCode;
     const translations = <Array<any>>await this.http.get('./assets/translations.json').toPromise();
     this.container.nativeElement.innerHTML = `
@@ -39,6 +38,13 @@ export class SettingsComponent implements AfterContentInit {
               <option value="${language.languageCode}">${t(language.label)}</option>
             `).join('')}
           </tangy-select>
+          <tangy-checkbox
+            value="${this.usePouchDbLastSequenceTracking ? 'on' : ''}"
+            name="usePouchDbLastSequenceTracking"
+            label="${t(`Use PouchDB's last sequence tracking when syncing.`)}"
+          >
+          </tangy-checkbox>
+
           <p>
             ${t('After submitting updated settings, you will be required to log in again.')}
           </p>
@@ -50,6 +56,10 @@ export class SettingsComponent implements AfterContentInit {
       const response = new TangyFormResponseModel(event.target.response)
       const selectedLanguageCode = response.inputsByName.language.value
       await this.languagesService.setLanguage(selectedLanguageCode, true)
+      const usePouchDbLastSequenceTracking = response.inputsByName.usePouchDbLastSequenceTracking.value
+        ? true
+        : false
+      await this.variableService.set('usePouchDbLastSequenceTracking', usePouchDbLastSequenceTracking)
       alert(t('Settings have been updated. You will now be redirected to log in.'))
       window.location.href = window.location.href.replace(window.location.hash, 'index.html')
     })

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -52,6 +52,7 @@ export class AppConfig {
   // List of views to skip optimization of after a sync.
   doNotOptimize: Array<string>
   dbBackupSplitNumberFiles: number;
+  usePouchDbLastSequenceTracking:boolean
 }
 
 export enum EncryptionPlugin {

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -30,6 +30,7 @@ export class SyncCouchdbDetails {
   groupId:string
   deviceId:string
   deviceToken:string
+  usePouchDbLastSequenceTracking:boolean
   formInfos:Array<FormInfo> = []
   locationQueries:Array<LocationQuery> = []
   deviceSyncLocations:Array<LocationConfig>
@@ -124,6 +125,9 @@ export class SyncCouchdbService {
       ? this.initialBatchSize
       : this.batchSize
     let replicationStatus:ReplicationStatus
+    syncDetails.usePouchDbLastSequenceTracking = appConfig.usePouchDbLastSequenceTracking || await this.variableService.get('usePouchDbLastSequenceTracking')
+      ? true
+      : false
     // Create sync session and instantiate remote database connection.
     let syncSessionUrl
     let remoteDb
@@ -353,7 +357,7 @@ export class SyncCouchdbService {
     let failureDetected = false
     let pushed = 0
     let syncOptions = {
-      "since":push_last_seq,
+      ...syncDetails.usePouchDbLastSequenceTracking ? { } : { "since": push_last_seq },
       "batch_size": this.batchSize,
       "batches_limit": 1,
       "changes_batch_size": appConfig.changes_batch_size ? appConfig.changes_batch_size : null,
@@ -514,7 +518,7 @@ export class SyncCouchdbService {
      * are kept in memory at a time, so the maximum docs in memory at once would equal batch_size × batches_limit."
      */
     let syncOptions = {
-      "since": pull_last_seq,
+      ...syncDetails.usePouchDbLastSequenceTracking ? { } : { "since": pull_last_seq },
       "batch_size": batchSize,
       "write_batch_size": this.writeBatchSize,
       "batches_limit": 1,


### PR DESCRIPTION
If usePouchDbLastSequenceTracking is set to true in either the app-config.json or manually on the settings page of a Device, when preparing sync options the code will skip the part where it defines a "since" parameter thus falling back to the PouchDB tracked last sequences. Setting it in app-config.json will result in all devices upgrading to use this setting, meanwhile the setting on the Device may allow for trying on some devices but not all. If you are on a Device and turn this setting on, your next sync will not sync from sequence 0 because I'm pretty sure PouchDB has been tracking all along.

<img width="332" alt="Screen Shot 2021-10-27 at 12 35 11 PM" src="https://user-images.githubusercontent.com/156575/139109022-48d57d6e-aafb-4804-851b-f557fb474ead.png">
