### PR TITLE
use replace() instead of replaceAll() in node<15.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@
 __New Features__
 
 - Feature: New version of mysql module, which is coded in javascript instead of python, exports records much faster than previous version. It should also use much less memory and provide more flexibility in terms of column data types and (eventually) support of different types of databases. Issue: [#3047](https://github.com/Tangerine-Community/Tangerine/issues/3047)
+- 
+  __Fixes__
+- The default password policy (T_PASSWORD_POLICY in config.sh) has been improved to support most special characters and the T_PASSWORD_RECIPE description has been updated to list the permitted special characters. Issue: https://github.com/Tangerine-Community/Tangerine/issues/3299
+
+```shell
+(\` ~ ! @ # $ % ^ & * ( ) \ - _ = + < > , . ; : \ | [ ] { } )
+```
+- Results with cycle sequences do not generate a CSV file Issue: [#3249](https://github.com/Tangerine-Community/Tangerine/issues/3249) PR: [3345](https://github.com/Tangerine-Community/Tangerine/pull/3345)
+
+
+__Server upgrade instructions__
+
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
+
+```
+cd tangerine
+# Check the size of the data folder.
+du -sh data
+# Check disk for free space. Ensure there is at least 10GB + size of the data folder amount of free space in order to perform the upgrade.
+df -h
+# Turn off tangerine and database.
+docker stop tangerine couchdb
+# Create a backup of the data folder.
+cp -r data ../data-backup-$(date "+%F-%T")
+# Check logs for the past hour on the server to ensure it's not being actively used. Look for log messages like "Created sync session" for Devices that are syncing and "login success" for users logging in on the server. 
+docker logs --since=60m tangerine
+# Fetch the updates.
+git fetch origin
+git checkout v3.22.5
+./start.sh v3.22.5
+# Remove Tangerine's previous version Docker Image.
+docker rmi tangerine/tangerine:v3.22.4
+```
 
 ## v3.22.4
 

--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -129,9 +129,10 @@ T_JWT_ISSUER="Tangerine"
 T_JWT_EXPIRES_IN="1h"
 
 # Password Policy
-T_PASSWORD_POLICY="^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})"
+T_PASSWORD_POLICY="^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[~!@#$%^&\*()\-_=+<>,.;:|[\]{}])(?=.{8,})"
 T_PASSWORD_RECIPE="Password must contain at least 1 lowercase alphabetical character, at least 1 uppercase alphabetical character,
-at least 1 numeric character, at least one special character, and must be eight characters or longer"
+at least 1 numeric character, at least one special character ( ~ ! @ # $ % ^ & \* ( ) - _ = + < > , . ; : | [ ] { } ),
+and must be eight characters or longer"
 
 # Array of origins that are allowed to make requests to this server. Useful if you have an outside browser based app on a different origin that needs to make calls back to this server. See Express Cors Options Origin setting for possible values. https://expressjs.com/en/resources/middleware/cors.html#configuration-options
 # Example usage. Note the forward slashes before double quotes are required otherwise bash filters them out and it won't be valid JSON.

--- a/docs/editor/README.md
+++ b/docs/editor/README.md
@@ -5,6 +5,7 @@
 - [Configuration Guide](configuration.md)
 - [The Tangerine Preview tool for advanced users writing forms in HTML and using Git for version control](tangerine-preview-tool.md)
 - [Form Versions](form-versions.md)
+- [Password Policy](password-policy.md)
 ## Case Module
   - [Case Management Data Model](case-module/case-data-model.md)
   - [Case Module Cookbook](case-module/case-module-cookbook.md)

--- a/docs/editor/password-policy.md
+++ b/docs/editor/password-policy.md
@@ -1,0 +1,25 @@
+# Password Policy
+
+The default password policy is in config.defaults.sh. Although you can change it, it is recommended that you have a strong password policy. 
+
+Relevant variables:
+- T_PASSWORD_POLICY - The policy, codedin the form of a regular expression.
+- T_PASSWORD_RECIPE - Description of the policy, to enable user to create a password that will pass the policy. 
+
+Ideally a password policy should include the following specifications:
+- 8 characters or more
+- at least one upper case letters
+- at least one lower case letter
+- at least one special character
+- at least one numeral
+
+Each group can have a unique password policy. When a group is created, the default policy and recipe from config.sh are copied over to the passwordPolicy and passwordRecipe variables in app-config.json.
+
+Editor on the server uses the T_PASSWORD_POLICY and T_PASSWORD_RECIPE variables.
+
+## Tips
+
+If the server's shell has problems interpreting any of the special characters when loading T_PASSWORD_POLICY from config.sh, you may need to add an escape `\` before the special character.
+
+The site https://www.regextester.com/ has been very helpful in testing out password policies. 
+

--- a/editor/src/app/core/auth/_components/update-personal-profile/update-personal-profile.component.ts
+++ b/editor/src/app/core/auth/_components/update-personal-profile/update-personal-profile.component.ts
@@ -54,6 +54,7 @@ export class UpdatePersonalProfileComponent implements OnInit {
     this.passwordIsNotStrong.message = this.passwordIsNotStrong.message + ' ' + this.passwordRecipe
   }
   async editUser() {
+    this.statusMessage = { type: '', message: '' };
     try {
       if (!this.updateUserPassword) {
         this.user.password = null;

--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -227,10 +227,11 @@ const  generateFlatResponse = async function (formResponse, locationList, saniti
   if (formResponse.form.id === '') {
     formResponse.form.id = 'blank'
   }
+  const cycleSequencesReplacer = new RegExp('\n', 'g')
   let flatFormResponse = {
     _id: formResponse._id,
     formId: formResponse.form.id,
-    cycleSequences: formResponse.form.cycleSequences? formResponse.form.cycleSequences.replaceAll('\n','  '): '',
+    cycleSequences: formResponse.form.cycleSequences? formResponse.form.cycleSequences.replace(cycleSequencesReplacer,'  '): '',
     sequenceOrderMap: formResponse.form.sequenceOrderMap?formResponse.form.sequenceOrderMap:'',
     startUnixtime: formResponse.startUnixtime||'',
     endUnixtime: formResponse.endUnixtime||'',


### PR DESCRIPTION
## Description
use replace() instead of replaceAll() in node<15.

- Fixes #3249 

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)


## Proposed Solution
use replace()