### PR TITLE
#3056 Fix database defaults when instantiating databases to ensure old revisions are pruned

### DIFF
--- a/client/src/app/shared/_factories/db.factory.ts
+++ b/client/src/app/shared/_factories/db.factory.ts
@@ -17,7 +17,7 @@ PouchDB.plugin({
   loadIt: PouchDBLoad.load
 });
 PouchDB.adapter('writableStream', window['PouchReplicationStream'].adapters.writableStream);
-const defaults = {auto_compaction: true, revs_limit: 1}
+const defaults = {revs_limit: 1}
 PouchDB.plugin(CryptoPouch)
 
 export function connectToSqlCipherDb(name, key = ''):PouchDB {

--- a/client/src/app/shared/_factories/db.factory.ts
+++ b/client/src/app/shared/_factories/db.factory.ts
@@ -17,7 +17,7 @@ PouchDB.plugin({
   loadIt: PouchDBLoad.load
 });
 PouchDB.adapter('writableStream', window['PouchReplicationStream'].adapters.writableStream);
-PouchDB.defaults({auto_compaction: true, revs_limit: 1});
+const defaults = {auto_compaction: true, revs_limit: 1}
 PouchDB.plugin(CryptoPouch)
 
 export function connectToSqlCipherDb(name, key = ''):PouchDB {
@@ -33,7 +33,7 @@ export function connectToSqlCipherDb(name, key = ''):PouchDB {
     pouchDBOptions.changes_batch_size = window['changes_batch_size']
   }
   try {
-    const pouch = new PouchDB(name, pouchDBOptions);
+    const pouch = new PouchDB(name, {...defaults, ...pouchDBOptions});
     return pouch
   } catch (e) {
     console.log("Database error: " + e);
@@ -57,7 +57,7 @@ export function connectToCryptoPouchDb(name, key = ''):PouchDB {
     pouchDBOptions.changes_batch_size = window['changes_batch_size']
   }
   try {
-    const pouch = new PouchDB(name, pouchDBOptions);
+    const pouch = new PouchDB(name, {...defaults, ...pouchDBOptions});
     if (key) {
       pouch.crypto(key)
       pouch.cryptoPouchIsEnabled = true
@@ -75,7 +75,7 @@ export function connectToPouchDb(name):PouchDB {
     pouchDBOptions.changes_batch_size = window['changes_batch_size']
   }
   try {
-    const pouch = new PouchDB(name, pouchDBOptions);
+    const pouch = new PouchDB(name, {...defaults, ...pouchDBOptions});
     return pouch
   } catch (e) {
     console.log("Database error: " + e);


### PR DESCRIPTION

## Description

- Fixes #3056

## Type of Change


- Bug fix

## Proposed Solution
Fix how we set the database defaults. At some point how we set them must have stopped working with an upgrade of PouchDB.

## Limitations and Trade-offs
We would have force a compaction on upgrade which might take some time.

## Tests
Create a case, then add an event, then run the following code in the console. Ensure that old revs are not listed as available in `_revs_info`. 

```javascript
const db = await T.user.getUserDatabase()
await db.db.get(T.case.id, {revs_info:true})
```

## TODOS/enhancements

* [ ] Add an upgrade script.