### PR TITLE
Fix bug causing document updated to get skipped over in sync after a Comparison Sync

### DIFF
--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -430,10 +430,6 @@ export class SyncService {
         } else {
           status.pulled = pulled
         }
-        // We must set sync-push-last_seq now so that replication doesn't have to go through a bunch of sequences that we just pulled down.
-        const lastLocalSequence = (await userDb.changes({descending: true, limit: 1})).last_seq
-        await this.variableService.set('sync-push-last_seq', lastLocalSequence)
-        console.log("Setting sync-push-last_seq to " + lastLocalSequence)
         this.syncMessage$.next(status)
       } catch (e) {
         console.log("Error: " + e)


### PR DESCRIPTION

## Description
0) Create Case A
1) do a regular sync 
2) Make a change to Case A 
3) do a comparison push sync 
4) do a regular sync... 

The change to Case A in step 2 will not be on the server any any subsequent syncs will not sync Case A until it has been changed again.


## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
Do not set mile marker of last push sequence when doing a comparison sync. Comparison sync only pushes new docs, not changed docs.
