### PR TITLE
Case Service API to Archive, Unarchive or Delete a Form Response

### DIFF
--- a/editor/src/app/case/classes/event-form.class.ts
+++ b/editor/src/app/case/classes/event-form.class.ts
@@ -2,6 +2,7 @@ class EventForm {
   id:string;
   participantId:string
   complete:boolean = false
+  archived?:boolean = false
   required:boolean
   caseId:string; 
   caseEventId:string;

--- a/editor/src/app/case/services/case.service.ts
+++ b/editor/src/app/case/services/case.service.ts
@@ -665,6 +665,77 @@ class CaseService {
     }
   }
 
+  async archiveFormResponse(caseEventId:string, eventFormId:string) {
+    const caseEvent = this.case.events.find(event => event.id === caseEventId)
+    if (caseEvent) {
+      var eventForm = caseEvent.eventForms.find(form => form.id === eventFormId)
+      if (eventForm && eventForm.formResponseId) {
+          const formResponse = await this.tangyFormService.getResponse(eventForm.formResponseId)
+          if (formResponse) {
+            formResponse.archived = true
+            await this.tangyFormService.saveResponse(formResponse)
+          }
+          eventForm.archived = true
+          await this.save()
+        }
+    }
+  }
+
+  async unarchiveFormResponse(caseEventId:string, eventFormId:string) {
+    const caseEvent = this.case.events.find(event => event.id === caseEventId)
+    if (caseEvent) {
+      var eventForm = caseEvent.eventForms.find(form => form.id === eventFormId)
+      if (eventForm && eventForm.formResponseId) {
+          const formResponse = await this.tangyFormService.getResponse(eventForm.formResponseId)
+          if (formResponse) {
+            formResponse.archived = false
+            await this.tangyFormService.saveResponse(formResponse)
+          }
+          eventForm.archived = false
+          await this.save()
+        }
+    }
+  }
+
+  async deleteFormResponse(caseEventId:string, eventFormId:string) {
+    const caseEvent = this.case.events.find(event => event.id === caseEventId)
+    if (caseEvent) {
+      var eventForm = caseEvent.eventForms.find(form => form.id === eventFormId)
+      if (eventForm && eventForm.formResponseId) {
+        const formResponse = await this.tangyFormService.getResponse(eventForm.formResponseId)
+        if (formResponse) {
+          const archivedFormResponse = new TangyFormResponseModel(
+            {
+              archived:true,
+              _rev : formResponse._rev,
+              _id : formResponse._id,
+              form : {
+                id: formResponse.form.id,
+                title: formResponse.form.title,
+                tagName: formResponse.form.tagName,
+                complete: formResponse.form.complete
+              },
+              items : [],
+              events : [],
+              location : formResponse.location,
+              type : "response",
+              caseId: formResponse.caseId,
+              eventId: formResponse.eventId,
+              eventFormId: formResponse.eventFormId,
+              participantId: formResponse.participantId,
+              groupId: formResponse.groupId,
+              complete: formResponse.complete,
+              tangerineModifiedOn: new Date().getTime()
+            }
+          )
+          await this.tangyFormService.saveResponse(archivedFormResponse)
+        }
+        this.deleteEventForm(caseEventId, eventFormId)
+        await this.save()
+      }
+    }
+  }
+
   /*
    * Participant API
    */


### PR DESCRIPTION
Adds Case Service APIs for Archive, Unarchive or Delete a form response. This is the first part of allowing single for responses to be archived programmatically. 

### Tech notes

#### archiveFormResponse
- sets the `archived` flag in the form response to `true` 
- sets a new flag on the event form called `archived` to `true`
-- Required so we can (eventually) know which event forms can be unarchived in the UI

#### unarchiveFormResponse
- sets the `archived` flag in the form response to `false` 
- sets a new flag on the event form called `archived` to `false`

#### deleteFormResponse
- sets the `archived` flag in the form response to `true` 
- squashes the data in the form response to only the necessary items (same as Case Archive)
- sets a new flag on the event form called `archived` to `true`
