### PR TITLE
Fix cors using credentials

### DIFF
--- a/server/src/express-app.js
+++ b/server/src/express-app.js
@@ -64,6 +64,12 @@ if (process.env.T_AUTO_COMMIT === 'true') {
 }
 module.exports = async function expressAppBootstrap(app) {
 
+// Enable CORS
+app.use(cors({
+  credentials: true,
+  origin: true
+}));
+
 // Enforce SSL behind Load Balancers.
 if (process.env.T_PROTOCOL == 'https') {
   app.use(function (req, res, next) {
@@ -95,12 +101,6 @@ app.use(mountpoint, function (req, res) {
     couchProxy;
   }
 });
-
-// Enable CORS
-app.use(cors({
-  credentials: true,
-}));
-app.options('*', cors()) // include before other routes
 app.use(cookieParser())
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json({ limit: '1gb' }))


### PR DESCRIPTION
When browser based apps use Tangerine API's, they currently get denied when using credentials because of the following error. 

<img width="565" alt="Screen Shot 2021-12-28 at 11 23 22 AM" src="https://user-images.githubusercontent.com/156575/147589822-aea67358-0d83-4802-9c7e-ed26b70d31ee.png">

This PR turns on matching Origin header using the CORs module. This PR builds on https://github.com/Tangerine-Community/Tangerine/pull/3118 and is only really this [one commit](https://github.com/Tangerine-Community/Tangerine/pull/3132/commits/c71a97b1102355a7bc29016c9a8a7b3fe6891746). 