### PR TITLE
fix(csv): Fix non standard Latin characters in group name break CSV Request creation

### DIFF
--- a/server/src/routes/group-csv.js
+++ b/server/src/routes/group-csv.js
@@ -164,8 +164,9 @@ const getDataset = async (datasetId) => {
   let fileExists = false;
   let stateExists = false
   let excludePii = false
+  const stateUrl = encodeURI(result.stateUrl)
   try {
-    response = await http.get(result.stateUrl)
+    const response = await http.get(stateUrl)
     stateExists = true
     complete = response.data.complete
     state = response.data


### PR DESCRIPTION
use `encodeUri` when requesting the state of the file

Refs Tangerine-Community/Tangerine#3439
Refs Tangerine-Community/Tangerine#3217