### PR TITLE
Fix after update messaging and async issues

### DIFF
--- a/client/src/app/core/update/update/update.component.ts
+++ b/client/src/app/core/update/update/update.component.ts
@@ -132,7 +132,6 @@ export class UpdateComponent implements AfterContentInit {
       const deviceToken = device.token
       
       await this.deviceService.didUpdate(deviceId, deviceToken, replicationStatus)
-      this.message = _TRANSLATE('✓ Yay! You are up to date.')
     }
     
     if (afterCustomUpdates) {
@@ -142,6 +141,7 @@ export class UpdateComponent implements AfterContentInit {
       } catch (e) {
         console.log("Error: " + e)
       }
+      this.message = _TRANSLATE('✓ Yay! You are up to date.')
     }
 
     /*

--- a/client/src/app/shared/_services/update.service.ts
+++ b/client/src/app/shared/_services/update.service.ts
@@ -223,17 +223,17 @@ export class UpdateService {
   
   async runCustomUpdatesBefore(customUpdates) {
     this.status$.next(_TRANSLATE(`Applying Custom Update before Main Updates. `))
-    // TODO capture output of script and pass up to the component
-    await eval("(async () => {" + customUpdates + "})()")
+    // Expose a generic log function for custom updates.
+    const log = this.status$.next
+    eval(customUpdates)
     this.status$.next(_TRANSLATE(`Finished Custom Update before Main Updates. `))
   }
   
   async runCustomUpdatesAfter(customUpdates) {
     this.status$.next(_TRANSLATE(`Applying Custom Update after Main Updates. `))
-    // TODO capture output of script and pass up to the component
-    eval(`(() => {${customUpdates}})()`).then(function() {
-      this.status$.next(_TRANSLATE(`Finished Custom Update after Main Updates. `))
-      console.log("done");
-    });
+    // Expose a generic log function for custom updates.
+    const log = this.status$.next
+    eval(customUpdates)
+    this.status$.next(_TRANSLATE(`Finished Custom Update after Main Updates. `))
   }
 }


### PR DESCRIPTION
## Description

Currently, when a tablet finishes updating, the "Finished Custom Update after Main Updates." message shows instead of the '✓ Yay! You are up to date.' message. The first commit on this PR makes sure that the '✓ Yay! You are up to date.' message is applied after the custom custom updates to fix this issue. The second commit fixes what I think has been preventing await from working properly in a custom after update. That second PR also refactors the structure of both custom before and after updates so they can be written flat as opposed to having to return a promise.

For example, before:

```javascript
return new Promise(async(resolve, reject) => {
  await something()
  await somethingElse()
 })
```

... can now be written as...

```javascript
await something()
await somethingElse()
```

Lastly, the second commit also exposes a log function that will update the message on the screen.

```javascript
log('Doing something...')
await something()
log('Doing something else...')
await somethingElse()
```

## Type of Change

This PR is all of these:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Notices, Regressions, Breaking Changes
Previously written custom updates scripts won't work anymore. @chrisekelley Will this be a problem are all of the custom update scripts behind us?
