### PR TITLE
Need to test for sync-protocol 1

### DIFF
--- a/client/src/app/core/update/update/updates.ts
+++ b/client/src/app/core/update/update/updates.ts
@@ -287,7 +287,7 @@ export const updates = [
   {
     requiresViewsUpdate: false,
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.9.1')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.9.1'))) return
       console.log('Updating to v3.9.1...')
       try {
         const view = await userDb.get('_design/case-events-by-all-days')
@@ -327,7 +327,7 @@ export const updates = [
     requiresViewsUpdate: false,
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
       console.log('Updating to v3.14.0...')
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.14.0')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.14.0'))) return
       // Reset sync-push-last_seq
       await variableService.set('sync-push-last_seq', 0);
       await variableService.set('ran-update-v3.14.0', 'true')
@@ -336,7 +336,7 @@ export const updates = [
   {
     requiresViewsUpdate: false,
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.15.0')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.15.0'))) return
       console.log('Updating to v3.15.0...')
      // Remove old search indexes.
       const searchDb = new PouchDB(`${userDb.name}-index`)
@@ -349,7 +349,7 @@ export const updates = [
   {
     requiresViewsUpdate: false,
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.15.3')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.15.3'))) return
       console.log('Updating to v3.15.3...')
       // Build search index.
       await window['T'].search.createIndex()
@@ -362,7 +362,7 @@ export const updates = [
     message: 'Checking if this tablet needs a full sync.',
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService, syncService:SyncService, status) => {
       const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true), milliseconds))
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.16.0')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.16.0'))) return
       console.log('Updating to v3.16.0...')
       // Check if this instance is configured for this update
       if (appConfig.forceFullSync) {
@@ -380,7 +380,7 @@ export const updates = [
   {
     requiresViewsUpdate: false,
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.16.3')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.16.3'))) return
       console.log('Updating to v3.16.3...')
       // Install SyncForm index.
       await window['T'].sync.createSyncFormIndex()
@@ -391,7 +391,7 @@ export const updates = [
   {
     requiresViewsUpdate: false,
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.19.0')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.19.0'))) return
       console.log('Updating to v3.19.0...')
       console.log('Adding support for previousDeviceSyncLocations variable...')
       const device = await window['T'].device.getDevice()
@@ -405,7 +405,7 @@ export const updates = [
   {
     requiresViewsUpdate: false,
     script: async (userDb, appConfig, userService: UserService, variableService:VariableService) => {
-      if (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.19.2')) return
+      if (appConfig.syncProtocol === '1' || (appConfig.syncProtocol === '2' && await variableService.get('ran-update-v3.19.2'))) return
       console.log('Updating to v3.19.2...')
       console.log('Trying to update index again for tablets that may have failed on the last update and then incorrectly proceeded due to update flag getting set too early...')
       await window['T'].search.createIndex()

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -2,14 +2,17 @@
 <div class="new-data-set-btn">
   <a routerLink="../csv-data-sets/new">
     <button mat-raised-button color="accent">
-      {{ "New Data Set" | translate }}
+      {{ "New CSV Data Set" | translate }}
     </button>
   </a>
 </div>
 
 <div class="tangy-full-width" *ngIf="csvDataSets?.length>0">
   <div class="instructions">
-    <p>{{ "You may monitor the progress of CSV file generation by clicking the link in the 'Status' column; this listing does not refresh the Status of a CSV Data Set generation automatically. When the CSV Data Set download file is complete, a link will be available in the 'Download File' column and the Status column will be marked 'Complete'." | translate }} </p>
+    <p>{{ "CSV Data sets are a collections of CSV files - one per form - that are downloaded via a zipped file. You may download a set of CSV's using the 'Download File' links below or configure a new CSV data set using the 'New CSV Data Set' link above. " | translate }} 
+    </p>
+    <p>{{ "You may monitor the progress of CSV file generation by clicking the link in the 'Status' column; this listing does not refresh the Status of a CSV Data Set generation automatically. When the CSV Data Set download file is complete, a link will be available in the 'Download File' column and the Status column will be marked 'Complete'. Clicking the link in the 'Status' column provides a listing of individual CSV files for download." | translate }} 
+    </p>
   </div>
   <table mat-table [dataSource]="csvDataSets" class="mat-elevation-z8 tangy-full-width">
     <ng-container matColumnDef="fileName">

--- a/editor/src/app/groups/group-data/group-data.component.html
+++ b/editor/src/app/groups/group-data/group-data.component.html
@@ -39,7 +39,7 @@
       <mat-card-title>
         <a>{{'CSV Output'|translate}}</a>
       </mat-card-title>
-      <mat-card-subtitle>{{'Download or configure a CSV Data Set, which is a zipped collection of CSVs. Configure the fields included in the CSV data output of a form using CSV Templates.' |translate}}</mat-card-subtitle>
+      <mat-card-subtitle>{{'Download or configure a CSV Data Set, which is a zipped collection of CSVs. Configure the fields included in the CSV data output of a form using CSV Templates. The "Download individual CSVs" feature will be merged soon with the CSV Data Set feature soon since it has similar output.' |translate}}</mat-card-subtitle>
     </mat-card-header>
     <mat-card-actions>
       <button mat-stroked-button color="accent" routerLink="csv-data-sets">{{'Download CSV Data Set'|translate}}</button>
@@ -62,22 +62,7 @@
       </mat-card-header>
     </mat-card>
   </span>
-   
   
-  
-  <mat-card *appHasAPermission="let i;group:groupId; permission:'can_access_download_csv'" class="is-link mat-elevation-z3" routerLink="download-statistical-files">
-    <mat-card-header>
-        <div mat-card-avatar>
-          <mwc-icon class="tangy-foreground-secondary">table_view</mwc-icon>
-        </div>
-        <mat-card-title>
-            <a>{{'Download Statistical Files'|translate}}</a>
-        </mat-card-title>
-        <mat-card-subtitle>{{'Download files of statistical packages.'|translate}}</mat-card-subtitle>
-    </mat-card-header>
-  </mat-card>
-
-
   <mat-card *appHasAPermission="let i;group:groupId; permission:'can_access_uploads'" class="is-link mat-elevation-z3" routerLink="uploads">
     <mat-card-header>
       <div mat-card-avatar>


### PR DESCRIPTION
Update to Data listing and CSV data sets description.
Removed download-statistical-files from Data listing.

## Description

Updates fail when upgrading app running sync protocol 1.

- Fixes #3111

## Type of Change



- Bug fix (non-breaking change which fixes an issue)
## Proposed Solution

Added code to check for s-p 1 in updates script for updates back to v3.14. Added this code to places where it looked very case module specific in case some updates were applicable for both types (byType query...)

## Limitations and Trade-offs

May need to tighten more of these updates - but in reality, we probably don't have any sites running Tangerine older than v3.14...