### PR TITLE
Fix messaging during data optimization and reduce number of view optimized that are never used

### DIFF
--- a/client/src/app/device/components/device-sync/device-sync.component.html
+++ b/client/src/app/device/components/device-sync/device-sync.component.html
@@ -14,7 +14,6 @@
     <div class="errorMessage" *ngIf="errorMessage">{{errorMessage}}</div>
     <div class="errorMessage" *ngIf="pullError">Pull Error: {{pullError}}</div>
     <div class="errorMessage" *ngIf="pushError">Push Error: {{pushError}}</div>
-    <div class="status">{{indexingMessage}}</div>
     <div><p>{{'Records in the local database'|translate}}: {{dbDocCount}}</p></div>
     <br>
     <paper-button (click)="onContinueClick()">{{'next'|translate}}</paper-button>

--- a/client/src/app/device/components/device-sync/device-sync.component.ts
+++ b/client/src/app/device/components/device-sync/device-sync.component.ts
@@ -124,7 +124,7 @@ export class DeviceSyncComponent implements OnInit, OnDestroy {
           }
           if (progress.indexing) {
             this.indexing = progress.indexing
-            this.indexingMessage = 'Indexing ' + progress.indexing.view + ' Doc Count: ' + progress.indexing.countIndexedDocs
+            this.indexingMessage = progress.indexingMessage 
           }
           // console.log('Sync Progress: ' + JSON.stringify(progress))
         }

--- a/client/src/app/sync/components/sync/sync.component.ts
+++ b/client/src/app/sync/components/sync/sync.component.ts
@@ -93,8 +93,8 @@ export class SyncComponent implements OnInit, OnDestroy {
     this.subscription = this.syncService.syncMessage$.subscribe({
       next: (progress) => {
         if (progress) {
+          this.syncMessage = progress.syncMessage || this.syncMessage
           let pendingMessage = '', docPulled = ''
-          // this.syncMessage = ''
           if (typeof progress.message !== 'undefined') {
             // this.otherMessage = progress.message
             if (progress.type == 'checkpoint') {
@@ -158,8 +158,9 @@ export class SyncComponent implements OnInit, OnDestroy {
           }
           if (progress.indexing) {
             this.indexing = progress.indexing
-            this.indexingMessage = 'Indexing ' + progress.indexing.view
+            this.indexingMessage = progress.indexingMessage 
           } else {
+            this.indexing = false
             this.indexingMessage = ''
           }
           // console.log('Sync Progress: ' + JSON.stringify(progress))


### PR DESCRIPTION
Fixes #3168 

## Summary
- On initial sync, a very precise percent complete is now shown instead of number of docs indexed in the current view being indexed. 
- On subsequent sync, messages during data optimization had broken. They have now returned and percent complete is a little more accurate than before.
- When data optimization completes, we now clear the message buffer as to not mislead the user with "Please wait...".
- Reduces unnecessary views that were being indexed when using the Case module.

## On initial sync
https://user-images.githubusercontent.com/156575/149636301-604df392-a650-45ef-9b35-cce8ba674a1e.mov

## On subsequent sync
https://user-images.githubusercontent.com/156575/149636295-930d2a29-7205-4daa-b670-f2bdfd9cf90d.mov



