### PR TITLE
If syncProtocol is 1, don't save form after opening.

### DIFF
--- a/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -170,7 +170,9 @@ export class TangyFormsPlayerComponent implements OnInit {
         formEl.newResponse()
         this.formResponseId = formEl.response._id
         formEl.response.formVersionId = this.formInfo.formVersionId
-        this.throttledSaveResponse(formEl.response)
+        if (this.appConfig.syncProtocol !== '1') {
+          this.throttledSaveResponse(formEl.response)
+        }
       }
       this.response = formEl.response
       // Listen up, save in the db.


### PR DESCRIPTION
## Description

- Fixes #3360 

## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

Prevents extra saves when using s-p-1, which doesn't need the extra save that the case-module needs.