### PR TITLE
#3270 Fix student subtest report failing by transforming data only for related curriculum

### DIFF
--- a/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.ts
+++ b/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.ts
@@ -171,7 +171,9 @@ export class StudentSubtestReportComponent implements OnInit, AfterViewChecked {
 
       // let results = (await this.getResultsByClass(classId, curriculumId, curriculumFormsList))
       //   .filter(result => studentIds.indexOf(result.studentId) !== -1)
-      const responses = await this.classFormService.getResponsesByStudentId(studentId);
+      const responses = (await this.classFormService.getResponsesByStudentId(studentId)).reduce((acc, curr) => {
+        return curr.doc.form.id === curriculumId ? acc.concat(curr) : acc;
+      }, [])
       const data = await this.dashboardService.transformResultSet(responses, curriculumFormsList, null);
       // clean the array
       const results: Array<StudentResult> = this.dashboardService.clean(data, undefined);


### PR DESCRIPTION

## Description
In certain content sets, after filling out some Curriculum's Item, the Student Subtest report will fail. 

- Fixes #3270

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution
Prepare the report one Curriculum at a time. There was responses to multiple different types of curriculum that would not match the curriculum being passed in to the transform, causing thrown errors.

## Limitations and Trade-offs
I'm not sure how this could have worked before. Either way, this PR now makes the code more cautious and I see less crashes.

## Security considerations
None.

## TODOS/enhancements
Alternatively, the `DashboardService.transformResultSet` function could be the thing that is more cautious. Also, the Component calls a query to get all students once for each curriculum. This could be more efficient by making this call for students once.