### PR TITLE
Check for custom search js when creating user dbs

### DIFF
--- a/client/src/app/shared/_services/user.service.ts
+++ b/client/src/app/shared/_services/user.service.ts
@@ -71,7 +71,15 @@ export class UserService {
   async installSharedUserDatabase(device) {
     this.sharedUserDatabase = new UserDatabase('shared-user-database', 'install', device.key, device._id, true)
     const formsInfo = await this.formsInfoService.getFormsInfo()
-    await createSearchIndex(this.sharedUserDatabase, formsInfo)
+
+    let customSearchJs = ''
+    try {
+      customSearchJs = await this.http.get('./assets/custom-search.js', {responseType: 'text'}).toPromise()
+    } catch (err) {
+      // No custom-search.js, no problem.
+    }
+
+    await createSearchIndex(this.sharedUserDatabase, formsInfo, customSearchJs)
     await this.installDefaultUserDocs(this.sharedUserDatabase)
     // install any extra views
     try {
@@ -130,7 +138,15 @@ export class UserService {
     const userDb = new UserDatabase(username, userId, device.key, device._id)
     this.installDefaultUserDocs(userDb)
     const formsInfo = await this.formsInfoService.getFormsInfo()
-    await createSearchIndex(userDb, formsInfo)
+
+    let customSearchJs = ''
+    try {
+      customSearchJs = await this.http.get('./assets/custom-search.js', {responseType: 'text'}).toPromise()
+    } catch (err) {
+      // No custom-search.js, no problem.
+    }
+
+    await createSearchIndex(userDb, formsInfo, customSearchJs)
     this.userDatabases.push(userDb)
     return userDb
   }

--- a/client/src/app/sync/sync.service.ts
+++ b/client/src/app/sync/sync.service.ts
@@ -17,7 +17,6 @@ import {VariableService} from "../shared/_services/variable.service";
 import * as moment from 'moment'
 import {AppConfig} from "../shared/_classes/app-config.class";
 import {FormInfo} from "../tangy-forms/classes/form-info.class";
-import {createSearchIndex} from "../shared/_services/create-search-index";
 import { createSyncFormIndex } from './create-sync-form-index';
 import PouchDB from 'pouchdb'
 


### PR DESCRIPTION
An implementer of Tangerine can add custom search logic in a file called 'custom-search.js'. Currently that file is only loaded in install and update scripts. It gets missed in tangerine-preview.

This fixes the issue by looking for 'custom-search.js' when installing the databases. 