### PR TITLE
Prevent double responses when denying access in the permitted middleware

### DIFF
--- a/server/src/middleware/permitted.js
+++ b/server/src/middleware/permitted.js
@@ -3,9 +3,9 @@ const permit = (allowedPermissions) => {
     const isAllowed = permissions => (allowedPermissions.filter(Set.prototype.has, new Set(permissions))).length > 0;
     return (req, res, next) => {
       if (isAllowed(req.user.sitewidePermissions)) {
-          next();
+        return next();
       } else {
-        res.status(403).send(`Access Denied at ${req.url}`);
+        return res.status(403).send(`Access Denied at ${req.url}`);
       }
     };
   };
@@ -18,12 +18,12 @@ const permitOnGroupIfAll = (permissions) => {
       const allGroupsPermissions = req.user.groupPermissions;
       const myGroupsPermissions = (allGroupsPermissions.find(g => g.groupName === group)).permissions;
       if (isAllowed(myGroupsPermissions)) {
-        next();
+        return next();
       } else {
-        res.status(403).send(`Access Denied at ${req.url}`);
+        return res.status(403).send(`Access Denied at ${req.url}`);
       }
     } catch (error) {
-      res.status(403).send(`Access Denied at ${req.url} with error: ${error}`);
+      return res.status(403).send(`Access Denied at ${req.url} with error: ${error}`);
     }
   };
 };
@@ -35,12 +35,12 @@ const permitOnGroupIfEither = (permissions) => {
       const allGroupsPermissions = req.user.groupPermissions;
       const myGroupsPermissions = (allGroupsPermissions.find(g => g.groupName === group)).permissions;
       if (isAllowed(myGroupsPermissions)) {
-        next();
+        return next();
       } else {
-        res.status(403).send(`Access Denied at ${req.url}`);
+        return res.status(403).send(`Access Denied at ${req.url}`);
       }
     } catch (error) {
-      res.status(403).send(`Access Denied at ${req.url}`);
+      return res.status(403).send(`Access Denied at ${req.url}`);
     }
   };
 };
@@ -49,20 +49,20 @@ const permitOnGroupIf = (permission) => {
   return (req, res, next) => {
     // log.warn("permission: |" + permission + "| permission type: " + Object.prototype.toString.call(permission))
     try {
-      const group = req.params.groupId || req.params.groupName || req.params.group || req.body.group;
+      const group = req.params.groupId || req.params.groupName || req.params.group || req.body.group || req.body.groupId
       const allGroupsPermissions = req.user.groupPermissions;
       const username = req.user.name;
       if (!group) {
-        res.status(403).send(`Access Denied at ${req.url}. Missing group parameter.`);
+        return res.status(403).send(`Access Denied at ${req.url}. Missing group parameter.`);
       }
       const myGroupsPermissions = (allGroupsPermissions.find(g => g.groupName === group)).permissions;
       if (isAllowed(myGroupsPermissions)) {
-        next();
+        return next();
       } else {
-        res.status(403).send(`Access Denied at ${req.url} for user: ${username}`);
+        return res.status(403).send(`Access Denied at ${req.url} for user: ${username}`);
       }
     } catch (error) {
-      res.status(403).send(`Access Denied at ${req.url} with error: ${error}`);
+      return res.status(403).send(`Access Denied at ${req.url} with error: ${error}`);
     }
   };
 };


### PR DESCRIPTION
In permitted.js middeware, use returns to avoid bugs where code may send a response twice which was happening in permitOnGroupIf when missing group parameter. The other returns are just implementing this pattern in case any code is added later that could be prone to this bug. This PR also adds support for defining groupId in body of request when using the permitOnGroupIf middleware.
