### PR TITLE
3063 no click on unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ __Fixes__
 - Fix issue when backup has never run, the Clean backups command in Maintenance on client fails, and the process alert 
   does not go away. This PR also copies over a fix for clearing all progress messages from Editor. PR: [#3098](https://github.com/Tangerine-Community/Tangerine/pull/3098)
 - Fix bad url for Print Content feature in Editor/Author. PR: [#3099](https://github.com/Tangerine-Community/Tangerine/pull/3099)
+- Clicking on unavailable form in Case should not open it Issue: [#3063](https://github.com/Tangerine-Community/Tangerine/issues/3063)
 
 __Upgrade notice__
 

--- a/client/src/app/case/components/event-form-list-item/event-form-list-item.component.css
+++ b/client/src/app/case/components/event-form-list-item/event-form-list-item.component.css
@@ -2,6 +2,7 @@
     border-left: red solid 4px;
 }
 .disabled {
+  pointer-events: none;
 	opacity: .5;
 }
 


### PR DESCRIPTION
## Description

---

Make form click events disabled when they do not have formResponses - like when the couchdbSyncSettings have "pull": false and have not sync'd to a client tablet.

- Fixes #3063 

## Type of Change


- Bug fix (non-breaking change which fixes an issue)


## Proposed Solution

Fixed via CSS 