### PR TITLE
Fix redirect to check if the form is complete. If complete, do not force to resume

### DIFF
--- a/client/src/app/shared/_components/redirect-to-default-route/redirect-to-default-route.component.ts
+++ b/client/src/app/shared/_components/redirect-to-default-route/redirect-to-default-route.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { TangyFormService } from 'src/app/tangy-forms/tangy-form.service';
 
 import { AppConfigService } from '../../_services/app-config.service';
 import {VariableService} from "../../_services/variable.service";
@@ -15,7 +16,8 @@ export class RedirectToDefaultRouteComponent implements OnInit {
     private router: Router, 
     private appConfigService: AppConfigService, 
     private activatedRoute: ActivatedRoute,
-    private variableService: VariableService
+    private variableService: VariableService,
+    private formsService: TangyFormService
   ) {
     this.window = window;
   }
@@ -23,8 +25,9 @@ export class RedirectToDefaultRouteComponent implements OnInit {
   async ngOnInit() {
     const defaultUrl = '/forms-list';
     
-    const incompleteResponseId = await this.variableService.get('incomplete-response-id')
-    if (this.window.T.appConfig.config.forceCompleteForms === true && incompleteResponseId) {
+    const incompleteResponseId = await this.variableService.get('incomplete-response-id');
+    const currentForm = await this.formsService.getResponse(incompleteResponseId);
+    if (this.window.T.appConfig.config.forceCompleteForms&& incompleteResponseId&&!currentForm.complete) {
       this.router.navigate([`/tangy-forms/resume/${incompleteResponseId}`]);
     } else {
       const home_url = await this.appConfigService.getDefaultURL();


### PR DESCRIPTION

---

Fix redirect to check if the form is complete. If complete, do not force to resume


- Fixes #3415

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

Check if the form with the `incomplete-response-id` is marked as complete. Only redirect if it is `false`


