### PR TITLE
Fix: Data Collector resumes unfinished Event Form

### DIFF
--- a/client/src/app/case/case-routing.module.ts
+++ b/client/src/app/case/case-routing.module.ts
@@ -47,7 +47,7 @@ export class CanDeactivateEventForm implements CanDeactivate<EventFormComponent>
     if (!component.formResponseId && !component.eventForm.formResponseId && component.formPlayer.response && component.formPlayer.response.items && component.formPlayer.response.items[0] && component.formPlayer.response.items[0].inputs && component.formPlayer.response.items[0].inputs.length > 0) {
       component.eventForm.formResponseId = component.formPlayer.formResponseId
       component.isSaving = true
-      await this.caseService.save()
+      await component.publicCaseService.save()
       component.isSaving = false
     }
     return true

--- a/client/src/app/case/components/event-form/event-form.component.ts
+++ b/client/src/app/case/components/event-form/event-form.component.ts
@@ -31,6 +31,7 @@ export class EventFormComponent implements OnInit, OnDestroy {
   templateId:string
   formResponseId:string
   allowCreationOfIssues:boolean
+  publicCaseService:CaseService
 
   hasEventFormRedirect = false
   eventFormRedirectUrl = ''
@@ -59,6 +60,7 @@ export class EventFormComponent implements OnInit, OnDestroy {
   ) {
     ref.detach()
     this.window = window
+    this.publicCaseService = caseService
   }
 
   async ngOnInit() {


### PR DESCRIPTION
## Description
When leaving an Event Form unfinished, the link to from the Event Form to the Form Response fails to be created and navigating away requires to clicks. When you navigate back to the Event Form, it appears that progress was lost and you have to start over again. Implications for data analysis is this leads to having multiple Form Responses in the database for the same Event Form.

Here's a screenshot of the what happens when you click back. Note the confusing error.

<img width="1864" alt="Screen Shot 2022-01-05 at 11 50 19 AM" src="https://user-images.githubusercontent.com/156575/148391485-47d30506-60c8-46d5-a635-e6785cdffd18.png">

## Type of Change
- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
When we changed the EventFormComponent to not use the CaseService singleton, the CanDeactivate route guard for the corresponding route was left to still use the singleton. That means when the CanDeactivate route guard detected a link between an Event Form and a Form Response that it needed to make, it was trying to cause a save on the CaseService singleton which had no Case loaded, thus the error in the save function complaining about accessing properties of undefined.

To solve this, I've made a public memory reference on the EventFormComponent to the CaseService instance localized to that Component so the CanDeactivate route guard can call save on that localized instance of CaseService.

## Limitations and Trade-offs
I'm not sure it's a good pattern to make a public reference to a private property. Perhaps we should expose the data of the case in the localized CaseService and load that in CanDeactivate route guard's own instance of CaseService? That doesn't seem very elegant to me either, seems like more of a framework question and perhaps Angular will have some answer to this in the future (or now I'm just not finding it).

## Security considerations
None.

## Tests
Create a case, start an Event Form with at least two pages, get to the second page, navigate away, navigate back to the Event Form, the Event Form should resume correctly.

## Notices, Regressions, Breaking Changes
None.

## TODOS/enhancements
None.