### PR TITLE
Add option for temporary reduction of batch sizes

### DIFF
--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -50,6 +50,8 @@ export class AppConfig {
   initialBatchSize:number
   // The max number of documents that will get written to disk during a sync. Tweak this down when using the SqlCipher encryption plugin to avoid database crashes.
   writeBatchSize:number
+  // The max number of documents that will indexed at a time. Tweak this down when using the SqlCipher encryption plugin to avoid database crashes.
+  changesBatchSize:number
   // The number of IDs to read from the database at a time when doing a Comparison Sync.
   compareLimit: number;
   // List of views to skip optimization of after a sync.

--- a/client/src/app/sync/components/sync/sync.component.html
+++ b/client/src/app/sync/components/sync/sync.component.html
@@ -94,13 +94,19 @@
   <mat-expansion-panel>
     <mat-expansion-panel-header>
       <mat-panel-title>
-        Advanced Options
+        {{'Advanced Options' | translate }}
       </mat-panel-title>
     </mat-expansion-panel-header>
     
     <p>{{'Please note that these options should not be done routinely. Choose one of the following options and then ' +
     'click the "Start" button above. To cancel your selection, click it again. If the Sync direction is "Pull", ' +
     'the app will first do a normal Sync to make sure all local docs have been pushed to the server.' | translate }}</p>
+
+    <p>{{'If Comparison or Rewind sync fail due to memory issues, check the box below to reduce the number of documents processed during ' +
+         'synchronization and indexing which may workaround the issue.' | translate }}</p>
+
+    <mat-checkbox id="reduce-batch-size-checkbox">{{'Reduce Batch Size' | translate }}</mat-checkbox>
+    <p></p>
     
     <h3>Comparison Sync</h3>
     

--- a/client/src/app/sync/components/sync/sync.component.html
+++ b/client/src/app/sync/components/sync/sync.component.html
@@ -105,7 +105,7 @@
     <p>{{'If Comparison or Rewind sync fail due to memory issues, check the box below to reduce the number of documents processed during ' +
          'synchronization and indexing which may workaround the issue.' | translate }}</p>
 
-    <mat-checkbox id="reduce-batch-size-checkbox">{{'Reduce Batch Size' | translate }}</mat-checkbox>
+    <mat-checkbox id="reduce-batch-size-checkbox" (click)="toggleReduceBatchSize()">{{'Reduce Batch Size' | translate }}</mat-checkbox>
     <p></p>
     
     <h3>Comparison Sync</h3>

--- a/client/src/app/sync/components/sync/sync.component.ts
+++ b/client/src/app/sync/components/sync/sync.component.ts
@@ -39,6 +39,7 @@ export class SyncComponent implements OnInit, OnDestroy {
   rewindDisabled = false;
   indexing: any
   indexingMessage: string
+  reduceBatchSize = false;
 
   @Input() fullSync: string;
   currentCheckedValue: boolean = null

--- a/client/src/app/sync/components/sync/sync.component.ts
+++ b/client/src/app/sync/components/sync/sync.component.ts
@@ -176,21 +176,21 @@ export class SyncComponent implements OnInit, OnDestroy {
         // Pull comparison
         this.otherMessage = "Forcing a sync before the Comparison Sync to make sure that all docs have been uploaded from the tablet."
         // force a sync to make sure all docs have been pushed. 
-        this.replicationStatus = await this.syncService.sync(false, null)
-        this.replicationStatus = await this.syncService.compareDocs('pull')
+        this.replicationStatus = await this.syncService.sync(false, null, this.reduceBatchSize)
+        this.replicationStatus = await this.syncService.compareDocs('pull', this.reduceBatchSize)
       } else if (this.runComparison === 'push') {
         // Push comparison
-        this.replicationStatus = await this.syncService.compareDocs('push')
+        this.replicationStatus = await this.syncService.compareDocs('push', this.reduceBatchSize)
       } else if (this.fullSync === 'pull') {
         // Pull Rewind Full Sync
         this.otherMessage = "Forcing a sync before the Rewind Sync to make sure that all docs have been uploaded from the tablet."
         // force a sync to make sure all docs have been pushed. 
-        this.replicationStatus = await this.syncService.sync(false, null)
+        this.replicationStatus = await this.syncService.sync(false, null, this.reduceBatchSize)
         // Rewind sync is activated when you provide the 'fullSync' variable - push or pull:
-        this.replicationStatus = await this.syncService.sync(false, SyncDirection.pull)
+        this.replicationStatus = await this.syncService.sync(false, SyncDirection.pull, this.reduceBatchSize)
       } else if (this.fullSync === 'push') {
         // Push Rewind Full Sync
-        this.replicationStatus = await this.syncService.sync(false, SyncDirection.push)
+        this.replicationStatus = await this.syncService.sync(false, SyncDirection.push, this.reduceBatchSize)
       }
       
       this.dbDocCount = this.replicationStatus.dbDocCount
@@ -243,11 +243,17 @@ export class SyncComponent implements OnInit, OnDestroy {
     this.runComparison = null
   }
 
+  toggleReduceBatchSize() {
+    this.reduceBatchSize = !this.reduceBatchSize
+    console.log(`Reduced batch size is: ${this.reduceBatchSize ? 'on' : 'off'}`)
+  }
+
   reset() {
     this.runComparison = null
     this.fullSync = null
     this.comparisonDisabled = false
     this.rewindDisabled = false
+    this.reduceBatchSize = false
   }
 
   checkState(el, direction, action) {

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -66,7 +66,7 @@ export class SyncService {
     })
   }
   
-  async sync(isFirstSync = false, fullSync?:SyncDirection):Promise<ReplicationStatus> {
+  async sync(isFirstSync = false, fullSync?:SyncDirection, reduceBatchSize = false):Promise<ReplicationStatus> {
     const appConfig = await this.appConfigService.getAppConfig()
     const device = await this.deviceService.getDevice()
     const formInfos = await this.tangyFormsInfoService.getFormsInfo()
@@ -100,7 +100,8 @@ export class SyncService {
       },
       null,
       isFirstSync,
-      fullSync
+      fullSync,
+      reduceBatchSize
     )
     console.log('Finished syncCouchdbService sync: ' + JSON.stringify(this.syncMessage))
 

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -55,6 +55,9 @@ export class SyncService {
   compareLimit: number = 150
   batchSize: number = 200
   writeBatchSize: number = 50
+  reducedBatchSize: number = 50
+  reducedWriteBatchSize: number = 20
+  reducedCompareLimit: number = 50
 
   cancel() {
     this.syncCouchdbService.cancel()
@@ -317,7 +320,7 @@ export class SyncService {
    * Indexes views.
    * @param direction
    */
-  async compareDocs(direction: string):Promise<ReplicationStatus> {
+  async compareDocs(direction: string, reduceBatchSize = false):Promise<ReplicationStatus> {
     
     let status = <ReplicationStatus>{
       pulled: 0,
@@ -328,18 +331,10 @@ export class SyncService {
     }
     
     const appConfig = await this.appConfigService.getAppConfig()
-    if (appConfig.batchSize) {
-      this.batchSize = appConfig.batchSize
-      console.log("this.batchSize: " + this.batchSize)
-    }
-    if (appConfig.writeBatchSize) {
-      this.writeBatchSize = appConfig.writeBatchSize
-      console.log("this.writeBatchSize: " + this.writeBatchSize)
-    }
-    if (appConfig.compareLimit) {
-      this.compareLimit = appConfig.compareLimit
-      console.log("this.compareLimit: " + this.compareLimit)
-    }
+    this.batchSize = reduceBatchSize ? this.reducedBatchSize : appConfig.batchSize || this.batchSize
+    this.writeBatchSize = reduceBatchSize ? this.reducedWriteBatchSize : appConfig.writeBatchSize || this.writeBatchSize
+    this.compareLimit = reduceBatchSize ? this.reducedCompareLimit : appConfig.compareLimit || this.compareLimit
+
     const device = await this.deviceService.getDevice()
     let userDb: UserDatabase = await this.userService.getUserDatabase()
 


### PR DESCRIPTION
This feature is aimed at enable device administrators to perform the 'Advanced Sync' settings on tablets that are hitting memory issues that block normal sync or advanced sync.  I added a description and checkbox in the 'Advanced Sync' settings panel. When checked, the batch size values will all be reduced. 

<img width="629" alt="Screen Shot 2022-04-04 at 12 12 41 PM" src="https://user-images.githubusercontent.com/8252364/161592057-935daaae-7ed8-4445-bbcb-8c54c37d6079.png">

The batch size defaults are defined in two locations (we should eventually make it one). The variables starting with 'reduced' are added in the following files. 

`sync.service.ts`
```
  compareLimit: number = 150
  batchSize: number = 200
  writeBatchSize: number = 50
  reducedBatchSize: number = 50
  reducedWriteBatchSize: number = 20
  reducedCompareLimit: number = 50
```

`sync-couchdb.service.ts`
```
  batchSize = 200
  initialBatchSize = 1000
  writeBatchSize = 50
  changesBatchSize = 25
  reducedBatchSize = 50
  reducedWriteBatchSize = 20
  reducedChangesBatchSize = 1
```

### Notes:
1. The values of the batch size config set in app-config will be ignored for this one operation
2. I intentionally **did not** add a reduced value for `initialBatchSize`
3. The checkbox only impacts the 'Advanced Sync' operations (not 'normal' sync)
4. The config for the indexing is being moved and renamed to be consistent -- 'changes_batch_size' is now 'changesBatchSize'
