### PR TITLE
Server User creates group with content set selection

### DIFF
--- a/editor/src/app/groups/new-group/new-group.component.html
+++ b/editor/src/app/groups/new-group/new-group.component.html
@@ -1,21 +1,31 @@
 <h1>
     {{'New Group'|translate}}
 </h1>
-<form novalidate (ngSubmit)="createGroup()" #newGroupForm="ngForm">
+<div *ngIf="!ready">
+  Loading...
+</div>
+<form novalidate (ngSubmit)="createGroup()" #newGroupForm="ngForm" *ngIf="ready">
     <mat-form-field>
-        <input
-            name="groupNameInput"
-            [(ngModel)]="groupName"
-            #groupNameInput="ngModel"
-            matInput
-            placeholder="{{'Group Name'|translate}}"
-            required
-        >
-        <mat-error
-            *ngIf="(groupNameInput.invalid||groupNameInput.errors) && (groupNameInput.dirty || groupNameInput.touched)"
-        >
-            {{'This Field is Required'|translate}}
-        </mat-error>
+      <input
+          name="groupNameInput"
+          [(ngModel)]="groupName"
+          #groupNameInput="ngModel"
+          matInput
+          placeholder="{{'Group Name'|translate}}"
+          required
+      >
+      <mat-error
+          *ngIf="(groupNameInput.invalid||groupNameInput.errors) && (groupNameInput.dirty || groupNameInput.touched)"
+      >
+          {{'This Field is Required'|translate}}
+      </mat-error>
+    </mat-form-field>
+    <br>
+    <mat-form-field appearance="fill" *ngIf="contentSets.length > 0">
+      <mat-label>Content Set</mat-label>
+      <select matNativeControl required name="contentSetSelect" [(ngModel)]="contentSet">
+        <option *ngFor="let contentSet of contentSets" value="{{contentSet.id}}">{{contentSet.label}}</option>
+      </select>
     </mat-form-field>
     <br>
     <br>

--- a/editor/src/app/groups/new-group/new-group.component.ts
+++ b/editor/src/app/groups/new-group/new-group.component.ts
@@ -11,6 +11,9 @@ import {UserService} from '../../core/auth/_services/user.service';
   styleUrls: ['./new-group.component.css']
 })
 export class NewGroupComponent implements OnInit {
+  contentSet:string
+  contentSets: any = [];
+  ready = false
 
   groupName = '';
   constructor(
@@ -20,14 +23,18 @@ export class NewGroupComponent implements OnInit {
     private userService: UserService
   ) { }
 
-  ngOnInit() {
-
+  async ngOnInit() {
+      this.contentSets = await this.groupsService.getContentSets();
+      if (this.contentSets.length > 0) {
+        this.contentSet = this.contentSets[0]['id']
+      }
+      this.ready = true
   }
 
   async createGroup() {
     try {
       const username = await this.userService.getCurrentUser();
-      const result: any = await this.groupsService.createGroup(this.groupName);
+      const result: any = await this.groupsService.createGroup(this.groupName, this.contentSet);
       this.window.nativeWindow.location = `${this.window.nativeWindow.location.origin}/app/${result._id}/index.html#/groups/${result._id}`
       if (result && result.statusCode && result.statusCode === 200) {
         this.groupName = '';

--- a/editor/src/app/groups/services/groups.service.ts
+++ b/editor/src/app/groups/services/groups.service.ts
@@ -14,6 +14,13 @@ export class GroupsService {
     private errorHandler: TangyErrorHandler
   ) { }
 
+  async getContentSets() {
+    return <any>await this
+      .httpClient
+      .get(`/nest/group/content-sets`)
+      .toPromise();
+  }
+
   async getGroupInfo(groupId) {
     return <any>await this
       .httpClient
@@ -41,9 +48,9 @@ export class GroupsService {
     }
   }
 
-  async createGroup(groupName: string) {
+  async createGroup(groupName: string, contentSet:string) {
     try {
-      const result = await this.httpClient.post('/nest/group/create', { label: groupName }).toPromise();
+      const result = await this.httpClient.post('/nest/group/create', { label: groupName, contentSet }).toPromise();
       return result;
     } catch (error) {
       console.error(error);

--- a/server/package.json
+++ b/server/package.json
@@ -98,6 +98,7 @@
     "pouchdb-replication-stream": "github:orolle/pouchdb-replication-stream",
     "pouchdb-upsert": "^2.2.0",
     "pretty": "^2.0.0",
+    "promisify-child-process": "^4.1.1",
     "read-yaml": "^1.1.0",
     "reflect-metadata": "^0.1.12",
     "rimraf": "^2.6.2",

--- a/server/src/core/group/group.controller.ts
+++ b/server/src/core/group/group.controller.ts
@@ -14,8 +14,8 @@ export class GroupController {
   ) { }
 
   @All('create')
-  async create(@Body('label') label:string, @Req() request: Request):Promise<Group> {
-    return await this.groupService.create(label, request['user']['name']);
+  async create(@Body('label') label:string, @Body('contentSet') contentSet:string, @Req() request: Request):Promise<Group> {
+    return await this.groupService.create(label, contentSet, request['user']['name']);
   }
 
   @All('read/:groupId')
@@ -46,6 +46,11 @@ export class GroupController {
         return user.groups.reduce((foundMembership, groupMembership) => foundMembership ? true : groupMembership.groupName === group._id, false)
       })
     }
+  }
+
+  @All('content-sets')
+  async contentSets() {
+    return await this.groupService.contentSets()
   }
 
   @Post('start-session')

--- a/server/src/scripts/create-group/bin.js
+++ b/server/src/scripts/create-group/bin.js
@@ -38,8 +38,6 @@ async function createGroup() {
   const serverUrl = `${process.env.T_PROTOCOL}://${process.env.T_HOST_NAME}/`
   const groupLabel = process.argv[2]
   const group = (await http.post('/nest/group/create', {label: groupLabel}))['data']
-  console.log('Created group:')
-  console.log(group)
   if (process.argv[3]) {
     const contentSet = process.argv[3].includes('.git')
       ? process.argv[3]
@@ -85,6 +83,7 @@ async function createGroup() {
       groupName: groupLabel,
       serverUrl
     })
+    console.log(JSON.stringify(group, null, 2))
   }
 }
 


### PR DESCRIPTION
## Description
An opt in feature where the Server Admin may add a `tangerine/content-sets/content-sets.json` file to define which Content Sets are available in the select when creating a new group. If no `content-sets.json` file is added, or it's an empty array, the Content Set selection will not appear.

<img width="546" alt="Screen Shot 2022-03-07 at 4 32 58 PM" src="https://user-images.githubusercontent.com/156575/157121375-da01783e-0693-46b4-a86e-4fabaf1b49bb.png">
<img width="533" alt="Screen Shot 2022-03-07 at 4 33 06 PM" src="https://user-images.githubusercontent.com/156575/157121392-f3d949c1-9f59-4827-9dbe-ea4e182a2087.png">

Example `tangerine/content-sets/content-sets.json`:

```json
[
  {
    "id": "default",
    "label": "Default"
  },
  {
    "id": "case-module",
    "label": "Case Module Example"
  }
]
```

The `id` property corresponds with the path to the Content Set in the `content-sets` directory. `label` property is what appears in the selection UI when creating a group.

## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution


## Limitations and Trade-offs

## Security considerations
Because the Content Selected gets fed into the `create-group` command, [spawn is used](https://github.com/Tangerine-Community/Tangerine/pull/3275/files#diff-7547302d9f7d704095819bcec92be825eaa7d83fc3e7f9855c8999cd6782d43fR148) to prevent [injection attacks that are possible by not carefully using exec](https://stackoverflow.com/questions/23697639/child-process-spawn-in-node-js-security-escaping). Because using spawn is does not come with support for promises out of the box, this PR imports spawn from the `promisify-child-process` package. 

## Screenshots/Videos



## Tests



## Notices, Regressions, Breaking Changes


## TODOS/enhancements
