### PR TITLE
Add Current Date to Teach Subtest Report

### DIFF
--- a/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.css
+++ b/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.css
@@ -15,8 +15,11 @@
   padding: 6px 13px;
   border: 1px solid #dfe2e5;
 }
-.subtest-report-header {
+
+.subtest-report-header mat-select {
   width:300px;
+}
+.subtest-report-header {
   padding-top:20px;
   margin-bottom:10px;
   margin-left:5px;

--- a/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.html
+++ b/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.html
@@ -1,6 +1,6 @@
 <mat-card class="tangy-card-content-container">
   <div class="subtest-report-header">
-    <h1>{{'Subtest Report'|translate}}</h1>
+    <h1>{{'Subtest Report'|translate}} ({{ today }})</h1>
     <p>
       <mat-select id="studentSelect" placeholder="{{'Select Student'|translate}}" (selectionChange)="onStudentSelect($event)">
         <mat-option value="none" selected>---</mat-option>

--- a/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.ts
+++ b/client/src/app/class/reports/student-subtest-report/student-subtest-report.component.ts
@@ -40,6 +40,7 @@ export class StudentSubtestReportComponent implements OnInit, AfterViewChecked {
   curriculums: any;
   subtestReports: any;
   revealReport = false;
+  today:string 
 
   @ViewChild('subTestReport', {static: true}) subTestReport: ElementRef;
   @ViewChild('curriculumSelectPara', {static: true}) curriculumSelect: ElementRef;
@@ -59,6 +60,8 @@ export class StudentSubtestReportComponent implements OnInit, AfterViewChecked {
   }
 
   async ngOnInit() {
+    const appConfig = await this.appConfigService.getAppConfig()
+    this.today = this.tNumber(window['moment'](Date.now()).format(appConfig.dateFormat))
     const currentUser = this.userService.getCurrentUser();
     if (currentUser) {
       this.classUtils = new ClassUtils();

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -18,6 +18,8 @@ export class AppConfig {
   languageDirection  = "ltr"
   languageCode = "en"
   useEthiopianCalendar:boolean
+  // Format of the date to be displayed in the application. Use Moment's Format standard. https://momentjs.com/docs/#/displaying/format/
+  dateFormat = "M/D/YYYY"
 
   //
   // Sync configuration


### PR DESCRIPTION
Example in Bangladesh:
<img width="831" alt="Screen Shot 2022-03-06 at 2 40 07 PM" src="https://user-images.githubusercontent.com/156575/156939350-704701dc-c32f-415d-8343-7a7302252cd9.png">
Example in English:
<img width="826" alt="Screen Shot 2022-03-06 at 2 39 51 PM" src="https://user-images.githubusercontent.com/156575/156939351-de3a75d4-82ec-4619-9ebf-0bea22c6be3f.png">

This PR also adds the ability to override the date format using `"dateFormat":"some Moment format"` in `app-config.json`. For Bangledesh I think the format is `D/M/YYYY`. 

