### PR TITLE
Prevent loss of case changes when leaving incomplete form by always saving the case

### DIFF
--- a/client/src/app/case/case-routing.module.ts
+++ b/client/src/app/case/case-routing.module.ts
@@ -46,10 +46,11 @@ export class CanDeactivateEventForm implements CanDeactivate<EventFormComponent>
   ): Promise<boolean> {
     if (!component.formResponseId && !component.eventForm.formResponseId && component.formPlayer.response && component.formPlayer.response.items && component.formPlayer.response.items[0] && component.formPlayer.response.items[0].inputs && component.formPlayer.response.items[0].inputs.length > 0) {
       component.eventForm.formResponseId = component.formPlayer.formResponseId
-      component.isSaving = true
-      await this.caseService.save()
-      component.isSaving = false
     }
+    component.isSaving = true
+    // This line need to change depending on wether the following PR makes it into the main branch. https://github.com/Tangerine-Community/Tangerine/pull/3153
+    await this.caseService.save()
+    component.isSaving = false
     return true
   }
 


### PR DESCRIPTION
## Description
This PR protects against data loss on Case objects in situations where you resume a form, page 3 a Case level variable is set, you navigate away, navigate back, and submit on page 4 causing the case level variable setting to vanish. The downside of saving every time is more revisions, but if folks don't navigate away from Event Forms that often, it's not a huge number of revisions. Thus, before deploying this PR, we may want to consider merging this in conjuction with #3155.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)


