### PR TITLE
Deprecate single csv download in favor of Spreadsheet Requests

### DIFF
--- a/client/src/app/device/services/device.service.ts
+++ b/client/src/app/device/services/device.service.ts
@@ -29,6 +29,7 @@ export interface AppInfo {
 })
 export class DeviceService {
 
+  device:Device
   username:string
   password:string
   rawBuildChannel:string
@@ -154,7 +155,8 @@ export class DeviceService {
         }
       }
       const locker = this.lockBoxService.getOpenLockBox()
-      return locker.contents.device
+      this.device = locker.contents.device
+      return this.device 
     } catch (e) {
       return new Device()
     }

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.css
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.css
@@ -5,3 +5,22 @@
 a{
     text-decoration: none;
 }
+
+mat-spinner {
+  margin-left: 3px;
+}
+
+#download-all-container {
+  position: relative;
+}
+#download-all-container button {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+}
+#download-all-container mat-spinner {
+  display: inline-block;
+  position: relative;
+  left: -5px;
+  top: -2px;
+}

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
@@ -35,7 +35,7 @@
     <ng-container matColumnDef="inProgress">
       <th mat-header-cell *matHeaderCellDef>{{'Status'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet?.inProgress ? dataSet?.skip : ''}} {{ dataSet?.inProgress ? 'rows processed' : ''}}  
+        {{ dataSet?.inProgress ? dataSet?.skip : ''}} {{ dataSet?.inProgress && dataSet.skip ? 'rows processed' : ''}}  {{ dataSet?.inProgress && !dataSet.skip ? 'Starting...' : ''}}
         {{ dataSet?.complete ? 'Complete' : '' | translate}}
         {{ !dataSet?.complete && !dataSet?.inProgress ? 'Queued' : '' | translate}}
       </td>

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
@@ -1,19 +1,19 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 <div id="download-all-container">
-  <button mat-raised-button color="warn" [hidden]="!datasetDetail.complete">
+  <button mat-raised-button color="warn" [hidden]="!datasetDetail?.complete">
     <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
     {{'download all'|translate}}
   </button>
- <button mat-raised-button color="warn" [hidden]="datasetDetail.complete" disabled>
+ <button mat-raised-button color="warn" [hidden]="datasetDetail?.complete" disabled>
     <mat-spinner diameter=25></mat-spinner> {{'download all'|translate}}
   </button>
 </div>
 <div *ngIf="datasetDetail" class="tangy-full-width">
-    <p [hidden]="!datasetDetail.description"><strong>{{'Description'|translate}}</strong>: {{datasetDetail.description}}</p>
-    <p><strong>{{'Include PII'|translate}}</strong>: {{datasetDetail.includePii}}</p>
-    <p><strong>{{"Status"|translate}}:</strong> {{datasetDetail.complete? 'Complete':'In Progress' |translate}}</p>
-    <p><strong>{{'Month'|translate}}:</strong> {{datasetDetail.month === '*' ? 'All months' : datasetDetail.month }}</p>
-    <p><strong>{{'Year'|translate}}:</strong> {{datasetDetail.year === '*' ? 'All years' : datasetDetail.year }}</p>
+    <p [hidden]="!datasetDetail?.description"><strong>{{'Description'|translate}}</strong>: {{datasetDetail?.description}}</p>
+    <p><strong>{{'Include PII'|translate}}</strong>: {{datasetDetail?.includePii}}</p>
+    <p><strong>{{"Status"|translate}}:</strong> {{datasetDetail?.complete? 'Complete':'In Progress' |translate}}</p>
+    <p><strong>{{'Month'|translate}}:</strong> {{datasetDetail?.month === '*' ? 'All months' : datasetDetail?.month }}</p>
+    <p><strong>{{'Year'|translate}}:</strong> {{datasetDetail?.year === '*' ? 'All years' : datasetDetail?.year }}</p>
 </div>
 <table *ngIf="datasetDetail"
     mat-table
@@ -23,29 +23,29 @@
     <ng-container matColumnDef="formTitle">
       <th mat-header-cell *matHeaderCellDef>{{'Form'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet.formTitle }}
+        {{ dataSet?.formTitle }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="csvTemplateTitle">
       <th mat-header-cell *matHeaderCellDef>{{'Spreadsheet Template'|translate}}</th>
-      <td mat-cell *matCellDef="let dataSet">{{ dataSet.csvTemplateTitle }}</td>
+      <td mat-cell *matCellDef="let dataSet">{{ dataSet?.csvTemplateTitle }}</td>
     </ng-container>
     
     <ng-container matColumnDef="inProgress">
       <th mat-header-cell *matHeaderCellDef>{{'Status'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet.inProgress ? dataSet.skip : ''}} {{ dataSet.inProgress ? 'rows processed' : ''}}  
-        {{ dataSet.complete ? 'Complete' : '' | translate}}
-        {{ !dataSet.complete && !dataSet.inProgress ? 'Queued' : '' | translate}}
+        {{ dataSet?.inProgress ? dataSet?.skip : ''}} {{ dataSet?.inProgress ? 'rows processed' : ''}}  
+        {{ dataSet?.complete ? 'Complete' : '' | translate}}
+        {{ !dataSet?.complete && !dataSet?.inProgress ? 'Queued' : '' | translate}}
       </td>
     </ng-container>
     
     <ng-container matColumnDef="outputPath">
       <th mat-header-cell *matHeaderCellDef>{{'Download File'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">
-        <mat-spinner diameter=25 [hidden]="dataSet.complete || !dataSet.inProgress"></mat-spinner>
-        <a *ngIf="dataSet.complete" mat-icon-button [href]="datasetDetail.baseUrl+ dataSet.outputPath">
+        <mat-spinner diameter=25 [hidden]="dataSet?.complete || !dataSet?.inProgress"></mat-spinner>
+        <a *ngIf="dataSet?.complete" mat-icon-button [href]="datasetDetail?.baseUrl+ dataSet?.outputPath">
           <i class="material-icons mat-32 tangy-location-list-icon">get_app</i> download file
         </a>
       </td>

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
@@ -1,21 +1,21 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
-<div id="download-all-container">
-  <button mat-raised-button color="warn" [hidden]="!datasetDetail?.complete">
+<div id="download-all-container" >
+  <button mat-raised-button color="warn" [hidden]="!datasetDetail?.complete || stateUnavailable">
     <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
     {{'download all'|translate}}
   </button>
- <button mat-raised-button color="warn" [hidden]="datasetDetail?.complete" disabled>
+ <button mat-raised-button color="warn" [hidden]="datasetDetail?.complete || stateUnavailable" disabled>
     <mat-spinner diameter=25></mat-spinner> {{'download all'|translate}}
   </button>
 </div>
-<div *ngIf="datasetDetail" class="tangy-full-width">
+<div *ngIf="datasetDetail && !stateUnavailable" class="tangy-full-width">
     <p [hidden]="!datasetDetail?.description"><strong>{{'Description'|translate}}</strong>: {{datasetDetail?.description}}</p>
     <p><strong>{{'Include PII'|translate}}</strong>: {{datasetDetail?.includePii}}</p>
     <p><strong>{{"Status"|translate}}:</strong> {{datasetDetail?.complete? 'Complete':'In Progress' |translate}}</p>
     <p><strong>{{'Month'|translate}}:</strong> {{datasetDetail?.month === '*' ? 'All months' : datasetDetail?.month }}</p>
     <p><strong>{{'Year'|translate}}:</strong> {{datasetDetail?.year === '*' ? 'All years' : datasetDetail?.year }}</p>
 </div>
-<table *ngIf="datasetDetail"
+<table *ngIf="datasetDetail && !stateUnavailable"
     mat-table
     [dataSource]="datasetDetail.csvs"
     class="mat-elevation-z8 full-width"
@@ -54,3 +54,7 @@
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
   </table>
+
+<div *ngIf="stateUnavailable" class="tangy-full-width">
+  <p>{{'The state of this data set is unavailable.'|translate}}</p>
+</div>

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
@@ -1,17 +1,17 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 <div id="download-all-container" >
-  <button mat-raised-button color="warn" [hidden]="!datasetDetail?.complete || stateUnavailable">
+  <button mat-raised-button color="warn" *ngIf="datasetDetail?.status === 'Available' ">
     <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
     {{'download all'|translate}}
   </button>
- <button mat-raised-button color="warn" [hidden]="datasetDetail?.complete || stateUnavailable" disabled>
+ <button mat-raised-button color="warn" *ngIf="datasetDetail?.status === 'In progress'" disabled>
     <mat-spinner diameter=25></mat-spinner> {{'download all'|translate}}
   </button>
 </div>
 <div *ngIf="datasetDetail && !stateUnavailable" class="tangy-full-width">
+    <p><strong>{{"Status"|translate}}:</strong> {{datasetDetail?.status}}</p>
     <p [hidden]="!datasetDetail?.description"><strong>{{'Description'|translate}}</strong>: {{datasetDetail?.description}}</p>
-    <p><strong>{{'Include PII'|translate}}</strong>: {{datasetDetail?.includePii}}</p>
-    <p><strong>{{"Status"|translate}}:</strong> {{datasetDetail?.complete? 'Complete':'In Progress' |translate}}</p>
+    <p><strong>{{'Exclude PII'|translate}}</strong>: {{datasetDetail?.state?.excludePii ? 'Yes' : 'No'}}</p>
     <p><strong>{{'Month'|translate}}:</strong> {{datasetDetail?.month === '*' ? 'All months' : datasetDetail?.month }}</p>
     <p><strong>{{'Year'|translate}}:</strong> {{datasetDetail?.year === '*' ? 'All years' : datasetDetail?.year }}</p>
 </div>
@@ -56,5 +56,5 @@
   </table>
 
 <div *ngIf="stateUnavailable" class="tangy-full-width">
-  <p>{{'The state of this data set is unavailable.'|translate}}</p>
+  <p>{{'Looking for data...'|translate}}</p>
 </div>

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
@@ -1,15 +1,19 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
+<div id="download-all-container">
+  <button mat-raised-button color="warn" [hidden]="!datasetDetail.complete">
+    <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
+    {{'download all'|translate}}
+  </button>
+ <button mat-raised-button color="warn" [hidden]="datasetDetail.complete" disabled>
+    <mat-spinner diameter=25></mat-spinner> {{'download all'|translate}}
+  </button>
+</div>
 <div *ngIf="datasetDetail" class="tangy-full-width">
-    <p><strong>{{'File Name'|translate}}</strong>: 
-      <span *ngIf="!datasetDetail.complete">{{datasetDetail.fileName}}</span>
-      <a *ngIf="datasetDetail.complete" 
-          class="tangy-foreground-secondary" [href]="datasetDetail.downloadUrl">{{datasetDetail.fileName}}</a>
-    </p>
+    <p [hidden]="!datasetDetail.description"><strong>{{'Description'|translate}}</strong>: {{datasetDetail.description}}</p>
     <p><strong>{{'Include PII'|translate}}</strong>: {{datasetDetail.includePii}}</p>
     <p><strong>{{"Status"|translate}}:</strong> {{datasetDetail.complete? 'Complete':'In Progress' |translate}}</p>
-    <p><strong>{{'Month'|translate}}:</strong> {{datasetDetail.month?datasetDetail.month: '*'}}</p>
-    <p><strong>{{'Year'|translate}}:</strong> {{datasetDetail.year?datasetDetail.year: '*'}}</p>
-    <p><strong>{{'Created On'|translate}}:</strong> {{datasetDetail.dateCreated |date:'medium'}}</p>
+    <p><strong>{{'Month'|translate}}:</strong> {{datasetDetail.month === '*' ? 'All months' : datasetDetail.month }}</p>
+    <p><strong>{{'Year'|translate}}:</strong> {{datasetDetail.year === '*' ? 'All years' : datasetDetail.year }}</p>
 </div>
 <table *ngIf="datasetDetail"
     mat-table
@@ -18,18 +22,20 @@
   >
     <ng-container matColumnDef="formTitle">
       <th mat-header-cell *matHeaderCellDef>{{'Form'|translate}}</th>
-      <td mat-cell *matCellDef="let dataSet">{{ dataSet.formTitle }}</td>
+      <td mat-cell *matCellDef="let dataSet">
+        {{ dataSet.formTitle }}
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="csvTemplateTitle">
-      <th mat-header-cell *matHeaderCellDef>{{'CSV Template'|translate}}</th>
+      <th mat-header-cell *matHeaderCellDef>{{'Spreadsheet Template'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">{{ dataSet.csvTemplateTitle }}</td>
     </ng-container>
     
     <ng-container matColumnDef="inProgress">
       <th mat-header-cell *matHeaderCellDef>{{'Status'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet.inProgress ? 'In Progress' : '' | translate}}
+        {{ dataSet.inProgress ? dataSet.skip : ''}} {{ dataSet.inProgress ? 'rows processed' : ''}}  
         {{ dataSet.complete ? 'Complete' : '' | translate}}
         {{ !dataSet.complete && !dataSet.inProgress ? 'Queued' : '' | translate}}
       </td>
@@ -38,8 +44,9 @@
     <ng-container matColumnDef="outputPath">
       <th mat-header-cell *matHeaderCellDef>{{'Download File'|translate}}</th>
       <td mat-cell *matCellDef="let dataSet">
+        <mat-spinner diameter=25 [hidden]="dataSet.complete || !dataSet.inProgress"></mat-spinner>
         <a *ngIf="dataSet.complete" mat-icon-button [href]="datasetDetail.baseUrl+ dataSet.outputPath">
-          <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
+          <i class="material-icons mat-32 tangy-location-list-icon">get_app</i> download file
         </a>
       </td>
     </ng-container>

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.html
@@ -18,7 +18,7 @@
 <table *ngIf="datasetDetail"
     mat-table
     [dataSource]="datasetDetail.csvs"
-    class="mat-elevation-z8 tangy-full-width"
+    class="mat-elevation-z8 full-width"
   >
     <ng-container matColumnDef="formTitle">
       <th mat-header-cell *matHeaderCellDef>{{'Form'|translate}}</th>

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
@@ -4,6 +4,8 @@ import { Breadcrumb } from 'src/app/shared/_components/breadcrumb/breadcrumb.com
 import { _TRANSLATE } from 'src/app/shared/_services/translation-marker';
 import { GroupsService } from '../services/groups.service';
 import { TangerineFormsService } from '../services/tangerine-forms.service';
+import { DatePipe } from '@angular/common';
+import { ProcessMonitorService } from 'src/app/shared/_services/process-monitor.service';
 
 @Component({
   selector: 'app-csv-data-set-detail',
@@ -13,54 +15,60 @@ import { TangerineFormsService } from '../services/tangerine-forms.service';
 export class CsvDataSetDetailComponent implements OnInit, OnDestroy {
   breadcrumbs: Array<Breadcrumb> = [
     <Breadcrumb>{
-      label: _TRANSLATE('Download CSV Data Set'),
+      label: _TRANSLATE('Data Downloads'),
       url: 'csv-data-sets'
     }]
-  title = _TRANSLATE('View CSV Data Set Details')
+  title = '' 
   groupId;
   datasetId
   datasetDetail
   displayedColumns = ['formTitle','csvTemplateTitle','inProgress','outputPath']
   detailInterval:any
+  stopPolling = false
   constructor(
     private route: ActivatedRoute,
     private formService: TangerineFormsService,
+    private processMonitor: ProcessMonitorService,
     private groupsService: GroupsService
   ) { 
     this.datasetId = this.route.snapshot.paramMap.get('dataSetId')
     this.groupId = this.route.snapshot.paramMap.get('groupId')
-    this.breadcrumbs = [
-      ...this.breadcrumbs,
-      <Breadcrumb>{
-        label: _TRANSLATE('View CSV Data Set Details'),
-        url: `csv-data-sets/${this.datasetId}`
-      }
-    ]
   }
 
   async ngOnInit(){
+    const process = this.processMonitor.start('csv-data-set-detail', 'Loading details...')
     await this.getDatasetDetail()
-    this.detailInterval = setInterval(() => this.getDatasetDetail, 15*1000)
-    if(this.datasetDetail.complete){
-      clearInterval(this.detailInterval)
-    }
+    this.processMonitor.stop(process.id)
   }
 
-  ngOnDestroy() {
-    clearInterval(this.detailInterval)
+  ngOnDestroy(){
+    this.stopPolling = true
   }
 
   async getDatasetDetail(){
-    const datasetDetail = await this.groupsService.getDatasetDetail(this.datasetId)
+    const datasetDetail = <any>await this.groupsService.getDatasetDetail(this.datasetId)
+    const datePipe = new DatePipe('en-US')
+    if (!this.title) {
+      this.title = `Spreadsheets requested on ${datePipe.transform(datasetDetail.dateCreated, 'medium')}`
+      this.breadcrumbs = [
+        ...this.breadcrumbs,
+        <Breadcrumb>{
+          label: this.title,
+          url: `csv-data-sets/${this.datasetId}`
+        }
+      ]
+    }
     const csvTemplates = await this.formService.listCsvTemplates(this.groupId)
     const formsInfo = await this.formService.getFormsInfo(this.groupId)
-
     datasetDetail['csvs'] = datasetDetail['csvs'].map(csv =>{return {
       ...csv,
       csvTemplateTitle: csvTemplates.find(t => t._id === csv.csvTemplateId)?.title || _TRANSLATE('All data'),
       formTitle: formsInfo.find(f => f.id === csv.formId)?.title || csv.formId
     }})
     this.datasetDetail = datasetDetail
+    if(!this.datasetDetail.complete && !this.stopPolling){
+      setTimeout(() => this.getDatasetDetail(), 5*1000)
+    }
   }
 
 }

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
@@ -15,7 +15,7 @@ import { ProcessMonitorService } from 'src/app/shared/_services/process-monitor.
 export class CsvDataSetDetailComponent implements OnInit, OnDestroy {
   breadcrumbs: Array<Breadcrumb> = [
     <Breadcrumb>{
-      label: _TRANSLATE('Spreadsheets'),
+      label: _TRANSLATE('Spreadsheet Requests'),
       url: 'csv-data-sets'
     }]
   title = '' 

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
@@ -15,7 +15,7 @@ import { ProcessMonitorService } from 'src/app/shared/_services/process-monitor.
 export class CsvDataSetDetailComponent implements OnInit, OnDestroy {
   breadcrumbs: Array<Breadcrumb> = [
     <Breadcrumb>{
-      label: _TRANSLATE('Data Downloads'),
+      label: _TRANSLATE('Spreadsheets'),
       url: 'csv-data-sets'
     }]
   title = '' 

--- a/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
+++ b/editor/src/app/groups/csv-data-set-detail/csv-data-set-detail.component.ts
@@ -69,10 +69,13 @@ export class CsvDataSetDetailComponent implements OnInit, OnDestroy {
         formTitle: formsInfo.find(f => f.id === csv.formId)?.title || csv.formId
       }})
       this.datasetDetail = datasetDetail
-      if(!this.datasetDetail.complete && !this.stopPolling){
+      if(datasetDetail.status === 'In progress' && !this.stopPolling){
         setTimeout(() => this.getDatasetDetail(), 5*1000)
       }
     } 
+    else {
+      setTimeout(() => this.getDatasetDetail(), 5*1000)
+    }
   }
 
 }

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.css
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.css
@@ -13,3 +13,10 @@
 .instructions {
   margin: 1em;
 }
+
+.available {
+  color: green;
+}
+paper-progress {
+  margin: 15px auto;
+}

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -40,9 +40,10 @@
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef>Status</th>
       <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet.complete ? "Complete" : ("In Progress" | translate) }}
+        {{ dataSet.status | translate }}
       </td>
     </ng-container>
+
 
     <ng-container matColumnDef="numberOfSpreadsheets">
       <th mat-header-cell *matHeaderCellDef>{{ "Spreadsheets" | translate }}</th>
@@ -51,7 +52,7 @@
  
     <ng-container matColumnDef="details">
       <th mat-header-cell *matHeaderCellDef></th>
-      <td class="tangy-foreground-secondary link" [routerLink]="dataSet._id" mat-cell *matCellDef="let dataSet">
+      <td class="tangy-foreground-secondary link" [routerLink]="dataSet.id" mat-cell *matCellDef="let dataSet">
         <mwc-icon>info</mwc-icon> More info 
       </td>
     </ng-container>
@@ -63,7 +64,7 @@
         <a *ngIf="dataSet.complete && dataSet.fileExists" mat-icon-button [href]="dataSet.downloadUrl">
           <i class="material-icons mat-32 tangy-location-list-icon">get_app</i> Download
         </a>
-        <mat-spinner diameter=25 [hidden]="dataSet.complete"></mat-spinner>
+        <mat-spinner diameter=25 [hidden]="dataSet.complete || dataSet.status === 'Timed out' || dataSet.status === 'Unavailable'"></mat-spinner>
       </td>
     </ng-container>
 

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -61,10 +61,10 @@
       <th mat-header-cell *matHeaderCellDef>
       </th>
       <td class="tangy-foreground-secondary link" mat-cell *matCellDef="let dataSet">
-        <a *ngIf="dataSet.complete && dataSet.fileExists" mat-icon-button [href]="dataSet.downloadUrl">
+        <a *ngIf="dataSet.state?.complete && dataSet.fileExists" mat-icon-button [href]="dataSet.downloadUrl">
           <i class="material-icons mat-32 tangy-location-list-icon">get_app</i> Download
         </a>
-        <mat-spinner diameter=25 [hidden]="dataSet.complete || dataSet.status === 'Timed out' || dataSet.status === 'Unavailable'"></mat-spinner>
+        <mat-spinner diameter=25 [hidden]="dataSet.status !== 'In progress'"></mat-spinner>
       </td>
     </ng-container>
 

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -7,12 +7,16 @@
   </a>
 </div>
 
-<div class="tangy-full-width" [hidden]="!ready">
+<div class="tangy-full-width">
   <div class="instructions">
     <p>
       {{ "Spreadsheets generate in CSV format and may be opened in Excel, Google Sheets, or any other Spreadsheet program. " | translate }} 
     </p>
   </div>
+</div>
+
+<div class="tangy-full-width">
+
   <table mat-table [dataSource]="csvDataSets" class="mat-elevation-z8 tangy-full-width">
 
     <ng-container matColumnDef="dateCreated">
@@ -40,7 +44,12 @@
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef>Status</th>
       <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet.status | translate }}
+        <span *ngIf="dataSet.status === 'Available'" class="available">
+          {{ dataSet.status | translate }}
+        </span>
+        <span *ngIf="dataSet.status !== 'Available'">
+          {{ dataSet.status | translate }}
+        </span>
       </td>
     </ng-container>
 
@@ -80,8 +89,4 @@
     </p>
     <p>{{'No Datasets available'|translate}}</p>
   </div>
-</div>
-
-<div class="tangy-full-width" *ngIf="!ready" style="margin: 15px">
-  {{'Loading...'|translate}}
 </div>

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -2,23 +2,23 @@
 <div class="new-data-set-btn">
   <a routerLink="../csv-data-sets/new">
     <button mat-raised-button color="accent">
-      {{ "New CSV Data Set" | translate }}
+      <mwc-icon>add</mwc-icon> {{ "Request Spreadsheets" | translate }}
     </button>
   </a>
 </div>
 
 <div class="tangy-full-width" *ngIf="csvDataSets?.length>0">
   <div class="instructions">
-    <p>{{ "CSV Data sets are a collections of CSV files - one per form - that are downloaded via a zipped file. You may download a set of CSV's using the 'Download File' links below or configure a new CSV data set using the 'New CSV Data Set' link above. " | translate }} 
-    </p>
-    <p>{{ "You may monitor the progress of CSV file generation by clicking the link in the 'Status' column; this listing does not refresh the Status of a CSV Data Set generation automatically. When the CSV Data Set download file is complete, a link will be available in the 'Download File' column and the Status column will be marked 'Complete'. Clicking the link in the 'Status' column provides a listing of individual CSV files for download." | translate }} 
+    <p>
+      {{ "Spreadsheets generate in CSV format and may be opened in Excel, Google Sheets, or any other Spreadsheet program. " | translate }} 
     </p>
   </div>
   <table mat-table [dataSource]="csvDataSets" class="mat-elevation-z8 tangy-full-width">
-    <ng-container matColumnDef="fileName">
-      <th mat-header-cell *matHeaderCellDef>{{ "File Name" | translate }}</th>
+
+    <ng-container matColumnDef="dateCreated">
+      <th mat-header-cell *matHeaderCellDef>{{ "Requested On" | translate }}</th>
       <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet.fileName }}
+        {{ dataSet.dateCreated | date: "medium" }}
       </td>
     </ng-container>
 
@@ -27,38 +27,43 @@
       <td mat-cell *matCellDef="let dataSet">{{ dataSet?.description || "" }}</td>
     </ng-container>
 
-    <ng-container matColumnDef="month">
+   <ng-container matColumnDef="month">
       <th mat-header-cell *matHeaderCellDef>{{ "Month" | translate }}</th>
-      <td mat-cell *matCellDef="let dataSet">{{ dataSet.month || "*" }}</td>
+      <td mat-cell *matCellDef="let dataSet">{{ dataSet.month || "All months" }}</td>
     </ng-container>
 
     <ng-container matColumnDef="year">
       <th mat-header-cell *matHeaderCellDef>{{ "Year" | translate }}</th>
-      <td mat-cell *matCellDef="let dataSet">{{ dataSet.year || "*" }}</td>
-    </ng-container>
-
-    <ng-container matColumnDef="dateCreated">
-      <th mat-header-cell *matHeaderCellDef>{{ "Created On" | translate }}</th>
-      <td mat-cell *matCellDef="let dataSet">
-        {{ dataSet.dateCreated | date: "medium" }}
-      </td>
+      <td mat-cell *matCellDef="let dataSet">{{ dataSet.year || "All years" }}</td>
     </ng-container>
 
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef>Status</th>
-      <td class="tangy-foreground-secondary link" [routerLink]="dataSet._id" mat-cell *matCellDef="let dataSet">
+      <td mat-cell *matCellDef="let dataSet">
         {{ dataSet.complete ? "Complete" : ("In Progress" | translate) }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="numberOfSpreadsheets">
+      <th mat-header-cell *matHeaderCellDef>{{ "Spreadsheets" | translate }}</th>
+      <td mat-cell *matCellDef="let dataSet">{{ dataSet?.formIds.length || "" }}</td>
+    </ng-container>
+ 
+    <ng-container matColumnDef="details">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td class="tangy-foreground-secondary link" [routerLink]="dataSet._id" mat-cell *matCellDef="let dataSet">
+        <mwc-icon>info</mwc-icon> More info 
       </td>
     </ng-container>
 
     <ng-container matColumnDef="downloadUrl">
       <th mat-header-cell *matHeaderCellDef>
-        {{ "Download File" | translate }}
       </th>
-      <td mat-cell *matCellDef="let dataSet">
-        <a *ngIf="dataSet.complete&&dataSet.fileExists" mat-icon-button [href]="dataSet.downloadUrl">
-          <i class="material-icons mat-32 tangy-location-list-icon">get_app</i>
+      <td class="tangy-foreground-secondary link" mat-cell *matCellDef="let dataSet">
+        <a *ngIf="dataSet.complete && dataSet.fileExists" mat-icon-button [href]="dataSet.downloadUrl">
+          <i class="material-icons mat-32 tangy-location-list-icon">get_app</i> Download
         </a>
+        <mat-spinner diameter=25 [hidden]="dataSet.complete"></mat-spinner>
       </td>
     </ng-container>
 

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.html
@@ -7,7 +7,7 @@
   </a>
 </div>
 
-<div class="tangy-full-width" *ngIf="csvDataSets?.length>0">
+<div class="tangy-full-width" [hidden]="!ready">
   <div class="instructions">
     <p>
       {{ "Spreadsheets generate in CSV format and may be opened in Excel, Google Sheets, or any other Spreadsheet program. " | translate }} 
@@ -71,7 +71,7 @@
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
   </table>
-  <mat-paginator [length]="csvDataSets[0]?.numberOfDocs" (page)="onPageChange($event)" [pageSize]="pageSize" [pageSizeOptions]="[5, 10, 25, 100]"></mat-paginator>
+  <mat-paginator [length]="numberOfDatasets" (page)="onPageChange($event)" [pageSize]="pageSize" [pageSizeOptions]="[5, 10, 25, 100]"></mat-paginator>
 </div>
 
 <div class="tangy-full-width" *ngIf="csvDataSets?.length<1 && ready">

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
@@ -11,10 +11,10 @@ import { GroupsService } from '../services/groups.service';
   styleUrls: ['./csv-data-sets.component.css']
 })
 export class CsvDataSetsComponent implements OnInit {
-  title = _TRANSLATE('Download CSV Data Set')
+  title = _TRANSLATE('Spreadsheet Requests')
   breadcrumbs: Array<Breadcrumb> = []
   csvDataSets;
-  displayedColumns = ['fileName','description', 'month', 'year', 'dateCreated', 'status', 'downloadUrl']
+  displayedColumns = ['dateCreated', 'description', 'month', 'year', 'status', 'numberOfSpreadsheets', 'details', 'downloadUrl']
   groupId
   pageIndex = 0
   pageSize = 10
@@ -27,7 +27,7 @@ export class CsvDataSetsComponent implements OnInit {
     this.groupId = this.route.snapshot.paramMap.get('groupId')
     this.breadcrumbs = [
       <Breadcrumb>{
-        label: _TRANSLATE('Download CSV Data Set'),
+        label: this.title,
         url: 'csv-data-sets'
       }
     ]
@@ -45,7 +45,13 @@ export class CsvDataSetsComponent implements OnInit {
 
   async getData(){
     try {
-      this.csvDataSets = await this.groupsService.listCSVDataSets(this.groupId, this.pageIndex, this.pageSize)
+      const csvDataSets = <any>await this.groupsService.listCSVDataSets(this.groupId, this.pageIndex, this.pageSize)
+      this.csvDataSets = csvDataSets.map(csvDataSet => {
+        csvDataSet.formIds = csvDataSet.formIds.split(',')
+        csvDataSet.month = csvDataSet.month === '*' ? 'All months' : csvDataSet.month
+        csvDataSet.year = csvDataSet.year === '*' ? 'All years' : csvDataSet.year
+        return csvDataSet
+      })
       this.ready = true
     } catch (error) {
       this.errorHandler.handleError(_TRANSLATE('Could Not Contact Server.'))

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
@@ -4,6 +4,7 @@ import { Breadcrumb } from 'src/app/shared/_components/breadcrumb/breadcrumb.com
 import { TangyErrorHandler } from 'src/app/shared/_services/tangy-error-handler.service';
 import { _TRANSLATE } from 'src/app/shared/_services/translation-marker';
 import { GroupsService } from '../services/groups.service';
+import { ProcessMonitorService } from 'src/app/shared/_services/process-monitor.service';
 
 @Component({
   selector: 'app-csv-data-sets',
@@ -17,7 +18,7 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   displayedColumns = ['dateCreated', 'description', 'month', 'year', 'status', 'numberOfSpreadsheets', 'details', 'downloadUrl']
   groupId
   pageIndex = 0
-  pageSize = 10
+  pageSize = 5
   refreshTimeout:any
   numberOfDatasets = 0
   ready = false
@@ -25,6 +26,7 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   constructor(
     private groupsService: GroupsService,
     private errorHandler: TangyErrorHandler,
+    private processMonitorService: ProcessMonitorService,
     private route: ActivatedRoute
   ) {
     this.groupId = this.route.snapshot.paramMap.get('groupId')
@@ -37,7 +39,9 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
+    const process = this.processMonitorService.start('csv-data-sets', 'Loading Spreadsheet Requests...')
     await this.getData()
+    this.processMonitorService.stop(process.id)
   }
 
   ngOnDestroy() {
@@ -46,12 +50,14 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   }
 
   async onPageChange(event){
+    const process = this.processMonitorService.start('csv-data-sets', 'Loading Spreadsheet Requests...')
     this.ready = false
     clearTimeout(this.refreshTimeout)
     this.pageIndex = event.pageIndex
     this.pageSize = event.pageSize
     await this.getData()
     this.ready = true
+    this.processMonitorService.stop(process.id)
   }
 
   async getData(){

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
@@ -19,6 +19,7 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   pageIndex = 0
   pageSize = 10
   refreshTimeout:any
+  numberOfDatasets = 0
   ready = false
   stopPolling = false
   constructor(
@@ -45,16 +46,19 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   }
 
   async onPageChange(event){
+    this.ready = false
     clearTimeout(this.refreshTimeout)
     this.pageIndex = event.pageIndex
     this.pageSize = event.pageSize
     await this.getData()
+    this.ready = true
   }
 
   async getData(){
     try {
-      const csvDataSets = <any>await this.groupsService.listCSVDataSets(this.groupId, this.pageIndex, this.pageSize)
-      this.csvDataSets = csvDataSets.map(csvDataSet => {
+      const datasetsInfo = <any>await this.groupsService.listCSVDataSets(this.groupId, this.pageIndex, this.pageSize)
+      this.numberOfDatasets = datasetsInfo.numberOfDatasets
+      this.csvDataSets = datasetsInfo.datasets.map(csvDataSet => {
         csvDataSet.formIds = csvDataSet.state?.formIds || []
         csvDataSet.month = csvDataSet.month === '*' ? 'All months' : csvDataSet.month
         csvDataSet.year = csvDataSet.year === '*' ? 'All years' : csvDataSet.year

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
@@ -20,6 +20,7 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   pageSize = 10
   refreshTimeout:any
   ready = false
+  stopPolling = false
   constructor(
     private groupsService: GroupsService,
     private errorHandler: TangyErrorHandler,
@@ -39,6 +40,7 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.stopPolling = true
     clearTimeout(this.refreshTimeout)
   }
 
@@ -58,8 +60,8 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
         csvDataSet.year = csvDataSet.year === '*' ? 'All years' : csvDataSet.year
         return csvDataSet
       })
-      if (this.csvDataSets.find(csvDataSet => csvDataSet.status === 'In progress')) {
-        this.refreshTimeout = setTimeout(() => this.getData(), 5000)
+      if (this.csvDataSets.find(csvDataSet => csvDataSet.status === 'In progress') && !this.stopPolling) {
+        this.refreshTimeout = setTimeout(() => this.getData(), 10 * 1000)
       }
       this.ready = true
     } catch (error) {

--- a/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
+++ b/editor/src/app/groups/csv-data-sets/csv-data-sets.component.ts
@@ -53,12 +53,12 @@ export class CsvDataSetsComponent implements OnInit, OnDestroy {
     try {
       const csvDataSets = <any>await this.groupsService.listCSVDataSets(this.groupId, this.pageIndex, this.pageSize)
       this.csvDataSets = csvDataSets.map(csvDataSet => {
-        csvDataSet.formIds = csvDataSet.formIds.split(',')
+        csvDataSet.formIds = csvDataSet.state?.formIds || []
         csvDataSet.month = csvDataSet.month === '*' ? 'All months' : csvDataSet.month
         csvDataSet.year = csvDataSet.year === '*' ? 'All years' : csvDataSet.year
         return csvDataSet
       })
-      if (this.csvDataSets.find(csvDataSet => csvDataSet.complete === false)) {
+      if (this.csvDataSets.find(csvDataSet => csvDataSet.status === 'In progress')) {
         this.refreshTimeout = setTimeout(() => this.getData(), 5000)
       }
       this.ready = true

--- a/editor/src/app/groups/csv-template/csv-template.component.ts
+++ b/editor/src/app/groups/csv-template/csv-template.component.ts
@@ -14,7 +14,7 @@ import { TangerineFormInfo } from 'src/app/shared/_classes/tangerine-form.class'
 })
 export class CsvTemplateComponent implements OnInit {
 
-  title = _TRANSLATE('CSV Template')
+  title = _TRANSLATE('Spreadsheet Template')
   breadcrumbs:Array<Breadcrumb> = []
 
   formId:string
@@ -54,7 +54,7 @@ export class CsvTemplateComponent implements OnInit {
       this.formsInfo = await this.formsService.getFormsInfo(this.groupId)
       this.breadcrumbs = [
         <Breadcrumb>{
-          label: _TRANSLATE('CSV Templates'),
+          label: 'Spreadsheet Templates',
           url: 'csv-templates'
         },
         <Breadcrumb>{

--- a/editor/src/app/groups/group-csv-templates/group-csv-templates.component.css
+++ b/editor/src/app/groups/group-csv-templates/group-csv-templates.component.css
@@ -1,3 +1,10 @@
 #description {
   margin: 15px;
 }
+#no-spreadsheets {
+  padding: 15px;
+  margin: 15px;
+  width: 100%;
+  background: #FFF;
+  text-align: center;
+}

--- a/editor/src/app/groups/group-csv-templates/group-csv-templates.component.html
+++ b/editor/src/app/groups/group-csv-templates/group-csv-templates.component.html
@@ -1,7 +1,16 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 <div id="description">
-  {{'CSV Template are filters for CSV output that allow you to define which columns to include in our CSV file for specific forms. Define a CSV Template for a specific form and then when selecting which forms to include in a CSV Data Set, the CSV Templates will be available to apply to the CSV Data Set output.'|translate}}
+  {{'Spreadsheet Templates allow you to define which columns and the order of columns on a Spreadsheet.'|translate}}
 </div>
-<app-dynamic-table [data]="csvTemplates" (rowDelete)="onRowDelete($event)" (rowEdit)="onRowEdit($event)"></app-dynamic-table>
+<app-dynamic-table 
+  *ngIf="csvTemplates.length > 0"
+  [data]="csvTemplates" 
+  (rowDelete)="onRowDelete($event)" 
+  (rowEdit)="onRowEdit($event)"
+>
+</app-dynamic-table>
+<div *ngIf="csvTemplates.length === 0" id="no-spreadsheets">
+  {{'No Spreadsheet Templates have been created. Click the + icon in the bottom right to get started.'|translate}}
+</div>
 <paper-fab (click)="createCsvTemplate()" mat-raised-button icon="add" color="accent" class="action">
 </paper-fab>

--- a/editor/src/app/groups/group-csv-templates/group-csv-templates.component.ts
+++ b/editor/src/app/groups/group-csv-templates/group-csv-templates.component.ts
@@ -11,10 +11,10 @@ import { CsvTemplate, TangerineFormsService } from '../services/tangerine-forms.
 })
 export class GroupCsvTemplatesComponent implements OnInit {
 
-  title = _TRANSLATE('CSV Templates')
+  title = _TRANSLATE('Spreadsheet Templates')
   breadcrumbs:Array<Breadcrumb> = [
     <Breadcrumb>{
-      label: _TRANSLATE('CSV Templates'),
+      label: _TRANSLATE('Spreadsheet Templates'),
       url: 'csv-templates'
     }
   ]

--- a/editor/src/app/groups/group-data/group-data.component.html
+++ b/editor/src/app/groups/group-data/group-data.component.html
@@ -37,7 +37,7 @@
         <mwc-icon class="tangy-foreground-secondary">table_chart</mwc-icon>
       </div>
       <mat-card-title>
-        <a>{{'Spreadsheets'|translate}}</a>
+        <a>{{'Download Data/Exports'|translate}}</a>
       </mat-card-title>
       <mat-card-subtitle>{{"Request multiple Spreadsheets at once, view Spreadsheets you've requested in the past, and manage Spreadsheet Templates which you can use to control the order of columns and which variables show up on Spreadsheets." |translate}}</mat-card-subtitle>
     </mat-card-header>

--- a/editor/src/app/groups/group-data/group-data.component.html
+++ b/editor/src/app/groups/group-data/group-data.component.html
@@ -22,7 +22,7 @@
           <mat-card-title>
               <a>{{'Case Management'|translate}}</a>
           </mat-card-title>
-          <mat-card-subtitle>{{'Review uploaded cases and related issues.'|translate}}</mat-card-subtitle>
+          <mat-card-subtitle>{{'Review uploaded cases and related Issues.'|translate}}</mat-card-subtitle>
       </mat-card-header>
       <mat-card-actions>
       <button mat-stroked-button color="accent" routerLink="cases"><mwc-icon class="tangy-foreground-secondary">folder</mwc-icon> {{'Cases'|translate}}</button>
@@ -34,19 +34,18 @@
   <mat-card *appHasAPermission="let i;group:groupId; permission:'can_access_download_csv'" class="mat-elevation-z3">
     <mat-card-header>
       <div mat-card-avatar>
-        <mwc-icon class="tangy-foreground-secondary">file_download</mwc-icon>
+        <mwc-icon class="tangy-foreground-secondary">table_chart</mwc-icon>
       </div>
       <mat-card-title>
-        <a>{{'Data Downloads'|translate}}</a>
+        <a>{{'Spreadsheets'|translate}}</a>
       </mat-card-title>
-      <mat-card-subtitle>{{"Create multiple Spreadsheets at once, view Spreadsheets you've generated in the past, and manage Spreadsheet Templates which you can use to control the order of columns and which variables show up on Spreadsheets." |translate}}</mat-card-subtitle>
+      <mat-card-subtitle>{{"Request multiple Spreadsheets at once, view Spreadsheets you've requested in the past, and manage Spreadsheet Templates which you can use to control the order of columns and which variables show up on Spreadsheets." |translate}}</mat-card-subtitle>
     </mat-card-header>
     <mat-card-actions>
-      <button mat-stroked-button color="accent" routerLink="csv-data-sets/new"><mwc-icon>add</mwc-icon> {{'Create Spreadsheets'|translate}}</button>
-      <button mat-stroked-button color="accent" routerLink="csv-data-sets"><mwc-icon>list</mwc-icon> {{'List Spreadsheets'|translate}}</button>
+      <button mat-stroked-button color="accent" routerLink="csv-data-sets/new"><mwc-icon>add</mwc-icon> {{'Request Spreadsheets'|translate}}</button>
+      <button mat-stroked-button color="accent" routerLink="csv-data-sets"><mwc-icon>list</mwc-icon> {{'Spreadsheet Requests'|translate}}</button>
       <button mat-stroked-button color="accent" routerLink="csv-templates"><mwc-icon>table_view</mwc-icon> {{'Manage Spreadsheet Templates'|translate}}</button>
     </mat-card-actions>
-
   </mat-card>
 
   <span *ngIf="config.enabledModules.includes('sync-protocol-2')">
@@ -58,7 +57,7 @@
           <mat-card-title>
             <a>{{'Database Conflicts'|translate}}</a>
           </mat-card-title>
-          <mat-card-subtitle>{{'Review Database Conflicts.'|translate}}</mat-card-subtitle>
+          <mat-card-subtitle>{{'Review Database Conflicts. Database Conflicts occur when the same Form or Case is modified in two different Devices between syncs. Use Active Conflicts tool to resolve conflicts and Archived Conflicts to see conflicts you have resolved in the past.'|translate}}</mat-card-subtitle>
       </mat-card-header>
     </mat-card>
   </span>

--- a/editor/src/app/groups/group-data/group-data.component.html
+++ b/editor/src/app/groups/group-data/group-data.component.html
@@ -1,6 +1,6 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 
-<ng-container *ngIf="groupId">
+<ng-container *ngIf="ready">
 
   <mat-card *appHasAPermission="let i;group:groupId; permission:'can_access_dashboard'" class="is-link mat-elevation-z3" routerLink="../dashboard">
     <mat-card-header>
@@ -25,8 +25,8 @@
           <mat-card-subtitle>{{'Review uploaded cases and related issues.'|translate}}</mat-card-subtitle>
       </mat-card-header>
       <mat-card-actions>
-      <button mat-stroked-button color="accent" routerLink="cases">{{'Cases'|translate}}</button>
-      <button mat-stroked-button color="accent" *appHasAPermission="let i;group:groupId; permission:'can_access_issues'" routerLink="issues">{{'Issues'|translate}}</button>
+      <button mat-stroked-button color="accent" routerLink="cases"><mwc-icon class="tangy-foreground-secondary">folder</mwc-icon> {{'Cases'|translate}}</button>
+      <button mat-stroked-button color="accent" *appHasAPermission="let i;group:groupId; permission:'can_access_issues'" routerLink="issues"><mwc-icon>bug_report</mwc-icon> {{'Issues'|translate}}</button>
     </mat-card-actions>
     </mat-card>
   </span>
@@ -34,17 +34,17 @@
   <mat-card *appHasAPermission="let i;group:groupId; permission:'can_access_download_csv'" class="mat-elevation-z3">
     <mat-card-header>
       <div mat-card-avatar>
-        <mwc-icon class="tangy-foreground-secondary">view_module</mwc-icon>
+        <mwc-icon class="tangy-foreground-secondary">file_download</mwc-icon>
       </div>
       <mat-card-title>
-        <a>{{'CSV Output'|translate}}</a>
+        <a>{{'Data Downloads'|translate}}</a>
       </mat-card-title>
-      <mat-card-subtitle>{{'Download or configure a CSV Data Set, which is a zipped collection of CSVs. Configure the fields included in the CSV data output of a form using CSV Templates. The "Download individual CSVs" feature will be merged soon with the CSV Data Set feature soon since it has similar output.' |translate}}</mat-card-subtitle>
+      <mat-card-subtitle>{{"Create multiple Spreadsheets at once, view Spreadsheets you've generated in the past, and manage Spreadsheet Templates which you can use to control the order of columns and which variables show up on Spreadsheets." |translate}}</mat-card-subtitle>
     </mat-card-header>
     <mat-card-actions>
-      <button mat-stroked-button color="accent" routerLink="csv-data-sets">{{'Download CSV Data Set'|translate}}</button>
-      <button mat-stroked-button color="accent" routerLink="csv-templates">{{'CSV Templates for CSV Data Sets'|translate}}</button>
-      <button mat-stroked-button color="accent" routerLink="download-csv">{{'Download individual CSVs (deprecated)'|translate}}</button>
+      <button mat-stroked-button color="accent" routerLink="csv-data-sets/new"><mwc-icon>add</mwc-icon> {{'Create Spreadsheets'|translate}}</button>
+      <button mat-stroked-button color="accent" routerLink="csv-data-sets"><mwc-icon>list</mwc-icon> {{'List Spreadsheets'|translate}}</button>
+      <button mat-stroked-button color="accent" routerLink="csv-templates"><mwc-icon>table_view</mwc-icon> {{'Manage Spreadsheet Templates'|translate}}</button>
     </mat-card-actions>
 
   </mat-card>
@@ -63,7 +63,7 @@
     </mat-card>
   </span>
   
-  <mat-card *appHasAPermission="let i;group:groupId; permission:'can_access_uploads'" class="is-link mat-elevation-z3" routerLink="uploads">
+  <mat-card *appHasAPermission="let i;group:groupId; permission:'can_access_uploads'" class="is-link mat-elevation-z3" routerLink="uploads" [hidden]="!showUploads">
     <mat-card-header>
       <div mat-card-avatar>
         <mwc-icon class="tangy-foreground-secondary">cloud_upload</mwc-icon>

--- a/editor/src/app/groups/group-data/group-data.component.ts
+++ b/editor/src/app/groups/group-data/group-data.component.ts
@@ -3,6 +3,10 @@ import { Breadcrumb } from './../../shared/_components/breadcrumb/breadcrumb.com
 import { ActivatedRoute } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { UserService } from 'src/app/core/auth/_services/user.service';
+import { ProcessMonitorService } from 'src/app/shared/_services/process-monitor.service';
+import { HttpClient } from '@angular/common/http';
+import { AppConfig } from '../../../../../client/src/app/shared/_classes/app-config.class';
+import { FormInfo } from 'src/app/tangy-forms/classes/form-info.class';
 
 @Component({
   selector: 'app-group-data',
@@ -14,18 +18,35 @@ export class GroupDataComponent implements OnInit {
   title = 'Data'
   breadcrumbs:Array<Breadcrumb> = []
   config:any = { enabledModules: [] }
+  ready = false
   groupId;
+  showUploads:boolean
 
   constructor(
     private serverConfig: ServerConfigService,
     private userService:UserService,
-    private route:ActivatedRoute
+    private http: HttpClient,
+    private route: ActivatedRoute,
+    private processMonitor:ProcessMonitorService
   ) { }
 
   async ngOnInit() {
+    const process = this.processMonitor.start('group-data', 'Loading...')
     this.config = await this.serverConfig.getServerConfig()
-    this.breadcrumbs = []
     this.groupId = this.route.snapshot.paramMap.get('groupId');
+    const forms = <Array<FormInfo>>await this.http.get('./assets/forms.json').toPromise()
+    const appConfig = <AppConfig>await this.http.get('./assets/app-config.json').toPromise()
+    // Show uploads if this is not a Case module group or if it is a Case module group and there is a form listed for being created independent of a Case.
+    if (
+      appConfig.homeUrl !== 'case-home' ||
+      forms.find(form => form.type !== 'case' && form.listed === true)
+    ) {
+      this.showUploads = true
+    } else {
+      this.showUploads = false
+    }
+    this.ready = true
+    this.processMonitor.stop(process.id)
   }
 
 }

--- a/editor/src/app/groups/groups.module.ts
+++ b/editor/src/app/groups/groups.module.ts
@@ -66,6 +66,7 @@ import { GroupReleasesComponent } from './group-releases/group-releases.componen
 import { GroupFormsEditComponent } from './group-forms-edit/group-forms-edit.component';
 import { GroupLocationListComponent } from './group-location-list/group-location-list.component';
 import { GroupDeviceUsersComponent } from './group-device-users/group-device-users.component';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner'
 import { GroupUploadsComponent } from './group-uploads/group-uploads.component';
 import { GroupReleaseApkTestComponent } from './group-release-apk-test/group-release-apk-test.component';
 import { GroupReleaseApkLiveComponent } from './group-release-apk-live/group-release-apk-live.component';
@@ -120,6 +121,7 @@ import { GroupDevicePasswordPolicyComponent } from './group-device-password-poli
     MatIconModule,
     MatMenuModule,
     MatTreeModule,
+    MatProgressSpinnerModule,
     MatGridListModule,
     MatSelectModule,
     MatFormFieldModule,

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.css
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.css
@@ -14,7 +14,7 @@ button {
   padding-top: 0px;
 }
 
-#container {
+.container {
     margin: 15px;
   }
   

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.css
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.css
@@ -29,6 +29,15 @@ button {
 .form-list{
   margin-top: 2rem;
 }
+#description, #year-and-month {
+  margin: 20px;
+}
+#description, #description input, #description mat-form-field {
+  width: 80%;
+}
+
+#description mat-form-field {
+}
 
 .csv-template-selection {
   position: relative;
@@ -45,6 +54,22 @@ table {
 
 .configure-instructions {
   margin: 1rem;
+}
+
+#submit-container {
+  position: sticky;
+  bottom: 0px;
+  right: 0px;
+  background: #CCC;
+  text-align: right;
+  padding: 0px 30px 10px;
+  border-top: solid 1px;
+}
+
+#submit-container button {
+  position: relative;
+  bottom: 15px;
+  right: 60px;
 }
 
 .select-instructions {

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.html
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.html
@@ -1,9 +1,11 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 
-<div class="tangy-full-width" id="container">
-  <div class="configure-instructions">{{ "Configure the date range (optional), data set description, Personal Identifiable Information (PII) exclusion, and which forms to generate Spreadsheets for." | translate }}</div>
+<div class="full-width">
+  <div class="container">
+    <div class="configure-instructions">{{ "Configure the date range (optional), data set description, Personal Identifiable Information (PII) exclusion, and which forms to generate Spreadsheets for." | translate }}</div>
+  </div>
   <form class="form">
-    <div>
+    <div class="container">
       <div id="year-and-month">
         <mat-form-field appearance="fill" color="primary">
           <mat-label>{{ "Month" | translate }}</mat-label>
@@ -44,8 +46,8 @@
           >
         </mat-form-field>
       </div>
+      <div class="select-instructions">{{ "Click the checkbox to the left of the 'Form title' column to select all forms. If there is a Spreadsheet Template available for a form, it will be displayed in the form's Spreadsheet Template dropdown." | translate }}</div>
     </div>
-    <div class="select-instructions">{{ "Click the checkbox to the left of the 'Form title' column to select all forms. If there is a Spreadsheet Template available for a form, it will be displayed in the form's Spreadsheet Template dropdown." | translate }}</div>
     <table class="form-list materialish">
       <tr class="table-header new-csv-header">
         <td>
@@ -76,7 +78,7 @@
       </tr>
     </table>
     <div id="submit-container">
-      <button mat-raised-button color="warn" (click)="process()" [disabled]="selectedForms.length<1">{{'Create Spreadsheets'|translate}}</button>
+      <button mat-raised-button color="warn" (click)="process()" [disabled]="selectedForms.length<1">{{'Submit Request'|translate}}</button>
     </div>
   </form>
 </div>

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.html
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.html
@@ -1,46 +1,51 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 
 <div class="tangy-full-width" id="container">
-  <div class="configure-instructions">{{ "Configure the date range (optional), data set description, Personal Identifiable Information (PII) exclusion, and forms for the CSV data set." | translate }}</div>
+  <div class="configure-instructions">{{ "Configure the date range (optional), data set description, Personal Identifiable Information (PII) exclusion, and which forms to generate Spreadsheets for." | translate }}</div>
   <form class="form">
     <div>
-      <mat-form-field appearance="fill" color="primary">
-        <mat-label>{{ "Month" | translate }}</mat-label>
-        <mat-select
-          name="selectedMonth"
-          class="month"
-          [(ngModel)]="selectedMonth"
-        >
-          <mat-option value="*" selected="selected">*</mat-option>
-          <mat-option *ngFor="let month of months" value="{{ month }}">{{
-            month
-          }}</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <mat-form-field appearance="fill" color="primary">
-        <mat-label>{{ "Year" | translate }}</mat-label>
-        <mat-select name="selectedYear" class="year" [(ngModel)]="selectedYear">
-          <mat-option value="*" selected="selected">*</mat-option>
-          <mat-option *ngFor="let year of years" value="{{ year }}">{{
-            year
-          }}</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <mat-form-field>
-        <input
-            name="descriptionInput"
-            [(ngModel)]="description"
-            #groupNameInput="ngModel"
-            matInput
-            placeholder="{{'Description'|translate}}"
-            required
-        >
-    </mat-form-field>
-      <mat-checkbox name="excludePII" [(ngModel)]="excludePII"
-        >{{ "Exclude PII?" | translate }}
-      </mat-checkbox>
+      <div id="year-and-month">
+        <mat-form-field appearance="fill" color="primary">
+          <mat-label>{{ "Month" | translate }}</mat-label>
+          <mat-select
+            name="selectedMonth"
+            class="month"
+            [(ngModel)]="selectedMonth"
+          >
+            <mat-option value="*" selected="selected">All months</mat-option>
+            <mat-option *ngFor="let month of months" value="{{ month }}">{{
+              month
+            }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="fill" color="primary">
+          <mat-label>{{ "Year" | translate }}</mat-label>
+          <mat-select name="selectedYear" class="year" [(ngModel)]="selectedYear">
+            <mat-option value="*" selected="selected">All years</mat-option>
+            <mat-option *ngFor="let year of years" value="{{ year }}">{{
+              year
+            }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-checkbox name="excludePII" [(ngModel)]="excludePII"
+          >{{ "Exclude PII?" | translate }}
+        </mat-checkbox>
+      </div>
+      <div
+        id="description"
+      >
+        <mat-form-field>
+          <input
+              name="descriptionInput"
+              [(ngModel)]="description"
+              #groupNameInput="ngModel"
+              matInput
+              placeholder="{{'Description'|translate}}"
+          >
+        </mat-form-field>
+      </div>
     </div>
-    <div class="select-instructions">{{ "Click the checkbox to the left of the 'Form title' column to select all forms. If there is a CSV Template available for a form, it will be displayed in the form's CSV Template dropdown." | translate }}</div>
+    <div class="select-instructions">{{ "Click the checkbox to the left of the 'Form title' column to select all forms. If there is a Spreadsheet Template available for a form, it will be displayed in the form's Spreadsheet Template dropdown." | translate }}</div>
     <table class="form-list materialish">
       <tr class="table-header new-csv-header">
         <td>
@@ -50,7 +55,7 @@
           Form Title
         </td>
         <td>
-          CSV Template
+          Spreadsheet Template
         </td>
       </tr>
       <tr *ngFor="let form of forms" >
@@ -70,6 +75,8 @@
         </td>
       </tr>
     </table>
-    <button mat-raised-button color="warn" (click)="process()" [disabled]="selectedForms.length<1||!description">{{'Submit'|translate}}</button>
+    <div id="submit-container">
+      <button mat-raised-button color="warn" (click)="process()" [disabled]="selectedForms.length<1">{{'Create Spreadsheets'|translate}}</button>
+    </div>
   </form>
 </div>

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.ts
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.ts
@@ -14,7 +14,7 @@ import { TangerineFormsService } from '../services/tangerine-forms.service';
   styleUrls: ['./new-csv-data-set.component.css']
 })
 export class NewCsvDataSetComponent implements OnInit {
-  title = _TRANSLATE('Create Spreadsheets')
+  title = _TRANSLATE('Request Spreadsheets')
   breadcrumbs: Array<Breadcrumb> = [
     <Breadcrumb>{
       label: _TRANSLATE('Spreadsheets'),
@@ -45,7 +45,7 @@ export class NewCsvDataSetComponent implements OnInit {
     this.breadcrumbs = [
       ...this.breadcrumbs,
       <Breadcrumb>{
-        label: _TRANSLATE('Create Spreadsheets'),
+        label: this.title,
         url: 'csv-data-sets/new'
       },
     ]

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.ts
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.ts
@@ -14,10 +14,10 @@ import { TangerineFormsService } from '../services/tangerine-forms.service';
   styleUrls: ['./new-csv-data-set.component.css']
 })
 export class NewCsvDataSetComponent implements OnInit {
-  title = _TRANSLATE('New CSV Data Set')
+  title = _TRANSLATE('Create Spreadsheets')
   breadcrumbs: Array<Breadcrumb> = [
     <Breadcrumb>{
-      label: _TRANSLATE('Download CSV Data Set'),
+      label: _TRANSLATE('Spreadsheets'),
       url: 'csv-data-sets'
     }]
 
@@ -45,7 +45,7 @@ export class NewCsvDataSetComponent implements OnInit {
     this.breadcrumbs = [
       ...this.breadcrumbs,
       <Breadcrumb>{
-        label: _TRANSLATE('New CSV Data Set'),
+        label: _TRANSLATE('Create Spreadsheets'),
         url: 'csv-data-sets/new'
       },
     ]
@@ -104,7 +104,7 @@ export class NewCsvDataSetComponent implements OnInit {
     try {
       const result: any = await this.groupsService.downloadCSVDataSet(this.groupId, forms, this.selectedYear, this.selectedMonth, this.description, this.excludePII);
       this.stateUrl = result.stateUrl;
-      this.router.navigate([`../`], { relativeTo: this.route })
+      this.router.navigate(['../', result.id], { relativeTo: this.route })
     } catch (error) {
       console.log(error);
     }

--- a/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.ts
+++ b/editor/src/app/groups/new-csv-data-set/new-csv-data-set.component.ts
@@ -17,7 +17,7 @@ export class NewCsvDataSetComponent implements OnInit {
   title = _TRANSLATE('Request Spreadsheets')
   breadcrumbs: Array<Breadcrumb> = [
     <Breadcrumb>{
-      label: _TRANSLATE('Spreadsheets'),
+      label: _TRANSLATE('Spreadsheet Requests'),
       url: 'csv-data-sets'
     }]
 

--- a/editor/src/styles.css
+++ b/editor/src/styles.css
@@ -58,6 +58,10 @@ table.materialish td {
   color: #777;
 }
 
+.full-width {
+  width: 100%;
+}
+
 
 .container {
   margin: 15px;

--- a/server/src/routes/group-csv.js
+++ b/server/src/routes/group-csv.js
@@ -156,6 +156,7 @@ const getDatasetDetail = async (req, res) => {
   const http = await getUser1HttpInterface()
   res.send({
      ...(await http.get(result.stateUrl)).data, 
+     description: result.description,
      month: result.month,
      year: result.year,
      downloadUrl: result.downloadUrl,

--- a/server/src/routes/group-csv.js
+++ b/server/src/routes/group-csv.js
@@ -95,7 +95,7 @@ const generateCSVDataSet = async (req, res) => {
   })
   const stateUrl = `${process.env.T_PROTOCOL}://${process.env.T_HOST_NAME}/csv/${fileName.replace('.zip', '.state.json')}`
   const downloadUrl = `${process.env.T_PROTOCOL}://${process.env.T_HOST_NAME}/csv/${fileName}`
-  await CSV_DATASETS.post({
+  const csvDataSetInfo = await CSV_DATASETS.post({
     groupId,
     formIds,
     fileName,
@@ -107,6 +107,7 @@ const generateCSVDataSet = async (req, res) => {
     dateCreated: Date.now()
   })
   res.send({
+    id: csvDataSetInfo.id,
     stateUrl,
     downloadUrl
   })

--- a/server/src/scripts/generate-csv-data-set/generate-csv-data-set.js
+++ b/server/src/scripts/generate-csv-data-set/generate-csv-data-set.js
@@ -20,7 +20,7 @@ async function getUser1HttpInterface() {
   return http
 }
 const writeState = async function (state) {
-  await writeFile(state.statePath, JSON.stringify(state, null, 2))
+  await writeFile(state.statePath, JSON.stringify({ ...state, updatedOn: Date.now() }, null, 2))
 }
 const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true), milliseconds))
 


### PR DESCRIPTION
## Changes
- Change terminology referring to "CSV" to more commonly recognized "Spreadsheet" term.
- "CSV Datasets" term changed to "Spreadsheet Requests". 
- Fix "CSV Datasets are not filtering by month and year when a 'Month' and 'Year' is selected #3181"
- Request Spreadsheets page: Submit button now hovers and is sticky to bottom of page; "*" in Month/Year selection clarified as "All months"/"All years"; "Description" no longer required and given own line for better formatting; other formatting cleanup.
- Data page: Removed deprecated CSV Download button; updated language; added "Request Spreadsheets" button for quick access to making a request for spreadsheets.
- Spreadsheet Request Info page: Now dynamically updates as Spreadsheets are rendered with row counts and status; removed unnecessary filename to download all, instead it's a "download all" button; new types of status including "File removed", "Stopped", "Available", and "In progress"; Month and Year values of "*" now clarified as "All months" and "All years"; loading screen improvements; title of page now the date the spreadsheets were requested on.
- Spreadsheet Requests page: Updated language; fixed total Spreadsheet Requests calculation in pagination; if status of Spreadsheet Request is "Available" the status shows in green; if the status of the Spreadsheet Request is "In progress" a spinner is shown where the Download button will be; labels of "More Info" and "Download" added to corresponding buttons; loading overlay now shown on initial load and when changing pages.
- Spreadsheet Templates page: Updated terminology from CSV Templates to Spreadsheet Templates.

## Screenshots
<img width="865" alt="Screen Shot 2022-01-26 at 9 23 16 AM" src="https://user-images.githubusercontent.com/156575/151180476-1fb57034-6d39-48fb-848b-b0c272408fd1.png">

<img width="862" alt="Screen Shot 2022-01-26 at 9 24 01 AM" src="https://user-images.githubusercontent.com/156575/151180602-cbdbe668-9070-4bea-beeb-a1d2dc2990d6.png">

<img width="863" alt="Screen Shot 2022-01-26 at 9 23 05 AM" src="https://user-images.githubusercontent.com/156575/151180643-232fff2f-73cc-496e-a99d-8f178ae0a328.png">

<img width="863" alt="Screen Shot 2022-01-26 at 9 22 50 AM" src="https://user-images.githubusercontent.com/156575/151180665-5f64ed29-83af-4586-8afc-c93ba2d0e090.png">
