### PR TITLE
replacing uses of window['turnOffAppLevelEncryption']

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ __New Features__
 - Statistical files are now available in Stata .do format for corresponding forms [#2971](https://github.com/Tangerine-Community/Tangerine/pull/2971)
 - The new `usePouchDbLastSequenceTracking` property in app-config.json and settings page enables the use of PouchDB's native last sequence tracking support when syncing. [#2999](https://github.com/Tangerine-Community/Tangerine/pull/2999)
 - The new `encryptionPlugin:'CryptoPouch'` property in app-config.json enables testing of the CryptoPouch extension currently in development. [#2998](https://github.com/Tangerine-Community/Tangerine/pull/2998) Please note that this feature is not yet ready for deployment.
+- We have changed how we determine which storage engine is being used. In the past we exposed a window['turnOffAppLevelEncryption']
+  global variable based on the same flag in app-config.json; however, now we are determining in app-init.ts which engine is running and exposing either `window['cryptoPouchRunning']` or `window['sqlCipherRunning']` to indicate which engine is running.
 
 __Backports/Good to Know__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ __New Features__
 - The login screen may now have custom markup. [#2979](https://github.com/Tangerine-Community/Tangerine/pull/2979)
 - Statistical files are now available in Stata .do format for corresponding forms [#2971](https://github.com/Tangerine-Community/Tangerine/pull/2971)
 - The new `usePouchDbLastSequenceTracking` property in app-config.json and settings page enables the use of PouchDB's native last sequence tracking support when syncing. [#2999](https://github.com/Tangerine-Community/Tangerine/pull/2999)
-- The new `encryptionPlugin:'CryptoPouch'` property in app-config.json enables testing of the CryptoPouch extension currently in development. [#2998](https://github.com/Tangerine-Community/Tangerine/pull/2998) Please note that this feature is not yet ready for deployment.
+- The new `encryptionPlugin:'CryptoPouch'` property in app-config.json enables testing of the CryptoPouch extension currently in development. [#2998](https://github.com/Tangerine-Community/Tangerine/pull/2998) Please note that this feature is not yet ready for deployment. There are now three different possible storage configurations for Tangerine:
+  1. "encryptionPlugin":"CryptoPouch" - Configures the app to use CryptoPouch, which encrypts documents in the app's indexedb for storage.
+  2. "turnOffAppLevelEncryption": true - Configures the app without encryption, using the app's indexedb for storage instead of sqlite/sqlCypher.
+  3. "encryptionPlugin":"SqlCipher" - or without any additional configuration (SqlCipher is the default configuration.) - Configures the app to use SqlCipher, which encrypts documents in an external sqlLite database for storage.
 - We have changed how we determine which storage engine is being used. In the past we exposed a window['turnOffAppLevelEncryption']
-  global variable based on the same flag in app-config.json; however, now we are determining in app-init.ts which engine is running and exposing either `window['cryptoPouchRunning']` or `window['sqlCipherRunning']` to indicate which engine is running.
+  global variable based on the same flag in app-config.json; however, now we are determining in app-init.ts which engine is running and exposing either `window['cryptoPouchRunning']` or `window['sqlCipherRunning']` to indicate which engine is running. It is important to note that even the app is configured with `encryptionPlugin:'CryptoPouch'` in app-config.json, the app may have been installed without that setting and is actually running sqlCypher. This is why it is important to observe if either `window['cryptoPouchRunning']` or `window['sqlCipherRunning']` is set. 
 
 __Backports/Good to Know__
 

--- a/client/src/app/core/export-data/export-data/export-data.component.ts
+++ b/client/src/app/core/export-data/export-data/export-data.component.ts
@@ -115,7 +115,7 @@ export class ExportDataComponent implements OnInit {
       }
       this.hideExportButton = false
     } else {
-      // APK's or PWA's that do not use in-app encryption - they are not window['sqlCipherRunning']
+      // APK's or PWA's that do not use sqlCypher - they are not window['sqlCipherRunning']
       if (this.window.isCordovaApp) {
         if (this.splitFiles.nativeElement.value && this.splitFiles.nativeElement.value.length > 0) {
           this.SPLIT = Number(this.splitFiles.nativeElement.value)

--- a/client/src/app/core/export-data/export-data/export-data.component.ts
+++ b/client/src/app/core/export-data/export-data/export-data.component.ts
@@ -71,7 +71,7 @@ export class ExportDataComponent implements OnInit {
       })
     }
 
-    if (this.window.isCordovaApp && window['turnOffAppLevelEncryption']) {
+    if (this.window.isCordovaApp && !window['sqlCipherRunning']) {
       this.shouldShow = true
     } else {
       this.shouldShow = false
@@ -79,7 +79,7 @@ export class ExportDataComponent implements OnInit {
   }
 
   async ngAfterViewInit() {
-    if (this.window.isCordovaApp && window['turnOffAppLevelEncryption']) {
+    if (this.window.isCordovaApp && !window['sqlCipherRunning']) {
       await this.calculateSplit()
       // this.splitFiles.nativeElement.value = String(this.SPLIT)
       this.splitFilesValue = String(this.SPLIT)
@@ -93,8 +93,8 @@ export class ExportDataComponent implements OnInit {
     this.hideExportButton = true
     this.hideLogs = false
     const dbNames = [SHARED_USER_DATABASE_NAME, USERS_DATABASE_NAME, LOCKBOX_DATABASE_NAME, VARIABLES_DATABASE_NAME]
-    // APK's that use in-app encryption
-    if (window['isCordovaApp'] && this.appConfig.syncProtocol === '2' && !window['turnOffAppLevelEncryption']) {
+    // APK's that use in-app encryption via sqlCipher
+    if (window['isCordovaApp'] && this.appConfig.syncProtocol === '2' && window['sqlCipherRunning']) {
       const backupLocation = cordova.file.externalRootDirectory + this.backupDir;
       for (const dbName of dbNames) {
         // copy the database
@@ -115,7 +115,7 @@ export class ExportDataComponent implements OnInit {
       }
       this.hideExportButton = false
     } else {
-      // APK's or PWA's that do not use in-app encryption - have turnOffAppLevelEncryption:true in app-config.json
+      // APK's or PWA's that do not use in-app encryption - they are not window['sqlCipherRunning']
       if (this.window.isCordovaApp) {
         if (this.splitFiles.nativeElement.value && this.splitFiles.nativeElement.value.length > 0) {
           this.SPLIT = Number(this.splitFiles.nativeElement.value)

--- a/client/src/app/device/components/restore-backup/restore-backup.component.ts
+++ b/client/src/app/device/components/restore-backup/restore-backup.component.ts
@@ -85,7 +85,7 @@ export class RestoreBackupComponent implements OnInit {
     }
     
     const appConfig = await this.appConfigService.getAppConfig()
-    if (window['isCordovaApp'] && appConfig.syncProtocol === '2' && !window['turnOffAppLevelEncryption']) {
+    if (window['isCordovaApp'] && appConfig.syncProtocol === '2' && window['sqlCipherRunning']) {
       const len = this.dbNames.length
       let copiedDbs = []
       for (let index = 0; index < this.dbNames.length; index++) {

--- a/client/src/app/device/services/device.service.ts
+++ b/client/src/app/device/services/device.service.ts
@@ -56,7 +56,7 @@ export class DeviceService {
     const device = await this.getDevice()
     const locationList = await this.appConfigService.getLocationList();
     const flatLocationList = Loc.flatten(locationList)
-    const encryptionLevel = (window['isCordovaApp'] && window['sqliteStorageFile'] && !window['turnOffAppLevelEncryption'])
+    const encryptionLevel = (window['isCordovaApp'] && window['sqlCipherRunning'])
       ? _TRANSLATE('in-app')
       : 'OS'
     let assignedLocation


### PR DESCRIPTION
## Description

Replaces uses of window['turnOffAppLevelEncryption']

- Fixes #3019

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

Get the status of which storage engine is in-use by using window['sqlCipherRunning']) .