### PR TITLE
#3227 Remove some appended Teach CSV columns

### DIFF
--- a/server/src/modules/class/index.js
+++ b/server/src/modules/class/index.js
@@ -11,10 +11,7 @@ module.exports = {
           if (formResponse.metadata && formResponse.metadata.studentRegistrationDoc && formResponse.metadata.studentRegistrationDoc.classId) {
             let studentRegistrationDoc = formResponse.metadata.studentRegistrationDoc
             flatFormResponse[`sr_classId`] = studentRegistrationDoc.classId;
-            flatFormResponse[`sr_student_name`] = studentRegistrationDoc.student_name;
             flatFormResponse[`sr_student_id`] = studentRegistrationDoc.id;
-            flatFormResponse[`sr_age`] = studentRegistrationDoc.age;
-            flatFormResponse[`sr_gender`] = studentRegistrationDoc.gender;
           }
           resolve({flatFormResponse, formResponse})
       })


### PR DESCRIPTION
Remove student_name, age, and gender from appended fields in Teach output for CSV because they are unpredictable data types and the context is not there like we usually have. Sites that use different data types for these variables have been experiencing broken output.

## Description

- Fixes #3227

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
Remove this functionality because fixing would require more LoE than we have time for. The root of the issue with LoE is that when info on these variables is attached to each Teach record, only the variable's value property is stashed which doesn't allow us to pass the input through our usual flattening algorithm. If we want build this out again in the future, I would suggest getting the related Student doc from the database to look up the full input objects for these variables which can then be run through our generic flattening of an input algorithm.

## Limitations and Trade-offs
Info on some variables are removed, but the relationship columns to Class ID and Student ID remain so they can be joined between two spreadsheets.

## Security considerations
None.

