### PR TITLE
Remove unnecessary and expensive query for conflicts on the client

### DIFF
--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -440,10 +440,8 @@ export class SyncCouchdbService {
       try {
         userDb.db['replicate'].from(remoteDb, syncOptions).on('complete', async (info) => {
           // console.log("info.last_seq: " + info.last_seq)
-          const conflictsQuery = await userDb.query('sync-conflicts')
           status = <ReplicationStatus>{
             pulled: info.docs_written,
-            pullConflicts: conflictsQuery.rows.map(row => row.id),
             info: info,
             direction: direction
           }


### PR DESCRIPTION
We currently query for conflicts after sync which no longer gets used. This query can take a very long time if the database has in the tens of thousands of documents. Removing the query to prevent unnecessary time spent waiting for sync to finish. 