### PR TITLE
Fixed resolution of promise in pruneFilesInPath

### DIFF
--- a/client/src/app/core/maintenance/maintenance/maintenance.component.css
+++ b/client/src/app/core/maintenance/maintenance/maintenance.component.css
@@ -43,6 +43,11 @@
   font-size: larger;
   font-weight: bold;
 }
+.complete {
+  color: green;
+  font-size: larger;
+  font-weight: bold;
+}
 .maintenance-card {
   max-width: 400px;
 }

--- a/client/src/app/core/maintenance/maintenance/maintenance.component.html
+++ b/client/src/app/core/maintenance/maintenance/maintenance.component.html
@@ -16,6 +16,9 @@
     <mat-card-title>{{'Cleanup Files'|translate}}</mat-card-title>
     <mat-card-content>
       <p>{{'This will delete any backups on this tablet that are in the "backup" or "restore" directories. Be sure you have transferred them before doing this procedure.'|translate}}</p>
+      <div *ngIf="displayPruningComplete" class="complete">
+        <p>{{'Disk Cleanup complete.'|translate}}</p>
+      </div>
     </mat-card-content>
     <mat-divider inset></mat-divider>
     <mat-card-actions>

--- a/client/src/app/shared/_components/process-monitor-dialog/process-monitor-dialog.component.ts
+++ b/client/src/app/shared/_components/process-monitor-dialog/process-monitor-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { _TRANSLATE } from '../../translation-marker';
+import {ProcessMonitorService} from "../../_services/process-monitor.service";
 
 interface DialogData {
   messages: Array<string>
@@ -13,13 +14,16 @@ interface DialogData {
 export class ProcessMonitorDialogComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DialogData,
+    public processMonitorService: ProcessMonitorService,
     public dialog: MatDialog
   ) {}
 
   cancel() {
     const confirmation = confirm(_TRANSLATE('Warning: Interrupting a process may lead to data corruption and data loss. Are you sure you want to continue?'))
     if (confirmation) {
-      this.dialog.closeAll()
+      this.processMonitorService
+        .processes
+        .forEach(process => this.processMonitorService.stop(process.id))
     }
   }
 


### PR DESCRIPTION
copy changes to process-monitor to client

## Description

If backup has never run, the Clean backups command in Maintenance on client fails, and the process alert does not go away. 

- Fixes #3097 

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)


## Proposed Solution

This fix also should improve behaviur of the process manager on client; it has a copy of a fix done previously in editor.