### PR TITLE
#3223 Teach Records should be one doc per Student per Curriculum per Class. Not per Student per Curriculum per Class per Item.

### DIFF
--- a/client/src/app/class/class-forms-player.component.ts
+++ b/client/src/app/class/class-forms-player.component.ts
@@ -44,6 +44,12 @@ export class ClassFormsPlayerComponent {
         ...formResponse,
         items: formResponse.items.filter(item => item.id === itemId)
       }
+    } else if (formResponse) {
+      formResponse.items = [{
+        id: itemId,
+        inputs: []
+      }]
+      formEl.response = formResponse
     } else {
       formEl.newResponse()
     }


### PR DESCRIPTION
…

## Description



- Fixes #3223

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Security considerations
None.

## Screenshots/Videos

---

[Optional. Post screenshots or videos to explain this change visually.]

## Tests
On client, create a class, create a student, fill out a few items for a student. Upload and check CSV. There should be a row for that one Student, not a row per item filled out.

## Notices, Regressions, Breaking Changes
Teach will still be backwards compatible on client. However the CSV output of new data will be that all items for a student per Curriculum per Class will be on one row where as old data will have a row for each item.


## TODOS/enhancements
If deemed necessary, we could write a data upgrade script to merge records of old data to conform to the fixed data structure.
