### PR TITLE
Restart couchdb container on failure

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -141,6 +141,7 @@ fi
 [ "$(docker ps -a | grep $T_COUCHDB_CONTAINER_NAME)" ] && docker rm $T_COUCHDB_CONTAINER_NAME
 
 CMD="docker run -d \
+   --restart on-failure \
    -e COUCHDB_USER=\"$T_COUCHDB_USER_ADMIN_NAME\" \
    -e COUCHDB_PASSWORD=\"$T_COUCHDB_USER_ADMIN_PASS\" \
    $T_COUCHDB_PORT_MAPPING \


### PR DESCRIPTION
## Description
Sometimes CouchDB container exits with a failure due to what appears to be a memory issue. This PR adds the `--restart on-failure` option in the `docker run` of the CouchDB container. The `on-failure` mode seems like the path that will create the least amount of friction as to how server admins expect the containers to behave. Docs here: https://docs.docker.com/config/containers/start-containers-automatically/