### PR TITLE
Fix loading of deploy page

### DIFF
--- a/editor/src/app/groups/group-deploy/group-deploy.component.html
+++ b/editor/src/app/groups/group-deploy/group-deploy.component.html
@@ -1,5 +1,5 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
-<mat-card [hidden]="!syncProtocol2Enabled" *appHasAllPermissions="let i;group:groupId; permissions:['can_access_devices']" class="is-link mat-elevation-z3" routerLink="devices">
+<mat-card [hidden]="!syncProtocol2Enabled || !ready" *appHasAllPermissions="let i;group:groupId; permissions:['can_access_devices']" class="is-link mat-elevation-z3" routerLink="devices">
   <mat-card-header>
       <div mat-card-avatar>
         <i class="material-icons tangy-foreground-secondary group-avatar">stay_current_portrait</i>
@@ -11,7 +11,7 @@
   </mat-card-header>
 </mat-card>
 
-<mat-card *appHasAllPermissions="let i;group:groupId; permissions:['can_access_device_users']" class="is-link mat-elevation-z3" routerLink="device-users">
+<mat-card [hidden]="!ready" *appHasAllPermissions="let i;group:groupId; permissions:['can_access_device_users']" class="is-link mat-elevation-z3" routerLink="device-users">
   <mat-card-header>
       <div mat-card-avatar>
         <mwc-icon class="tangy-foreground-secondary">people</mwc-icon>
@@ -23,7 +23,7 @@
   </mat-card-header>
 </mat-card>
 
-<mat-card *appHasAllPermissions="let i;group:groupId; permissions:['can_access_releases']" class="is-link mat-elevation-z3" routerLink="releases">
+<mat-card [hidden]="!ready" *appHasAllPermissions="let i;group:groupId; permissions:['can_access_releases']" class="is-link mat-elevation-z3" routerLink="releases">
   <mat-card-header>
       <div mat-card-avatar>
         <i class="material-icons tangy-foreground-secondary group-avatar">system_update</i>
@@ -35,7 +35,7 @@
   </mat-card-header>
 </mat-card>
 
-<mat-card *appHasAllPermissions="let i;group:groupId; permissions:['can_access_releases']" class="is-link mat-elevation-z3" routerLink="onlineSurvey">
+<mat-card [hidden]="!ready" *appHasAllPermissions="let i;group:groupId; permissions:['can_access_releases']" class="is-link mat-elevation-z3" routerLink="onlineSurvey">
   <mat-card-header>
       <div mat-card-avatar>
         <i class="material-icons tangy-foreground-secondary group-avatar">system_update</i>

--- a/editor/src/app/groups/group-deploy/group-deploy.component.ts
+++ b/editor/src/app/groups/group-deploy/group-deploy.component.ts
@@ -2,6 +2,7 @@ import { Breadcrumb } from './../../shared/_components/breadcrumb/breadcrumb.com
 import { _TRANSLATE } from 'src/app/shared/_services/translation-marker';
 import { Component, OnInit } from '@angular/core';
 import { ServerConfigService } from 'src/app/shared/_services/server-config.service';
+import { ProcessMonitorService } from 'src/app/shared/_services/process-monitor.service';
 
 
 @Component({
@@ -15,14 +16,21 @@ export class GroupDeployComponent implements OnInit {
   breadcrumbs:Array<Breadcrumb> = []
   syncProtocol2Enabled: boolean
   groupId:string
+  ready = false
 
-  constructor(private serverConfig:ServerConfigService ) { }
+  constructor(
+    private serverConfig:ServerConfigService,
+    private processMonitor:ProcessMonitorService
+  ) { }
 
   async ngOnInit() {
     this.breadcrumbs = []
     this.groupId = window.location.pathname.split('/')[2]
+    const process = this.processMonitor.start('group-deploy', 'Loading...')
     const config = await this.serverConfig.getServerConfig()
     this.syncProtocol2Enabled = !!(config.enabledModules.find(module=>module==='sync-protocol-2'))
+    this.processMonitor.stop(process.id)
+    this.ready = true
   }
 
 }


### PR DESCRIPTION
Currently the deploy page menu items will jump around as things load. This puts a modal over the page as things loads and makes sure to not display anything until all menu items are ready.