### PR TITLE
Add Kiosk Mode to client

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<mat-toolbar *ngIf="installed" dir="{{languageDirection}}" color="primary" class="mat-typography mat-tangy-custom-toolbar">
+<mat-toolbar *ngIf="installed && !kioskModeEnabled" dir="{{languageDirection}}" color="primary" class="mat-typography mat-tangy-custom-toolbar">
   <span class="home-icon" *ngIf="isLoggedIn">
     <a class="tangy-no-text-decoration tangy-app-name" routerLink="/home">
       <app-tangy-svg-logo [tangyLogoStyle]="{'height':'45px'}"></app-tangy-svg-logo>
@@ -22,6 +22,10 @@
 
   <paper-icon-button icon="more-vert" [matMenuTriggerFor]="appMenu" class="hamburger-menu"></paper-icon-button>
   <mat-menu #appMenu="matMenu">
+    <button *ngIf="ready && appConfig && appConfig.kioskMode" (click)="kioskModeEnabled = true" mat-menu-item>
+      <mat-icon class="material-icons menu-tangy-location-list-icon">screen_lock_landscape</mat-icon>
+      <span>{{'Kiosk Mode'|translate}}</span>
+    </button>
     <button *ngIf="ready && !appConfig.hideProfile" routerLink="manage-user-profile" mat-menu-item>
       <mat-icon class="material-icons menu-tangy-location-list-icon">create</mat-icon>
       <span>{{'Manage Profile'|translate}}</span>
@@ -66,6 +70,6 @@
   </mat-menu>
 
 </mat-toolbar>
-<div class="tangerine-app-content mat-typography">
+<div class="tangerine-app-content mat-typography " [ngClass]="{'has-topbar': !kioskModeEnabled}">
   <router-outlet *ngIf="ready"></router-outlet>
 </div>

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -47,6 +47,7 @@ export class AppComponent implements OnInit {
   installed = false
   isLoggedIn = false
   isAdmin = false
+  kioskModeEnabled = false
   freespaceCorrectionOccuring = false;
   updateIsRunning = false;
   languageCode:string

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -67,6 +67,8 @@ export class AppConfig {
   passwordRecipe:string
   // Disregard password functionality.
   noPassword = false
+  // Prevent users from logging out and accessing menu. Useful when used in conjunction with a kiosk mode app.
+  kioskMode = false
 
   //
   // Profile configuration.

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -116,7 +116,7 @@ button.tangy-froms-margin-left{
   display: block;
 }
 
-.tangerine-app-content{
+.tangerine-app-content.has-topbar{
     /* min-height: 100vh; */
     @media screen and (max-width: 600px) {
       margin-top: 56px;


### PR DESCRIPTION
## Description
For projects that want to prevent user from using the Tangerine menu and only focus on content, this PR adds a "Kiosk Mode". 

To enable Kiosk Mode:

1. Device administrator logs into an account on Device.
2. Device Administrator opens menu and selects "Kiosk Mode". Top bar disappears, thus locking people out from logging out or other tasks like syncing.
4. Device Administrator uses other Kiosk App to enable Kiosk Mode for Tangerine App which prevents users from leaving the Tangerine App and accessing other system level functions.
5. Device can now be given to folks who will be entering data onto Device.

To disable Kiosk Mode:
1. Device Administrator uses special trick (depends on Kiosk Mode app being used) to disable system level Kiosk Mode.
2. Device Administrator closes Tangerine App.
3. Device Administrator opens Tangerine App and is presented with Log In. At this point they are free to repeat the steps to enable Kiosk Mode under a different user account if that's their use case.



## Type of Change

- New feature (non-breaking change which adds functionality)

## Proposed Solution
To implement Kiosk Mode, set `"kioskMode": true` in `app-config.json`. This flag makes the "Kiosk Mode" menu item appear. When Kiosk Mode is enabled, it's a simple show/hide of the top bar.

## Limitations and Trade-offs
Maybe it's inconvenient to have to exit the app to stop kiosk mode? I would be hesitant to offer any other way to exit kiosk mode because the Device Administrator already has to deal with some special trick from a Kiosk App.

## Security considerations
Actual Device Users will not be able to log out themselves. This understanding needs to be baked into protocols of how studies work.

## Screenshots/Videos

Enabling Kiosk Mode from the menu:

<img width="834" alt="Screen Shot 2022-03-10 at 10 17 45 AM" src="https://user-images.githubusercontent.com/156575/157708425-1a66d893-6739-4371-81e5-3f38684c97f9.png">

Kiosk Mode enabled. Note the lack of the top bar:

<img width="835" alt="Screen Shot 2022-03-10 at 11 10 22 AM" src="https://user-images.githubusercontent.com/156575/157708440-7acfe09d-bac0-4c6e-977f-13394c4a6fe9.png">

