### PR TITLE
Case Service API for activate or de-active case event and event form

### DIFF
--- a/client/src/app/case/classes/case-event.class.ts
+++ b/client/src/app/case/classes/case-event.class.ts
@@ -6,6 +6,7 @@ class CaseEvent {
   caseEventDefinitionId:string
   eventForms: Array<EventForm> = []
   complete?:boolean = false
+  inactive?:boolean = false
   caseId?: string
   // @TODO Remove estimate. Not used.
   estimate? = true

--- a/client/src/app/case/classes/event-form.class.ts
+++ b/client/src/app/case/classes/event-form.class.ts
@@ -7,6 +7,7 @@ class EventForm {
   formResponseId?:string;
   participantId?:string
   complete?:boolean = false
+  inactive?:boolean = false
   required?:boolean = false
   caseId?:string;
   caseEventId?:string;

--- a/client/src/app/case/components/case/case.component.html
+++ b/client/src/app/case/components/case/case.component.html
@@ -16,6 +16,7 @@
   <div class="cover-when-not-confirmed" *ngIf="caseService.openCaseConfirmed === false"></div>
   <div *ngFor="let eventInfo of readableCaseEventsInfo">
     <app-case-event-list-item *ngFor="let caseEvent of eventInfo.caseEvents" 
+      [style.display]="caseEvent.inactive?'none':'inherit'"
       [caseEvent]="caseEvent"
       [caseDefinition]="caseService.caseDefinition"
       [caseEventDefinition]="eventInfo.caseEventDefinition"
@@ -28,6 +29,7 @@
     <app-case-event-list-item
       *ngFor="let caseEvent of eventInfo.caseEvents" 
       disabled
+      [style.display]="caseEvent.inactive?'none':'inherit'"
       [caseEvent]="caseEvent"
       [caseDefinition]="caseService.caseDefinition"
       [caseEventDefinition]="eventInfo.caseEventDefinition"

--- a/client/src/app/case/components/event-forms-for-participant/event-forms-for-participant.component.html
+++ b/client/src/app/case/components/event-forms-for-participant/event-forms-for-participant.component.html
@@ -15,6 +15,7 @@
   </div>
   <app-event-form-list-item (formDeleted)="updateFormList($event)"
     *ngFor="let eventFormInfo of participantInfo.eventFormInfos"
+    [style.display]="eventFormInfo.eventForm.inactive?'none':'inherit'"
     [case]="caseService.case"
     [caseDefinition]="caseService.caseDefinition"
     [caseEvent]="caseEvent"

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -283,7 +283,7 @@ class CaseService {
   // @TODO Add EventForm.permissions to interface and pass in eventForm in every usage of hasEventFormPermission.
   hasEventFormPermission(operation:EventFormOperation, eventFormDefinition:EventFormDefinition, eventForm?:EventForm) {
     if (
-      (
+      ((
         eventForm &&
         eventForm.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
       ) ||
@@ -291,7 +291,8 @@ class CaseService {
         !eventFormDefinition.permissions ||
         !eventFormDefinition.permissions[operation] ||
         eventFormDefinition.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
-      )
+      )) &&
+      !eventForm.inactive
     ) {
       return true
     } else {
@@ -301,9 +302,11 @@ class CaseService {
 
   hasCaseEventPermission(operation:CaseEventOperation, eventDefinition:CaseEventDefinition) {
     if (
-        !eventDefinition.permissions ||
+        (!eventDefinition.permissions ||
         !eventDefinition.permissions[operation] ||
-        eventDefinition.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
+        eventDefinition.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0)
+        &&
+        !this.caseEvent.inactive
     ) {
       return true
     } else {
@@ -398,6 +401,34 @@ class CaseService {
   disableEventDefinition(eventDefinitionId) {
     if (this.case.disabledEventDefinitionIds.indexOf(eventDefinitionId) === -1) {
       this.case.disabledEventDefinitionIds.push(eventDefinitionId)
+    }
+  }
+
+  activateCaseEvent(caseEventId:string) {
+    this.case = {
+      ...this.case,
+      events: this.case.events.map(event => {
+        return event.id === caseEventId
+          ? {
+            ...event,
+            inactive: false
+          }
+          : event
+      })
+    }
+  }
+
+  deactivateCaseEvent(caseEventId:string) {
+    this.case = {
+      ...this.case,
+      events: this.case.events.map(event => {
+        return event.id === caseEventId
+          ? {
+            ...event,
+            inactive: true
+          }
+          : event
+      })
     }
   }
 
@@ -547,6 +578,44 @@ class CaseService {
     }
   }
 
+  activateEventForm(caseEventId:string, eventFormId:string) {
+    this.case = {
+      ...this.case,
+      events: this.case.events.map(event => event.id !== caseEventId
+        ? event
+        : {
+          ...event,
+          eventForms: event.eventForms.map(eventForm => eventForm.id !== eventFormId
+            ? eventForm
+            : {
+              ...eventForm,
+              inactive: false
+            }
+          )
+        }
+      )
+    }
+  }
+
+  deactivateEventForm(caseEventId:string, eventFormId:string) {
+    this.case = {
+      ...this.case,
+      events: this.case.events.map(event => event.id !== caseEventId
+        ? event
+        : {
+          ...event,
+          eventForms: event.eventForms.map(eventForm => eventForm.id !== eventFormId
+            ? eventForm
+            : {
+              ...eventForm,
+              inactive: true
+            }
+          )
+        }
+      )
+    }
+  }
+
   /*
    * Participant API
    */
@@ -613,7 +682,7 @@ class CaseService {
     }
   }
 
-  async activateParticipant(participantId:string) {
+  activateParticipant(participantId:string) {
     this.case = {
       ...this.case,
       participants: this.case.participants.map(participant => {
@@ -627,7 +696,7 @@ class CaseService {
     }
   }
 
-  async deactivateParticipant(participantId:string) {
+  deactivateParticipant(participantId:string) {
     this.case = {
       ...this.case,
       participants: this.case.participants.map(participant => {

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -283,16 +283,15 @@ class CaseService {
   // @TODO Add EventForm.permissions to interface and pass in eventForm in every usage of hasEventFormPermission.
   hasEventFormPermission(operation:EventFormOperation, eventFormDefinition:EventFormDefinition, eventForm?:EventForm) {
     if (
-      ((
-        eventForm &&
+      (
+        eventForm && !eventForm.inactive &&
         eventForm.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
       ) ||
       (
         !eventFormDefinition.permissions ||
         !eventFormDefinition.permissions[operation] ||
         eventFormDefinition.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
-      )) &&
-      !eventForm.inactive
+      )
     ) {
       return true
     } else {
@@ -300,13 +299,13 @@ class CaseService {
     }
   }
 
-  hasCaseEventPermission(operation:CaseEventOperation, eventDefinition:CaseEventDefinition) {
+  hasCaseEventPermission(operation:CaseEventOperation, eventDefinition:CaseEventDefinition, caseEvent?:CaseEvent) {
     if (
         (!eventDefinition.permissions ||
         !eventDefinition.permissions[operation] ||
         eventDefinition.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0)
-        &&
-        !this.caseEvent.inactive
+        ||
+        caseEvent && !caseEvent.inactive
     ) {
       return true
     } else {


### PR DESCRIPTION
### Use Case

A site protocol using Case has a set of visits that they want to hide from the data collector for a specific case. For example, in a mother-infant cohort, the site wants the Antenatal Care events to be hidden after birth so the data collector does not incorrectly fill those events after delivery. 

This adds Case APIs to deactive (or active) a Case Event or Event Form.

### Technical Specs

When the Case API are run, they will add set the `inactive` flag in the Case Event or Event Form.  Once the flag is set, the Case Event or Event Form will no longer appear in the client-side interface.  The Case Event or Event Form marked inactive will be hidden in the interface by setting `display: none;` in the case-event-list or event-form-list.