### PR TITLE
Fix app config doNotOptimize logic

### DIFF
--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -268,7 +268,7 @@ export class SyncService {
       }
     }
     if (appConfig.doNotOptimize && Array.isArray(appConfig.doNotOptimize)) {
-      viewsToOptimize = viewsToOptimize.filter(view => appConfig.doNotOptimize.includes(view))
+      viewsToOptimize = viewsToOptimize.filter(view => !appConfig.doNotOptimize.includes(view))
     }
     console.log(`Indexing ${viewsToOptimize.length} views.`)
     let i = 0


### PR DESCRIPTION
The logic for the 'doNotOptimize' setting in appConfig is applied in reverse. This fixes it.

```
  // List of views to skip optimization of after a sync.
  doNotOptimize: Array<string>
```