### PR TITLE
Enable upload of photos and other media types including pdf and Word …

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -67,7 +67,7 @@
     "rxjs": "^6.5.5",
     "rxjs-compat": "^6.5.5",
     "spark-md5": "^3.0.2",
-    "tangy-form": "4.34.5",
+    "tangy-form": "4.35.1",
     "translation-web-component": "1.1.1",
     "tslib": "^1.10.0",
     "underscore": "^1.9.1",

--- a/client/src/app/sync/sync-media.service.ts
+++ b/client/src/app/sync/sync-media.service.ts
@@ -68,7 +68,7 @@ export class SyncMediaService {
     for (var i = 0; i < mediaDirEntries.length; i++) {
       this.lastEntry = (i + 1) === mediaDirEntries.length
       const entry = mediaDirEntries[i]
-      const fileName = entry.name + '.webm'
+      const fileName = entry.name
       console.log("processing file: " + fileName)
       this.statusMessage = _TRANSLATE("Uploading file: ") + fileName + "; " + (i + 1) + _TRANSLATE(" of ") + mediaDirEntries.length + _TRANSLATE(" to upload")
 
@@ -120,10 +120,10 @@ export class SyncMediaService {
       let reader = this.getFileReader();
       reader.onloadend = async (e) => {
         // Create a blob based on the FileReader "result", which we asked to be retrieved as an ArrayBuffer
-        const blob = new Blob([new Uint8Array(<ArrayBuffer>e.target.result)], {type: "video/webm"});
-        const fileName = file.name + '.webm'
+        const blob = new Blob([new Uint8Array(<ArrayBuffer>e.target.result)], {type: file.type});
+        const fileName = file.name
         const formData = new FormData();
-        formData.append('video', blob, fileName);
+        formData.append('media', blob, fileName);
         formData.append('md5', md5);
         // /app/:group/media-upload
         const url = `${appConfig.serverUrl}app/${appConfig.groupId}/client-media-upload`

--- a/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -173,14 +173,49 @@ export class TangyFormsPlayerComponent implements OnInit {
         })
         formEl.addEventListener('TANGY_MEDIA_UPDATE', async _ => {
           // _.preventDefault()
-          const filename = _.target.name + '_' + this.response?._id
+          let filename = _.target.name + '_' + this.response?._id
           const domString = _.target.value
           console.log("Caught TANGY_MEDIA_UPDATE event at: " + filename)
           if (this.window.isCordovaApp) {
             async function getBlob() {
               return new Promise((resolve, reject) => {
                 function reqListener () {
-                  console.log(this.response);
+                  console.log(`this.response type: ${this.response?.type} size: ${this.response?.size} `);
+                  let extension
+                  if (this.response.type === 'image/jpeg') {
+                    extension = '.jpg'
+                  } else if (this.response.type === 'image/png') {
+                    extension = '.png'
+                  } else if (this.response.type === 'audio/mpeg') {
+                    extension = '.mp3'
+                  } else if (this.response.type === 'video/mp4') {
+                    extension = '.mp4'
+                  } else if (this.response.type === 'text/csv') {
+                    extension = '.csv'
+                  } else if (this.response.type === 'application/pdf') {
+                    extension = '.pdf'
+                  } else if (this.response.type === 'application/msword') {
+                    extension = '.doc'
+                  } else if (this.response.type === 'application/vnd.ms-excel') {
+                    extension = '.xls'
+                  } else if (this.response.type === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') {
+                    extension = '.xlsx'
+                  } else if (this.response.type === 'application/zip') {
+                    extension = '.zip'
+                  } else if (this.response.type === 'application/json') {
+                    extension = '.json'
+                  } else if (this.response.type === 'application/xml') {
+                    extension = '.xml'
+                  } else if (this.response.type === 'image/svg+xml') {
+                    extension = '.svg'
+                  } else if (this.response.type === 'audio/wav') {
+                    extension = '.wav'
+                  } else if (this.response.type === 'video/webm') {
+                    extension = '.webm'
+                  } else if (this.response.type === 'audio/webm') {
+                    extension = '.weba'
+                  }
+                  filename = filename + extension
                   resolve(this.response)
                 }
                 const xhr = new XMLHttpRequest();
@@ -199,7 +234,7 @@ export class TangyFormsPlayerComponent implements OnInit {
             this.mediaFilesDirEntry.getFile(filename, {create: true, exclusive: false}, (fileEntry) => {
               fileEntry.createWriter((fileWriter) => {
                 fileWriter.onwriteend = (data) => {
-                  console.log(`Media file stored at ${this.mediaFilesDir}/${filename}`)
+                  console.log(`Media file stored at ${this.mediaFilesDir}${filename}`)
                 };
                 fileWriter.onerror = (e) => {
                   alert(`${_TRANSLATE('Write Failed')}` + e.toString());

--- a/editor/package.json
+++ b/editor/package.json
@@ -49,7 +49,7 @@
     "redux": "^4.0.5",
     "rxjs": "~6.5.5",
     "rxjs-compat": "^6.5.5",
-    "tangy-form": "4.34.5",
+    "tangy-form": "4.35.1",
     "tangy-form-editor": "7.14.5",
     "translation-web-component": "0.0.3",
     "tslib": "^1.11.2",

--- a/online-survey-app/package.json
+++ b/online-survey-app/package.json
@@ -25,7 +25,7 @@
     "material-design-icons-iconfont": "^6.1.0",
     "redux": "^4.0.5",
     "rxjs": "~6.6.0",
-    "tangy-form": "4.34.5",
+    "tangy-form": "4.35.1",
     "translation-web-component": "^1.1.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/server/src/routes/group-client-upload.js
+++ b/server/src/routes/group-client-upload.js
@@ -12,11 +12,7 @@ module.exports = async (req, res) => {
   const uploadedMd5 = req.body['md5']
   for (let file of req.files) {
     const fileMd5 = await md5File(file.path)
-    // const fileMd5Base64 = Buffer.from(fileMd5, 'binary').toString('base64')
-    // console.log("uploadedMd5: " + uploadedMd5 + " fileMd5Base64: " + fileMd5Base64 + " file.path: " + file.path)
-    // console.log("uploadedMd5: " + uploadedMd5 + " fileMd5: " + fileMd5 + " file.path: " + file.path)
     if (fileMd5 !== uploadedMd5) {
-    // if (fileMd5 !== fileMd5Base64) {
       console.error('md5 mismatch')
       res.statusMessage = 'File upload error: Invalid MD5';
       res.status(400).send('Invalid MD5')


### PR DESCRIPTION
In order to cause minimal negative impact upon current projects, the default behavior will be to save image files created by the tangy-photo-capture input to the database, instead of saving to a file and uploading. That being said, it is preferable to save to save as a file and upload. To over-ride this default, set the new `mediaFileStorageLocation` property to 'file' in the group's app-config.json. The default is 'database'. If this property is not defined, it will save to the database. New groups will be created with
  `mediaFileStorageLocation` set to 'file'. Videos created using the tangy-video-capture input will always be uploaded to the server due to their large file size.


Since tangy-forms-player.component uses the uploaded file's mime-type to create file extension, other inputs may take advantage of this new code to upload other types of files. See list below.

This PR also bumps tangy-form to 4.35.1

## Description

---

Enables file upload of the following file types:
- jpg
- png
- mp3
- mp4
- csv
- pdf
- doc
- xls
- xlsx
- zip
- json
- xml
- svg
- wav
- webm
- weba

Fixes #3352

## Type of Change

- New feature (non-breaking change which adds functionality)


