### PR TITLE
 Fix use of window.eventFormRedirect 

### DIFF
--- a/client/src/app/case/components/event-form/event-form.component.ts
+++ b/client/src/app/case/components/event-form/event-form.component.ts
@@ -153,9 +153,12 @@ export class EventFormComponent implements OnInit, OnDestroy {
           // @TODO This redirect may not be need now that we are not displaying form until `this.readyForDataEntry = true`.
           // @TODO Why do we have to redirect back to the case event page to avoid a database conflict error when redirecting
           // to another event form???
-          window.location.hash = `#/${['case', 'event', this.caseService.case._id, this.caseEvent.id].join('/')}`
           if (window['eventFormRedirect']) {
-            this.eventFormRedirect()
+            await this.router.navigate(['case', 'event', this.caseService.case._id, this.caseEvent.id])
+            this.router.navigateByUrl(window['eventFormRedirect'])
+            window['eventFormRedirect'] = ''
+          } else {
+            this.router.navigate(['case', 'event', this.caseService.case._id, this.caseEvent.id])
           }
           this.processMonitorService.stop(this.submitProcess.id)
         }, 500)
@@ -173,11 +176,6 @@ export class EventFormComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(){
     eval(this.eventFormDefinition.onEventClose)
-  }
-  eventFormRedirect() {
-    window.location.hash = window['eventFormRedirect']
-    // Reset the event form redirect so it doesn't become permanent.
-    window['eventFormRedirect'] = ''
   }
 
 }


### PR DESCRIPTION


## Description
Currently when using window.eventFormRedirect in form logic to redirect to another Event Form after submitting the current Event Form, the subsequent Event Form does not load. This is because at some point the Angular router got wise we were redirecting to the "same route" (but different parameters) and then not loading a new instance of EventFormComponent. EventFormComponent is not built to switch to a new Event Form, so things break.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
Refactor eventFormRedirect to await a router navigate to force a new instance of EventFormComponent to be instantiated avoiding impedance mismatch.


## Limitations and Trade-offs
This fixes causes a "double redirect". This forces the Event page to load and then redirect to the intended redirect. This has a performance impact but at least the loading modal will persist throughout the "double redirect".  Alternatively we could refactor EventFormComponent to support switching of Event Forms but this would likely get complicated also involving a refactor of TangyFormsPlayer.

## Security considerations
None.


## Tests
See the Form Workflow event in case-module Content Set.

## Notices, Regressions, Breaking Changes
None.
