### PR TITLE
Make createEvent syncrhonous; add onOpenCaseEvent API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # What's new
 
+## v3.27.6
+
+__Fixes__
+- Address issues using the CaseService `createCaseEvent` API in `on-submit` logic by making the function synchronous
+
+__Server upgrade instructions__
+
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
+
+```
+cd tangerine
+# Check the size of the data folder.
+du -sh data
+# Check disk for free space. Ensure there is at least 10GB + size of the data folder amount of free space in order to perform the upgrade.
+df -h
+# Turn off tangerine and database.
+docker stop tangerine couchdb
+# Create a backup of the data folder.
+cp -r data ../data-backup-$(date "+%F-%T")
+# Check logs for the past hour on the server to ensure it's not being actively used. Look for log messages like "Created sync session" for Devices that are syncing and "login success" for users logging in on the server. 
+docker logs --since=60m tangerine
+# Fetch the updates.
+git fetch origin
+git checkout v3.27.6
+./start.sh v3.27.6
+# Remove Tangerine's previous version Docker Image.
+docker rmi tangerine/tangerine:v3.27.5
+```
+
+
 ## v3.27.5
 
 __Fixes__

--- a/client/src/app/case/components/case/case.component.ts
+++ b/client/src/app/case/components/case/case.component.ts
@@ -136,7 +136,8 @@ export class CaseComponent implements AfterContentInit, OnDestroy {
   async onSubmit() {
     const process = this.processMonitorService.start('savingEvent', _TRANSLATE('Saving event...'))
     if (this.selectedNewEventType !== '') {
-      await this.caseService.createEvent(this.selectedNewEventType)
+      var caseEvent = this.caseService.createEvent(this.selectedNewEventType)
+      await this.caseService.onCaseEventCreate(caseEvent)
       await this.caseService.save()
       this.calculateTemplateData()
       this.processMonitorService.stop(process.id)

--- a/client/src/app/case/components/event-form-add/event-form-add.component.ts
+++ b/client/src/app/case/components/event-form-add/event-form-add.component.ts
@@ -100,7 +100,7 @@ export class EventFormAddComponent implements AfterContentInit {
   }
 
   async startEventForm(eventFormDefinitionId:string, participantId:string) {
-    const eventForm = await this.caseService.createEventForm(this.caseEvent.id, eventFormDefinitionId, participantId)
+    const eventForm = this.caseService.createEventForm(this.caseEvent.id, eventFormDefinitionId, participantId)
     await this.caseService.save()
     // Then navigate
     this.router.navigate(['case', 'event', 'form', eventForm.caseId, eventForm.caseEventId, eventForm.id])

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -201,7 +201,7 @@ class CaseService {
     await this.setCase(this.case)
     this.case.caseDefinitionId = caseDefinitionId;
     if (this.caseDefinition.startFormOnOpen && this.caseDefinition.startFormOnOpen.eventFormId) {
-      const caseEvent = await this.createEvent(this.caseDefinition.startFormOnOpen.eventId)
+      const caseEvent = this.createEvent(this.caseDefinition.startFormOnOpen.eventId)
       this.createEventForm(caseEvent.id, this.caseDefinition.startFormOnOpen.eventFormId) 
     }
     await this.save()
@@ -328,7 +328,7 @@ class CaseService {
    * Case Event API
    */
 
-  async createEvent(eventDefinitionId:string): Promise<CaseEvent> {
+  createEvent(eventDefinitionId:string) {
     const caseEventDefinition = this.caseDefinition
       .eventDefinitions
       .find(eventDefinition => eventDefinition.id === eventDefinitionId)
@@ -361,9 +361,6 @@ class CaseService {
         }
       }
     }
-
-    await eval(caseEventDefinition.onEventCreate)
-
     return caseEvent
   }
 
@@ -1190,7 +1187,7 @@ class CaseService {
 
     if (caseEvent === undefined) {
         const newDate = moment(new Date(), 'YYYY-MM-DD').unix() * 1000;
-        caseEvent = await this.createEvent(this.queryCaseEventDefinitionId);
+        caseEvent = this.createEvent(this.queryCaseEventDefinitionId);
         await this.save();
       } else {
         caseEvent = this.case.events

--- a/client/src/app/case/services/case.service.ts
+++ b/client/src/app/case/services/case.service.ts
@@ -364,6 +364,14 @@ class CaseService {
     return caseEvent
   }
 
+  async onCaseEventCreate(caseEvent: CaseEvent) {
+    const caseEventDefinition = this.caseDefinition
+    .eventDefinitions
+    .find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
+
+    await eval(caseEventDefinition.onEventCreate)
+  }
+
   setEventName(eventId, name:string) {
     this.case.events = this.case.events.map(event => {
       return event.id === eventId

--- a/editor/src/app/case/components/case/case.component.ts
+++ b/editor/src/app/case/components/case/case.component.ts
@@ -204,8 +204,14 @@ export class CaseComponent implements AfterContentInit {
   }
 
   async onSubmit() {
-    await this.caseService.save()
-    this.calculateTemplateData()
+    const process = this.processMonitorService.start('savingEvent', _TRANSLATE('Saving event...'))
+    if (this.selectedNewEventType !== '') {
+      var caseEvent = this.caseService.createEvent(this.selectedNewEventType)
+      await this.caseService.onCaseEventCreate(caseEvent)
+      await this.caseService.save()
+      this.calculateTemplateData()
+      this.processMonitorService.stop(process.id)
+    }
   }
   async onRestore(event) {
     const restoreConfirmed = confirm(_TRANSLATE('Restore this event?'));

--- a/editor/src/app/case/components/event-form-add/event-form-add.component.ts
+++ b/editor/src/app/case/components/event-form-add/event-form-add.component.ts
@@ -94,7 +94,7 @@ export class EventFormAddComponent implements AfterContentInit {
   }
 
   async startEventForm(eventFormDefinitionId:string, participantId:string) {
-    const eventForm = await this.caseService.createEventForm(this.caseEvent.id, eventFormDefinitionId, participantId)
+    const eventForm = this.caseService.createEventForm(this.caseEvent.id, eventFormDefinitionId, participantId)
     await this.caseService.save()
     // Then navigate
     this.router.navigate(['case', 'event', 'form', eventForm.caseId, eventForm.caseEventId, eventForm.id])

--- a/editor/src/app/case/components/new-case/new-case.component.ts
+++ b/editor/src/app/case/components/new-case/new-case.component.ts
@@ -26,7 +26,7 @@ export class NewCaseComponent implements AfterContentInit {
       this.caseService.openCaseConfirmed = true
       let eventForm:EventForm
       if (this.caseService.caseDefinition.startFormOnOpen && this.caseService.caseDefinition.startFormOnOpen.eventFormId) {
-        const caseEvent = await this.caseService.createEvent(this.caseService.caseDefinition.startFormOnOpen.eventId)
+        const caseEvent = this.caseService.createEvent(this.caseService.caseDefinition.startFormOnOpen.eventId)
         eventForm = caseEvent.eventForms.find(eventForm => eventForm.eventFormDefinitionId === this.caseService.caseDefinition.startFormOnOpen.eventFormId)
         if (!eventForm){
           eventForm = await this.caseService.createEventForm(caseEvent.id, this.caseService.caseDefinition.startFormOnOpen.eventFormId) 

--- a/editor/src/app/case/services/case.service.ts
+++ b/editor/src/app/case/services/case.service.ts
@@ -375,7 +375,7 @@ class CaseService {
    * Case Event API
    */
 
-  async createEvent(eventDefinitionId:string): Promise<CaseEvent> {
+  createEvent(eventDefinitionId:string) {
     const caseEventDefinition = this.caseDefinition
       .eventDefinitions
       .find(eventDefinition => eventDefinition.id === eventDefinitionId)
@@ -409,9 +409,15 @@ class CaseService {
       }
     }
 
-    await eval(caseEventDefinition.onEventCreate)
-
     return caseEvent
+  }
+
+  async onCaseEventCreate(caseEvent: CaseEvent) {
+    const caseEventDefinition = this.caseDefinition
+    .eventDefinitions
+    .find(eventDefinition => eventDefinition.id === caseEvent.caseEventDefinitionId)
+
+    await eval(caseEventDefinition.onEventCreate)
   }
 
   setEventName(eventId, name:string) {
@@ -1269,7 +1275,7 @@ class CaseService {
 
     if (caseEvent === undefined) {
         const newDate = moment(new Date(), 'YYYY-MM-DD').unix() * 1000;
-        caseEvent = await this.createEvent(this.queryCaseEventDefinitionId);
+        caseEvent = this.createEvent(this.queryCaseEventDefinitionId);
         await this.save();
       } else {
         caseEvent = this.case.events


### PR DESCRIPTION
Fix breaking change for a critical bug in the Tangerine v3.27 branch that impacts clients using the caseService.createEvent API. Tangerine v3.27.0 added the ability to hook into the 'createEvent' API by adding a function in the case-definition.json file. The method introduced was made asynchronous which causes issues when running the API in on-submit logic. 