### PR TITLE
Feature/add support for showing photo and signature in issue diffs

### DIFF
--- a/editor/src/app/case/components/issue/diff-template.ts
+++ b/editor/src/app/case/components/issue/diff-template.ts
@@ -82,6 +82,10 @@ function valueTemplate(input) {
           .join(', ')
     } else if (
       input.tagName === 'TANGY-SIGNATURE' || 
+      input.tagName === 'TANGY-PHOTO-CAPTURE'
+    ) {
+      return '<img src="' + input.value + '" />'
+    } else if (
       input.tagName === 'TANGY-TIMED' || 
       input.tagName === 'TANGY-LOCATION' ||
       input.value === 'object'


### PR DESCRIPTION
## Description
Currently when making a proposal on an Issue, if you update a signature or photo data, the base64 string will appear in the proposal's diff. This instead puts that base64 string in an image tag so folks can see the image in the proposal diff.

## Type of Change

Kind of a bug fix, kind of a feature. The major quality of life improvement is actually that the base64 string would destroy the formatting of the diff table. Added benefit they can actually see the image now.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
