### PR TITLE
Allow for AppConfig Class defaults and overrides

### DIFF
--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -1,5 +1,9 @@
 export class AppConfig {
 
+  constructor(data) {
+    Object.assign(this, data)
+  }
+
   // 
   // Tangerine Flavor
   //

--- a/client/src/app/shared/_services/app-config.service.ts
+++ b/client/src/app/shared/_services/app-config.service.ts
@@ -34,7 +34,7 @@ export class AppConfigService {
   ) { }
 
   async getAppConfig():Promise<AppConfig> {
-    this.config = this.config ? this.config : <AppConfig>await this.http.get('./assets/app-config.json').toPromise();
+    this.config = this.config ? this.config : new AppConfig(await this.http.get('./assets/app-config.json').toPromise())
     return this.config;
   }
 


### PR DESCRIPTION
Currently none of the defaults set in the AppConfig Class are actually applied if they are not in `app-config.json`. This fixes that. Note however this may have some unintended side affects of defaults suddenly being applied that were not before. We should perhaps consider removing all the defaults set in AppConfig Class and only provide them on a per case basis in the future.