### PR TITLE
Logging solution using express-winston and sample transport config

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -55,12 +55,7 @@
     "start:debug": "nodemon --config nodemon-debug.json",
     "prestart:prod": "rimraf dist && npm run build",
     "start:prod": "node dist/main.js",
-    "lint": "tslint -p tsconfig.json -c tslint.json",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "lint": "tslint -p tsconfig.json -c tslint.json"
   },
   "dependencies": {
     "@nestjs/common": "^6.0.0",
@@ -115,38 +110,22 @@
     "sqlstring": "^2.3.3",
     "tangy-log": "^1.0.0",
     "underscore": "^1.8.3",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "winston": "^3.8.2",
+    "express-winston": "^4.2.0",
+    "winston-daily-rotate-file": "^4.7.1"
   },
   "devDependencies": {
     "@nestjs/testing": "^6.0.0",
     "@types/express": "^4.16.0",
-    "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",
     "@types/supertest": "^2.0.7",
-    "jest": "^24.9.0",
-    "jest-circus": "^24.9.0",
     "nodemon": "^1.18.9",
     "prettier": "^1.15.3",
     "supertest": "^3.4.1",
-    "ts-jest": "^23.10.5",
     "ts-node": "^7.0.1",
     "tsconfig-paths": "^3.7.0",
     "tslint": "5.12.1",
     "typescript": "^3.2.4"
-  },
-  "jest": {
-    "testRunner": "jest-circus/runner",
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".spec.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
## Description



- Fixes #3497

## Type of Change

[Please delete irrelevant options]

- New feature (non-breaking change which adds functionality)

## Proposed Solution

 This would provide the following output: 

```json
{"level":"info","message":"GET /nest/group/list 401 59ms","meta":{}}
{"level":"info","message":"GET /nest/group/grumblepunk 404 11ms","meta":{}}
{"level":"info","message":"POST /api/group-3d906deb-cf37-4ddd-92d6-8ac3352aa5ca/upload 200 145ms","meta":{}}
{"level":"info","message":"POST /api/group-3d906deb-cf37-4ddd-92d6-8ac3352aa5ca/upload 200 197ms","meta":{}}
```

The second line would show if someone is trying to hack us. 
The 3rd and 4th shows that uploads were successful (200), and the time it took in ms. 