### PR TITLE
Client issue improvements and fixes

### DIFF
--- a/client/src/app/case/classes/case.class.ts
+++ b/client/src/app/case/classes/case.class.ts
@@ -15,6 +15,7 @@ class Case extends TangyFormResponseModel {
   disabledEventDefinitionIds?: Array<string> = []
   notifications?: Array<Notification> = []
   archived:boolean
+  groupId:string
 
   constructor(data?:any) {
     super()

--- a/client/src/app/case/components/issue/issue.component.html
+++ b/client/src/app/case/components/issue/issue.component.html
@@ -42,7 +42,7 @@
       </div>
       <div class="card-actions">
         <paper-button routerLink="form-revision"><mwc-icon>call_split</mwc-icon>{{'Propose'|translate}}</paper-button>
-        <!-- Not showing this on client for now paper-button *ngIf="hasProposedChange" (click)="onMergeClick()"><mwc-icon>call_merge</mwc-icon>Merge</paper-button -->
+        <paper-button *ngIf="hasProposedChange && hasMergeChangePermission" (click)="onMergeClick()"><mwc-icon>call_merge</mwc-icon>Commit</paper-button>
       </div>
     </paper-card>
 

--- a/client/src/app/case/components/issue/issue.component.ts
+++ b/client/src/app/case/components/issue/issue.component.ts
@@ -57,6 +57,7 @@ export class IssueComponent implements OnInit {
   numberOfChanges:number
   numberOfRevisions:number
   canMergeProposedChange = false
+  hasMergeChangePermission = false
   hasProposedChange = false
   isOpen = false
   diffMarkup:string
@@ -91,6 +92,8 @@ export class IssueComponent implements OnInit {
     this.isOpen = this.issue.status === IssueStatus.Open ? true : false
     this.canMergeProposedChange = await this.caseService.canMergeProposedChange(this.issue._id)
     this.hasProposedChange = await this.caseService.hasProposedChange(this.issue._id)
+    this.hasMergeChangePermission = await this.caseService.hasMergeChangePermission()
+
     this.eventInfos = this.issue.events.map(event => {
       return <EventInfo>{
         id: event.id,

--- a/client/src/app/case/components/issue/issue.component.ts
+++ b/client/src/app/case/components/issue/issue.component.ts
@@ -92,7 +92,7 @@ export class IssueComponent implements OnInit {
     this.isOpen = this.issue.status === IssueStatus.Open ? true : false
     this.canMergeProposedChange = await this.caseService.canMergeProposedChange(this.issue._id)
     this.hasProposedChange = await this.caseService.hasProposedChange(this.issue._id)
-    this.hasMergeChangePermission = await this.caseService.hasMergeChangePermission()
+    this.hasMergeChangePermission = await this.caseService.hasMergeChangePermission(this.issue._id)
 
     this.eventInfos = this.issue.events.map(event => {
       return <EventInfo>{

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -848,7 +848,8 @@ class CaseService {
   async createIssuesInQueue() {
     const userProfile = await this.userService.getUserProfile()
     for (let queuedIssue of this.queuedIssuesForCreation) {
-      await this.createIssue(queuedIssue.label, queuedIssue.comment, this.case._id, this.getCurrentCaseEventId(), this.getCurrentEventFormId(), userProfile._id, this.userService.getCurrentUser(), false, '')
+      const device = await this.deviceService.getDevice()
+      await this.createIssue(queuedIssue.label, queuedIssue.comment, this.case._id, this.getCurrentCaseEventId(), this.getCurrentEventFormId(), userProfile._id, this.userService.getCurrentUser(), false, device._id)
     }
     this.queuedIssuesForCreation = []
   }

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -1068,6 +1068,11 @@ class CaseService {
     return currentFormResponse._rev === eventBase.data.response._rev && currentCaseInstance._rev === eventBase.data.caseInstance._rev ? true : false
   }
 
+  async hasMergeChangePermission() {
+    const appConfig = await this.appConfigService.getAppConfig()
+    return appConfig.allowMergeOfIssues ? appConfig.allowMergeOfIssues : false
+  }
+
   async issueDiff(issueId) {
     const issue = new Issue(await this.tangyFormService.getResponse(issueId))
     const firstOpenEvent = issue.events.find(event => event.type === IssueEventType.Open)
@@ -1109,7 +1114,7 @@ class CaseService {
   }
 
   isIssueContext() {
-    return window.location.hash.includes('/issues/')
+    return window.location.hash.includes('/issues/') || window.location.hash.includes('/issue/')
       ? true
       : false
   }

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -1056,7 +1056,9 @@ class CaseService {
 
   async hasProposedChange(issueId:string) {
     const issue = new Issue(await this.tangyFormService.getResponse(issueId))
-    return !!issue.events.find(event => event.type === IssueEventType.ProposedChange)
+    const baseEvent = [...issue.events].reverse().find(event => event.type === IssueEventType.Open || event.type === IssueEventType.Rebase)
+    const indexOfBaseEvent = issue.events.findIndex(event => event.id === baseEvent.id)
+    return !!issue.events.find((event, i) => event.type === IssueEventType.ProposedChange && i > indexOfBaseEvent)
   }
 
   async canMergeProposedChange(issueId:string) {

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -284,7 +284,7 @@ class CaseService {
   hasEventFormPermission(operation:EventFormOperation, eventFormDefinition:EventFormDefinition, eventForm?:EventForm) {
     if (
       (
-        eventForm && !eventForm.inactive &&
+        eventForm && !eventForm.inactive && eventForm.permissions &&
         eventForm.permissions[operation].filter(op => this.userService.roles.includes(op)).length > 0
       ) ||
       (
@@ -1068,9 +1068,30 @@ class CaseService {
     return currentFormResponse._rev === eventBase.data.response._rev && currentCaseInstance._rev === eventBase.data.caseInstance._rev ? true : false
   }
 
-  async hasMergeChangePermission() {
-    const appConfig = await this.appConfigService.getAppConfig()
-    return appConfig.allowMergeOfIssues ? appConfig.allowMergeOfIssues : false
+  async hasMergeChangePermission(issueId:string) {
+    var allowed = false
+    const issue = new Issue(await this.tangyFormService.getResponse(issueId))
+    if (issue && issue.caseId && issue.eventId) {
+      const caseEvent = this.events.find(event => event.id === issue.eventId)
+      const caseEventDefinition = this.caseDefinition.eventDefinitions.find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
+
+      const eventForm = caseEvent.eventForms.find(form => form.id === issue.eventFormId)
+      const eventFormDefinition = caseEventDefinition.eventFormDefinitions.find(formDefinition => formDefinition.id === eventForm.eventFormDefinitionId)
+
+      const caseEventUpdatePermission = this.hasCaseEventPermission(CaseEventOperation.UPDATE, caseEventDefinition)
+
+      const eventFormUpdatePermission = this.hasEventFormPermission(EventFormOperation.UPDATE, eventFormDefinition)
+
+      const appConfig = await this.appConfigService.getAppConfig()
+
+      if (caseEventUpdatePermission && eventFormUpdatePermission) {
+        allowed = true
+      } else if (appConfig.allowMergeOfIssues) {
+        allowed = true
+      }
+    }
+
+    return allowed
   }
 
   async issueDiff(issueId) {

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -145,6 +145,10 @@ class CaseService {
     }, [])
   }
 
+  get groupId() {
+    return this._case.groupId
+  }
+
   get roleDefinitions() {
     return this.caseDefinition.caseRoles
   }

--- a/client/src/app/device/classes/device.class.ts
+++ b/client/src/app/device/classes/device.class.ts
@@ -8,6 +8,7 @@ export class Device {
   version:string
   syncLocations:Array<LocationConfig> = []
   assignedLocation:LocationConfig
+  assignedFormResponseIds:Array<string> = []
 }
 
 export interface LocationConfig {

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -118,7 +118,6 @@ export class AppConfig {
   // Determines if a "Merge Issue" button appears in the Issues Revision page.
   allowMergeOfIssues:boolean
   filterCaseEventScheduleByDeviceAssignedLocation:boolean = false
-  pullFormsModifiedOnServer:boolean = false
 
 
   //

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -115,7 +115,10 @@ export class AppConfig {
   barcodeSearchMapFunction:string
   // Determines if a "Create Issue" button appears when viewing submitted Event Forms.
   allowCreationOfIssues:boolean
+  // Determines if a "Merge Issue" button appears in the Issues Revision page.
+  allowMergeOfIssues:boolean
   filterCaseEventScheduleByDeviceAssignedLocation:boolean = false
+
 
   //
   // Tangerine Coach configuration.

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -118,6 +118,7 @@ export class AppConfig {
   // Determines if a "Merge Issue" button appears in the Issues Revision page.
   allowMergeOfIssues:boolean
   filterCaseEventScheduleByDeviceAssignedLocation:boolean = false
+  pullFormsModifiedOnServer:boolean = false
 
 
   //

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -17,6 +17,7 @@ import {TangyFormService} from "../tangy-forms/tangy-form.service";
 import { SyncDirection } from './sync-direction.enum';
 import { UserService } from '../shared/_services/user.service';
 import { DeviceService } from '../device/services/device.service';
+
 const sleep = (milliseconds) => new Promise((res) => setTimeout(() => res(true), milliseconds))
 const retryDelay = 5*1000
 
@@ -254,9 +255,44 @@ export class SyncCouchdbService {
     replicationStatus = {...replicationStatus, ...pullReplicationStatus}
     this.syncMessage$.next(replicationStatus);
 
-    // Whatever we pulled, even if there was an error, we don't need to push so set last push sequence again.
-    const localSequenceAfterPull = (await userDb.changes({descending: true, limit: 1})).last_seq
-    await this.variableService.set('sync-push-last_seq', localSequenceAfterPull)
+    // Pull Form Response Ids Assigned to the Device
+    // get the list of docs assigned to the device from the server device database
+    const deviceDoc = await this.deviceService.getRemoteDeviceInfo(syncDetails.deviceId, syncDetails.deviceToken)
+    const assignedFormResponseIds = deviceDoc?.assignedFormResponseIds ? deviceDoc.assignedFormResponseIds : []
+
+    /*
+    // Alternative implementation: Use a query on the server group database
+    // Why: Removes the need to manage saving form response ids to the devices group
+    // To implement, we need to make the 'deviceId' assigned to the form response perminent
+    const results = await pouch.query("changedFormResponsesByDeviceId", {
+      key          : syncDetails.deviceId,
+      include_docs : false
+    }).then(function (result) {
+      // handle result
+    }).catch(function (err) {
+      // handle errors
+    });
+    */
+
+    let pullIssueFormsReplicationStatus
+    let hadPullIssueFormsSuccess = false
+    while (!hadPullIssueFormsSuccess && !this.cancelling) {
+      try {
+        pullIssueFormsReplicationStatus = await this.pullFormResponses(userDb, remoteDb, assignedFormResponseIds, appConfig, syncDetails, batchSize);
+        if (!pullIssueFormsReplicationStatus.pullError) {
+          hadPullIssueFormsSuccess = true
+          pullIssueFormsReplicationStatus.hadPullSuccess = true
+        } else {
+          await sleep(retryDelay)
+          ++this.retryCount
+        }
+      } catch (e) {
+        console.error(e)
+        await sleep(retryDelay)
+      }
+    }
+    replicationStatus = {...replicationStatus, ...pullIssueFormsReplicationStatus}
+    this.syncMessage$.next(replicationStatus);
 
     if (this.cancelling) {
       this.finishCancelling(replicationStatus)
@@ -523,7 +559,7 @@ export class SyncCouchdbService {
     if (this.fullSync && this.fullSync === 'pull') {
       pull_last_seq = 0;
     }
-    const pullSelector = this.getPullSelector(syncDetails, userDb);
+    const pullSelector = this.getPullSelector(syncDetails);
     let progress = {
       'direction': 'pull',
       'message': 'Received data from remote server.'
@@ -580,18 +616,7 @@ export class SyncCouchdbService {
     return status;
   }
 
-  async getPullSelector(syncDetails:SyncCouchdbDetails, userDb:UserDatabase) {
-    const config = await this.appConfigService.getAppConfig()
-    var forms = []
-    if (config.pullFormsModifiedOnServer) {
-      try {
-        // filter out the _design docs with a start_key and end_key
-        const results = await userDb.allDocs({start_key: "0", end_key: "_", "inclusive_end": false})
-        forms = results.rows.reduce((forms, row) => {return [...forms,row.id]}, forms)
-      } catch (err) {
-        console.error("Failed to get local docs for pull selector")
-      }
-    }
+  getPullSelector(syncDetails:SyncCouchdbDetails) {
     const pullSelector = {
       "$or": [
         ...syncDetails.formInfos.reduce(($or, formInfo) => {
@@ -649,19 +674,81 @@ export class SyncCouchdbService {
               "resolveOnAppContext": AppContext.Client,
               "type": "issue"
             }
-          ],
-          ...config.pullFormsModifiedOnServer && forms.length > 0
-          ? [
-              {
-                "_id": {
-                  "$in": forms
-                }
-              }
-            ]
-          : []
+          ]
       ]
     }
     return pullSelector;
   }
+
+  async pullFormResponses(userDb, remoteDb, changedFormDocs, appConfig, syncDetails, batchSize): Promise<ReplicationStatus> {
+    let status = <ReplicationStatus>{
+      pulled: 0,
+      pullError: '',
+      pullConflicts: [],
+      info: '',
+      remaining: 0,
+      direction: 'pull' 
+    };
+    let pull_last_seq = await this.variableService.get('sync-pull-last_seq')
+    if (typeof pull_last_seq === 'undefined') {
+      pull_last_seq = 0;
+    }
+    if (this.fullSync && this.fullSync === 'pull') {
+      pull_last_seq = 0;
+    }
+
+    let progress = {
+      'direction': 'pull',
+      'message': 'Received data from remote server.'
+    }
+    this.syncMessage$.next(progress)
+    let failureDetected = false
+    let error;
+    let pulled = 0
+
+    /**
+     * The sync option batches_limit is set to 1 in order to reduce the memory load on the tablet. 
+     * From the pouchdb API doc:      
+     * "Number of batches to process at a time. Defaults to 10. This (along wtih batch_size) controls how many docs 
+     * are kept in memory at a time, so the maximum docs in memory at once would equal batch_size × batches_limit."
+     */
+    let syncOptions = {
+      ...syncDetails.usePouchDbLastSequenceTracking ? { } : { "since": pull_last_seq },
+      "batch_size": batchSize,
+      "write_batch_size": this.writeBatchSize,
+      "batches_limit": 1,
+      "pulled": pulled,
+      "doc_ids": changedFormDocs,
+      "checkpoint": 'target',
+      "changes_batch_size": this.changesBatchSize
+    }
+    syncOptions = this.pullSyncOptions ? this.pullSyncOptions : syncOptions
+
+    try {
+      status = <ReplicationStatus>await this._pull(userDb, remoteDb, syncOptions);
+      if (typeof status.pulled !== 'undefined') {
+        pulled = pulled + status.pulled
+        status.pulled = pulled
+      } else {
+        status.pulled = pulled
+      }
+      this.syncMessage$.next(status)
+    } catch (e) {
+      console.log("Error: " + e)
+      failureDetected = true
+      error = e
+    }
     
+    status.initialPullLastSeq = pull_last_seq
+    status.currentPushLastSeq = status.info.last_seq
+    status.batchSize = batchSize
+
+    if (failureDetected) {
+      status.pullError = `${error.message || error}. ${window['t']('Trying again')}: ${window['t']('Retry ')}${this.retryCount}.`
+    } 
+    
+    this.syncMessage$.next(status)
+    
+    return status;
+  }
 }

--- a/client/src/app/sync/sync-couchdb.service.ts
+++ b/client/src/app/sync/sync-couchdb.service.ts
@@ -261,20 +261,6 @@ export class SyncCouchdbService {
     const deviceDoc = await this.deviceService.getRemoteDeviceInfo(syncDetails.deviceId, syncDetails.deviceToken)
     const assignedFormResponseIds = deviceDoc?.assignedFormResponseIds ? deviceDoc.assignedFormResponseIds : []
 
-    /*
-    // Alternative implementation: Use a query on the server group database
-    // Why: Removes the need to manage saving form response ids to the devices group
-    // To implement, we need to make the 'deviceId' assigned to the form response perminent
-    const results = await pouch.query("changedFormResponsesByDeviceId", {
-      key          : syncDetails.deviceId,
-      include_docs : false
-    }).then(function (result) {
-      // handle result
-    }).catch(function (err) {
-      // handle errors
-    });
-    */
-
     let pullIssueFormsReplicationStatus
     let hadPullIssueFormsSuccess = false
     while (!hadPullIssueFormsSuccess && !this.cancelling) {

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -355,7 +355,7 @@ export class SyncService {
     const remoteDb = new PouchDB(syncSessionUrl)
     const pushOptions = {limit: this.compareLimit}
     const localDocs = await this.pageThroughAlldocsOrSelector(userDb.db, pushOptions, "local device");
-    const pullSelector = this.syncCouchdbService.getPullSelector(syncDetails);
+    const pullSelector = this.syncCouchdbService.getPullSelector(syncDetails, userDb);
     const pullOptions = {
       limit: this.compareLimit,
       selector: pullSelector,

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -355,7 +355,7 @@ export class SyncService {
     const remoteDb = new PouchDB(syncSessionUrl)
     const pushOptions = {limit: this.compareLimit}
     const localDocs = await this.pageThroughAlldocsOrSelector(userDb.db, pushOptions, "local device");
-    const pullSelector = this.syncCouchdbService.getPullSelector(syncDetails, userDb);
+    const pullSelector = this.syncCouchdbService.getPullSelector(syncDetails);
     const pullOptions = {
       limit: this.compareLimit,
       selector: pullSelector,

--- a/editor/src/app/case/classes/case.class.ts
+++ b/editor/src/app/case/classes/case.class.ts
@@ -17,6 +17,7 @@ class Case extends TangyFormResponseModel {
   notifications: Array<Notification> = []
   type:string = 'case'
   archived:boolean
+  groupId:string
   
   constructor(data?:any) {
     super()

--- a/editor/src/app/case/services/case.service.ts
+++ b/editor/src/app/case/services/case.service.ts
@@ -22,6 +22,7 @@ import { Injectable } from '@angular/core';
 import * as moment from 'moment';
 import { AppContext } from 'src/app/app-context.enum';
 import { CaseEventDefinition } from '../classes/case-event-definition.class';
+import { GroupDevicesService } from '../../groups/services/group-devices.service'
 
 @Injectable({
   providedIn: 'root'
@@ -103,7 +104,8 @@ class CaseService {
     private caseDefinitionsService: CaseDefinitionsService,
     private deviceService:DeviceService,
     private appConfigService:AppConfigService,
-    private http:HttpClient
+    private http:HttpClient,
+    private groupDevicesService:GroupDevicesService
   ) {
     this.queryCaseEventDefinitionId = 'query-event';
     this.queryEventFormDefinitionId = 'query-form-event';
@@ -133,6 +135,10 @@ class CaseService {
         ...forms
       ]
     }, [])
+  }
+
+  get groupId() {
+    return this._case.groupId
   }
 
   get roleDefinitions() {
@@ -1143,6 +1149,11 @@ class CaseService {
     const proposedFormResponse = await this.getProposedChange(issueId)
     await this.tangyFormService.saveResponse(proposedFormResponse.response)
     await this.tangyFormService.saveResponse(proposedFormResponse.caseInstance)
+    if (issue.sendToDeviceById) {
+      const device = await this.groupDevicesService.getDevice(this.groupId, issue.sendToDeviceById)
+      device.assignedFormResponseIds = [...new Set([...device.assignedFormResponseIds, ...[proposedFormResponse.response._id]])];
+      await this.groupDevicesService.updateDevice(this.groupId, device)
+    }
     await this.load(proposedFormResponse.caseInstance._id)
     return await this.tangyFormService.saveResponse({
       ...issue,

--- a/editor/src/app/groups/classes/group-device.class.ts
+++ b/editor/src/app/groups/classes/group-device.class.ts
@@ -15,6 +15,7 @@ export class GroupDevice {
   replicationStatus: ReplicationStatus // deprecated - migrate to replicationStatuses
   replicationStatuses: Array<ReplicationStatus>
   description:string
+  assignedFormResponseIds:Array<string> = []
 }
 
 class LocationInfo {

--- a/server/src/shared/classes/group-device.class.ts
+++ b/server/src/shared/classes/group-device.class.ts
@@ -11,6 +11,7 @@ export class GroupDevice {
   version:string
   syncLocations:Array<LocationConfig> = []
   assignedLocation:LocationConfig = new LocationConfig()
+  assignedFormResponseIds:Array<string> = []
 }
 
 export class SyncLocation {


### PR DESCRIPTION
Some quick fixes and updates on the client:

Fix: 
1. Calling caseService.isIssueContext() is broken --- it always returns 'false' on the client even when reviewing an issue. This is a problem when it is used in forms to prevent some form logic from running. The fix is to use the correct path with 'issue' instead of 'issues'

Updates:
1. Some Tangerine users have asked for any client user to be able to merge or commit proposed changes. This adds a app-config flag that turns the button on or off. It is set to 'off' by default.
2. Alternatively, merging updates can be granted via the CaseEvent and EventForm definitions in the case definition config
3. Add a flag to pull forms created on the client that were changed on the server. 
      
Notes on Update 3:

Assigning Issues to a Device:
1. Any issue created on the **client** will automatically add the deviceId to the issue's `sendToDeviceById` list. 
2. For an issue created on the **server**, the server admin must manually add the device `sendToDeviceById` list in the UI
```
 {
  "_id": "issue1",
  "type": "issue"
  "sendToDeviceById": "b0287fd1-34f3-480f-90d0-d1153ee7c0e2"
}
```

Assigning Issues to Device Documents:
When the issue is Merged, the issue's `formResponseId` will be added to the 'assignedFormResponseIds' list in the client's device doc on the server. 
```
 {
  "_id": "device1",
  "collection": "Device",
  "assignedFormResponseIds": [
    "b0287fd1-34f3-480f-90d0-d1153ee7c0e2"
  ]
}
```

Pulling Form Responses:
To pull down the form response, the sync protocol on the client has two new queries. First, it queries the group-<id>-devices group on the server by deviceId which has the list of 'assignedFormResponseIds':

```
const deviceDoc = this.deviceService.getRemoteDeviceInfo(syncDetails.deviceId, syncDetails.deviceToken)
const assignedFormResponseIds = deviceDoc.assignedFormResponseIds
```

The client then does a 'pull' on the list of doc ids using the sync-pull protocol using  a couchdb replicate option `doc_ids` instead of `selector`. All form responses in the list will be replicated.

```
const options = {
  ...
  doc_ids: assignedFormResponseIds
}
userDb.replicate(localDb, remoteDb, options)
```