### PR TITLE
Prevent failure of csv template listing

### DIFF
--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -9,7 +9,7 @@
 
 <div class="tangy-full-width" *ngIf="csvDataSets?.length>0">
   <div class="instructions">
-    <p>{{ "You may monitor the progress of CSV file generation by clicking the link in the 'Status' column. When the CSV Data Set download file is complete, a link will be available in the 'Download File' column." | translate }} </p>
+    <p>{{ "You may monitor the progress of CSV file generation by clicking the link in the 'Status' column; this listing does not refresh the Status of a CSV Data Set generation automatically. When the CSV Data Set download file is complete, a link will be available in the 'Download File' column and the Status column will be marked 'Complete'." | translate }} </p>
   </div>
   <table mat-table [dataSource]="csvDataSets" class="mat-elevation-z8 tangy-full-width">
     <ng-container matColumnDef="fileName">

--- a/editor/src/app/groups/group-csv-templates/group-csv-templates.component.ts
+++ b/editor/src/app/groups/group-csv-templates/group-csv-templates.component.ts
@@ -42,7 +42,7 @@ export class GroupCsvTemplatesComponent implements OnInit {
     this.csvTemplates = csvTemplates.map(csvTemplate => { return {
       "_id": csvTemplate._id,
       "Template Title": csvTemplate.title,
-      "Form": formsInfo.find(formInfo => formInfo.id === csvTemplate.formId).title,
+      "Form": formsInfo.find(formInfo => formInfo.id === csvTemplate.formId)?.title,
       "Columns": csvTemplate.headers
     }})
   }

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.css
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.css
@@ -50,6 +50,7 @@ table {
 .select-instructions {
   margin-top: 2rem;
   margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 .new-csv-header {

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.html
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.html
@@ -40,7 +40,7 @@
         >{{ "Exclude PII?" | translate }}
       </mat-checkbox>
     </div>
-    <div class="select-instructions">{{ "Click the checkbox to the left of the 'Form title' column to select all forms." | translate }}</div>
+    <div class="select-instructions">{{ "Click the checkbox to the left of the 'Form title' column to select all forms. If there is a CSV Template available for a form, it will be displayed in the form's CSV Template dropdown." | translate }}</div>
     <table class="form-list materialish">
       <tr class="table-header new-csv-header">
         <td>


### PR DESCRIPTION
UI tweaks

## Description

When you click the button for CSV Templates, it *immediately* creates a blank CSV template, which caused problems with how the listing worked. 

- Fixes #3115 

## Type of Change

Added a `?` guardrail...

