### PR TITLE
When cancelling process dialog, clear processes so if they are stuck they don't reappear on next process start

### DIFF
--- a/editor/src/app/shared/_components/process-monitor-dialog/process-monitor-dialog.component.ts
+++ b/editor/src/app/shared/_components/process-monitor-dialog/process-monitor-dialog.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ProcessMonitorService } from '../../_services/process-monitor.service';
 import { _TRANSLATE } from '../../_services/translation-marker';
 
 interface DialogData {
@@ -13,13 +14,16 @@ interface DialogData {
 export class ProcessMonitorDialogComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DialogData,
+    public processMonitorService: ProcessMonitorService,
     public dialog: MatDialog
   ) {}
 
   cancel() {
     const confirmation = confirm(_TRANSLATE('Warning: Interrupting a process may lead to data corruption and data loss. Are you sure you want to continue?'))
     if (confirmation) {
-      this.dialog.closeAll()
+      this.processMonitorService
+        .processes
+        .forEach(process => this.processMonitorService.stop(process.id))
     }
   }
 


### PR DESCRIPTION
If the app crashes before a process is stopped, a user will likely click cancel. Then when the dialog pops up again, that same process (along with whatever process just caused it to pop back up) will still be listed as a running process and the dialog won't close thus leading to the user having to click cancel again. This is really annoying and unnecessary. This PR refactors how cancelling a process works not to just be visual, but actually stopping processes so the next time the dialog opens, it doesn't get stuck again with the old process that may have crashed.
