### PR TITLE
Make Loc and t available on Editor's window object for consistency with Client environment

### DIFF
--- a/editor/src/polyfills.ts
+++ b/editor/src/polyfills.ts
@@ -96,6 +96,12 @@ import * as Redux from 'redux';
 import * as _ from 'underscore';
 (window as any)._ = _;
 
+import { Loc } from 'tangy-form/util/loc.js';
+(window as any).Loc = Loc
+
+import { t } from 'tangy-form/util/t.js';
+(window as any).t = t 
+
 import './global-shim'
 import 'tangy-form-editor/tangy-form-editor.js'
 import './app/couchdb-conflict-manager/src/couchdb-conflict-manager.js'


### PR DESCRIPTION
Some projects reference window.Loc in their content. This will work on client but fail on editor. This PR fixes that.