### PR TITLE
Allow temporary CouchDB users to have a role that is group or sitewide specific

### DIFF
--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -5,6 +5,7 @@ import { TangerineConfigService } from './shared/services/tangerine-config/tange
 import { GroupService } from './shared/services/group/group.service';
 import { TangerineConfig } from './shared/classes/tangerine-config';
 import { ModulesDoc } from './shared/classes/modules-doc.class';
+import createSitewideDatabase = require('./create-sitewide-database');
 const reportingWorker = require('./reporting/reporting-worker')
 const log = require('tangy-log').log
 const util = require('util');
@@ -80,7 +81,10 @@ export class AppService {
     log.info('Installing...')
     log.info('Creating _users database...')
     log.info(`${this.config.couchdbEndpoint}/_users`)
-    await this.httpClient.put(`${this.config.couchdbEndpoint}/_users`).toPromise()
+    await createSitewideDatabase('_users')
+    await createSitewideDatabase('app')
+    await createSitewideDatabase('groups')
+    await createSitewideDatabase('users')
     await this.appDb.put({_id: 'installed', value: true})
     await this.appDb.put({_id: 'version', value: process.env.TANGERINE_VERSION})
     await exec('git config --system user.name "tangerine"')

--- a/server/src/create-group-database.js
+++ b/server/src/create-group-database.js
@@ -1,0 +1,26 @@
+const axios = require('axios')
+const createGroupDatabase = async (groupId, suffix = '', addSyncRole = false) => {
+  const databaseName = `${groupId}${suffix ? suffix : ''}`
+  try {
+    // Create databases and corresponding security settings.
+    await axios.put(`${process.env.T_COUCHDB_ENDPOINT}${databaseName}`)
+  } catch (e) {
+    // The database already exists. That's fine.
+  }
+  await axios.put(`${process.env.T_COUCHDB_ENDPOINT}${databaseName}/_security`, {
+    admins: {
+      roles: [
+        `admin-sitewide`,
+        `admin-${groupId}`
+      ]
+    },
+    members: {
+      roles: [
+        `member-sitewide`,
+        `member-${groupId}`, 
+        ...addSyncRole ? [`sync-${groupId}`] : []
+      ]
+    }
+  })
+}
+module.exports = createGroupDatabase

--- a/server/src/create-sitewide-database.js
+++ b/server/src/create-sitewide-database.js
@@ -1,0 +1,26 @@
+const axios = require('axios')
+const createSitewideDatabase = async (dbId) => {
+  try {
+    // Create databases and corresponding security settings.
+    await axios.put(`${process.env.T_COUCHDB_ENDPOINT}${dbId}`)
+  } catch (e) {
+    // The database already exists. That's fine.
+  }
+  // We don't actually create CouchDB users with sitewide roles, a role is required to lock the 
+  // datbase down to CouchDB admins. Optionally, if someone does need access to all databases,
+  // they can create a user with the `admin-sitewide` role manually without making that user a 
+  // CouchDB Admin.
+  await axios.put(`${process.env.T_COUCHDB_ENDPOINT}${dbId}/_security`, {
+    admins: {
+      roles: [
+        `admin-sitewide`
+      ]
+    },
+    members: {
+      roles: [ 
+        `member-sitewide`
+      ]
+    }
+  })
+}
+module.exports = createSitewideDatabase

--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -8,6 +8,7 @@ const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
 const CODE_SKIP = '999'
 const createGroupDatabase = require('../../create-group-database.js')
+const groupsList = require('/tangerine/server/src/groups-list.js')
 
 async function insertGroupReportingViews(groupName) {
   let designDoc = Object.assign({}, groupReportingViews)
@@ -32,6 +33,13 @@ async function insertGroupReportingViews(groupName) {
 module.exports = {
   name: 'csv',
   hooks: {
+    enable: async function() {
+      const groups = await groupsList()
+      for (groupId of groups) {
+        await createGroupDatabase(groupId, '-reporting')
+        await createGroupDatabase(groupId, '-reporting-sanitized')
+      }
+    },
     clearReportingCache: async function(data) {
       const { groupNames } = data
       for (let groupName of groupNames) {

--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
 const CODE_SKIP = '999'
+const createGroupDatabase = require('../../create-group-database.js')
 
 async function insertGroupReportingViews(groupName) {
   let designDoc = Object.assign({}, groupReportingViews)
@@ -38,6 +39,8 @@ module.exports = {
         await db.destroy()
         db = DB(`${groupName}-reporting-sanitized`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-reporting')
+        await createGroupDatabase(groupName, '-reporting-sanitized')
         await insertGroupReportingViews(groupName)
       }
       return data
@@ -184,6 +187,8 @@ module.exports = {
     groupNew: function(data) {
       return new Promise(async (resolve, reject) => {
         const {groupName, appConfig} = data
+        await createGroupDatabase(groupName, '-reporting')
+        await createGroupDatabase(groupName, '-reporting-sanitized')
         await insertGroupReportingViews(groupName)
         resolve(data)
       })

--- a/server/src/modules/logstash/index.js
+++ b/server/src/modules/logstash/index.js
@@ -6,11 +6,18 @@ const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
 const createGroupDatabase = require('../../create-group-database.js')
+const groupsList = require('/tangerine/server/src/groups-list.js')
 
 
 module.exports = {
   name: 'logstash',
   hooks: {
+    enable: async function() {
+      const groups = await groupsList()
+      for (groupId of groups) {
+        await createGroupDatabase(groupId, '-logstash')
+      }
+    },
     clearReportingCache: async function(data) {
       const { groupNames } = data
       for (let groupName of groupNames) {
@@ -77,7 +84,6 @@ module.exports = {
       return new Promise(async (resolve, reject) => {
         const {groupName, appConfig} = data
         await createGroupDatabase(groupName, '-logstash')
-        await createGroupDatabase(groupName, '-logstash-sanitized')
         resolve(data)
       })
     }

--- a/server/src/modules/logstash/index.js
+++ b/server/src/modules/logstash/index.js
@@ -5,6 +5,8 @@ const {promisify} = require('util');
 const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
+const createGroupDatabase = require('../../create-group-database.js')
+
 
 module.exports = {
   name: 'logstash',
@@ -15,6 +17,7 @@ module.exports = {
         console.log(`removing db ${groupName}-logstash`)
         const db = new DB(`${groupName}-logstash`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-logstash')
       }
       return data
     },
@@ -67,6 +70,14 @@ module.exports = {
             'lon': processedResult['geoip.lon'] ? processedResult['geoip.lon'] : ''
           }
         }, logstashDb);
+        resolve(data)
+      })
+    },
+    groupNew: function(data) {
+      return new Promise(async (resolve, reject) => {
+        const {groupName, appConfig} = data
+        await createGroupDatabase(groupName, '-logstash')
+        await createGroupDatabase(groupName, '-logstash-sanitized')
         resolve(data)
       })
     }

--- a/server/src/modules/mysql/index.js
+++ b/server/src/modules/mysql/index.js
@@ -31,6 +31,8 @@ module.exports = {
       const groups = await groupsList()
       for (groupId of groups) {
         await initializeGroupForMySQL(groupId)
+        await createGroupDatabase(groupId, '-mysql')
+        await createGroupDatabase(groupId, '-mysql-sanitized')
       }
     },
     disable: function(data) {

--- a/server/src/modules/mysql/index.js
+++ b/server/src/modules/mysql/index.js
@@ -8,6 +8,7 @@ const exec = util.promisify(require('child_process').exec)
 const { spawn } = require('child_process');
 const fsCore = require('fs');
 const readFile = util.promisify(fsCore.readFile);
+const createGroupDatabase = require('../../create-group-database.js')
 
 /* Enable this if you want to run commands manually when debugging.
 const exec = async function(cmd) {
@@ -41,6 +42,8 @@ module.exports = {
       await initializeGroupForMySQL(groupId)
       const pathToStateFile = `/mysql-module-state/${groupId}.ini`
       startTangerineToMySQL(pathToStateFile)
+      await createGroupDatabase(groupName, '-mysql')
+      await createGroupDatabase(groupName, '-mysql-sanitized')
       return data
     },
     clearReportingCache: async function(data) {
@@ -51,8 +54,10 @@ module.exports = {
         console.log(`removing db ${groupName}-mysql`)
         let db = new DB(`${groupName}-mysql`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-mysql')
         db = new DB(`${groupName}-mysql-sanitized`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-mysql-sanitized')
       }
       return data
     },

--- a/server/src/modules/rshiny/index.js
+++ b/server/src/modules/rshiny/index.js
@@ -6,10 +6,18 @@ const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
 const createGroupDatabase = require('../../create-group-database.js')
+const groupsList = require('/tangerine/server/src/groups-list.js')
 
 module.exports = {
   name: 'rshiny',
   hooks: {
+    enable: async function() {
+      const groups = await groupsList()
+      for (groupId of groups) {
+        await createGroupDatabase(groupId, '-rshiny')
+        await createGroupDatabase(groupId, '-rshiny-sanitized')
+      }
+    },
     clearReportingCache: async function(data) {
       const { groupNames } = data
       for (let groupName of groupNames) {

--- a/server/src/modules/rshiny/index.js
+++ b/server/src/modules/rshiny/index.js
@@ -5,6 +5,7 @@ const {promisify} = require('util');
 const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
+const createGroupDatabase = require('../../create-group-database.js')
 
 module.exports = {
   name: 'rshiny',
@@ -15,8 +16,10 @@ module.exports = {
         console.log(`removing db ${groupName}-rshiny`)
         let db = new DB(`${groupName}-rshiny`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-rshiny')
         db = new DB(`${groupName}-rshiny-sanitized`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-rshiny-sanitized')
       }
       return data
     },
@@ -104,6 +107,14 @@ module.exports = {
       sanitized = true;
       await generateDatabase(sourceDb, rshinySanitizedDb, doc, locationList, sanitized, exclusions);
       return data
+    },
+    groupNew: function(data) {
+      return new Promise(async (resolve, reject) => {
+        const {groupName, appConfig} = data
+        await createGroupDatabase(groupName, '-rshiny')
+        await createGroupDatabase(groupName, '-rshiny-sanitized')
+        resolve(data)
+      })
     }
   }
 }

--- a/server/src/modules/synapse/index.js
+++ b/server/src/modules/synapse/index.js
@@ -6,10 +6,18 @@ const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
 const createGroupDatabase = require('../../create-group-database.js')
+const groupsList = require('/tangerine/server/src/groups-list.js')
 
 module.exports = {
   name: 'synapse',
   hooks: {
+    enable: async function() {
+      const groups = await groupsList()
+      for (groupId of groups) {
+        await createGroupDatabase(groupId, '-synapse')
+        await createGroupDatabase(groupId, '-synapse-sanitized')
+      }
+    },
     clearReportingCache: async function(data) {
       const { groupNames } = data
       for (let groupName of groupNames) {

--- a/server/src/modules/synapse/index.js
+++ b/server/src/modules/synapse/index.js
@@ -5,6 +5,7 @@ const {promisify} = require('util');
 const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const tangyModules = require('../index.js')()
+const createGroupDatabase = require('../../create-group-database.js')
 
 module.exports = {
   name: 'synapse',
@@ -15,8 +16,10 @@ module.exports = {
         console.log(`removing db ${groupName}-synapse`)
         let db = new DB(`${groupName}-synapse`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-synapse')
         db = new DB(`${groupName}-synapse-sanitized`)
         await db.destroy()
+        await createGroupDatabase(groupName, '-synapse-sanitized')
       }
       return data
     },
@@ -131,6 +134,12 @@ module.exports = {
       }
       sanitized = true;
       await generateDatabase(sourceDb, synapseSanitizedDb, doc, locationList, sanitized, exclusions, substitutions, pii);
+      return data
+    },
+    groupNew: async function(data) {
+      const {groupName} = data
+      await createGroupDatabase(groupName, '-synapse')
+      await createGroupDatabase(groupName, '-synapse-sanitized')
       return data
     }
   }

--- a/server/src/modules/sync-protocol-2/index.js
+++ b/server/src/modules/sync-protocol-2/index.js
@@ -1,7 +1,14 @@
 const createGroupDatabase = require('../../create-group-database.js')
+const groupsList = require('/tangerine/server/src/groups-list.js')
 module.exports = {
   name: 'sync-protocol-2',
   hooks: {
+    enable: async function() {
+      const groups = await groupsList()
+      for (groupId of groups) {
+        await createGroupDatabase(groupId, '-devices')
+      }
+    },
     groupNew: async function(data) {
       const {groupName} = data
       const groupId = groupName

--- a/server/src/modules/sync-protocol-2/index.js
+++ b/server/src/modules/sync-protocol-2/index.js
@@ -1,5 +1,13 @@
+const createGroupDatabase = require('../../create-group-database.js')
 module.exports = {
   name: 'sync-protocol-2',
-  hooks: {}
+  hooks: {
+    groupNew: async function(data) {
+      const {groupName} = data
+      const groupId = groupName
+      await createGroupDatabase(groupName, '-devices')
+      return data
+    }
+  }
 }
  


### PR DESCRIPTION
* [x] In all reporting modules, make sure to create the group databases when during module enable hook.