### PR TITLE
Online Survey App: Add GroupId to form response when uploading

### DIFF
--- a/online-survey-app/src/app/shared/_services/forms-service.service.ts
+++ b/online-survey-app/src/app/shared/_services/forms-service.service.ts
@@ -35,9 +35,14 @@ export class FormsServiceService {
     }
   }
 
-  async uploadFormResponse(formResponse, formId): Promise<boolean>{
+  async uploadFormResponse(formResponse): Promise<boolean>{
     try {
       const {formUploadURL, groupId, uploadKey} = await this.appConfigService.getAppConfig();
+
+      // Set the groupId or it will be missing from the form
+      // TODO: Move this logic to tangy-form so it happens for all responses
+      formResponse.groupId = groupId
+
       const headers = new HttpHeaders();
       headers.set('formUploadToken', uploadKey);
       const data = await this.httpClient.post(formUploadURL, formResponse, {headers, observe: 'response'}).toPromise();

--- a/online-survey-app/src/app/tangy-forms-player/tangy-forms-player.component.ts
+++ b/online-survey-app/src/app/tangy-forms-player/tangy-forms-player.component.ts
@@ -15,14 +15,13 @@ export class TangyFormsPlayerComponent implements OnInit {
   ) { }
 
   async ngOnInit(): Promise<any> {
-    const formId = this.route.snapshot.paramMap.get('formId');
     const data = await this.httpClient.get('./assets/form/form.html', {responseType: 'text'}).toPromise();
     this.container.nativeElement.innerHTML = data;
     const tangyForm = this.container.nativeElement.querySelector('tangy-form');
     tangyForm.addEventListener('after-submit', async (event) => {
       event.preventDefault();
       try {
-        if (await this.formsService.uploadFormResponse(event.target.response, formId)){
+        if (await this.formsService.uploadFormResponse(event.target.response)){
           this.router.navigate(['/form-submitted-success']);
         } else {
           alert('Form could not be submitted. Please retry');


### PR DESCRIPTION
Form responses generated by the Online Survey App do not currently contain values for the GroupId variable. This prevents the forms from being output to MySQL. This fixes that by added the groupId when the form response is about to be uploaded to the server. 