### PR TITLE
if submit event is cancelled, stop process monitor when throttledSave…

### DIFF
--- a/docs/system-administrator/restore-from-backup.md
+++ b/docs/system-administrator/restore-from-backup.md
@@ -49,7 +49,7 @@ The restore feature logs the process for each database. After the databases have
 
 ![Restore backup prompt](./assets/restore-optimizing.jpg )
 
-When restoring an encrypted database, indexing is *not* run due to the state of the application at this point of the installtion. In this case, prepare to wait a few minutes or longer after restarting the app and logging in to allow it to index the home page. Once the home page is displayed, do a Sync to upload/download any updated files; this will also kick off indexing.
+When restoring an encrypted database, indexing is *not* run due to the state of the application at this point of the installation. In this case, prepare to wait a few minutes or longer after restarting the app and logging in to allow it to index the home page. Once the home page is displayed, do a Sync to upload/download any updated files; this will also kick off indexing.
 
 ![backup-files-listing](./assets/restore-encrypted.jpg )
 

--- a/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -143,6 +143,12 @@ export class TangyFormsPlayerComponent {
       formEl.addEventListener('before-submit', async (event) => {
         if (this.preventSubmit) event.preventDefault()
         this.process = this.processMonitorService.start('saving-a-tangy-form', 'Updating a form response.')
+        if (this.preventSubmit) {
+          while (this.throttledSaveFiring === true) {
+            await sleep(1000)
+          }
+          this.processMonitorService.stop(this.process.id)
+        }
         this.$submit.next(true)
       })
       formEl.addEventListener('submit', async (event) => {

--- a/server/src/modules/disable-module.js
+++ b/server/src/modules/disable-module.js
@@ -1,8 +1,14 @@
-const tangyModules = require('./index.js')()
-
 module.exports = async function disableModule(moduleName) {
-  const module = require(`/tangerine/server/src/modules/${moduleName}/index.js`)
-  if (module.disable) {
+  let module
+  try {
+    module = require(`/tangerine/server/src/modules/${moduleName}/index.js`)
+  } catch (e) {
+    console.log(`require failed for ${moduleName}`)
+    return {
+      message: `${moduleName} is disabled but note that ${moduleName} module does not exit on the file system so this command did nothing.`
+    }
+  }
+  if (module && module.disable) {
     await module.disable()
     return {
       message: `${moduleName} disabled.`

--- a/server/src/shared/services/group-responses/group-responses.service.ts
+++ b/server/src/shared/services/group-responses/group-responses.service.ts
@@ -118,7 +118,15 @@ export class GroupResponsesService {
 
   async read(groupId, responseId) {
     const groupDb = this.getGroupsDb(groupId)
-    const response = <Group>await groupDb.get(responseId)
+    let response
+    try {
+      response = <Group>await groupDb.get(responseId)
+    } catch (e) {
+      // Eat the error if it is a 404 - this is probably happening while viewing a form.
+      if (e.status !== 404) {
+        log.error(e)
+      }
+    }
     return response
   }
 


### PR DESCRIPTION
…Firing

is true
Fix application stop when module is missing
Catch server error when it is a legitimate 404 error - avoids a 500 error in js console.

## Description

Sometimes the listing of processes in the ProcessMonitor prompt does not go away after submitting a form.

- Fixes #3050

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

if submit event is cancelled, stop process monitor when throttledSaveFired is true. 

We can use this same pattern of waiting (whiling?) for throttledSaveFired to become true in other situations where the process monitor list needs to be cleared.

