### PR TITLE
Release/v3.27.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # What's new
 
+## v3.27.8
+
+__Fixes__
+- Copy all media directories from the client form directories to ensure assets are available in online surveys
+- Allows form developers to publish images and sounds in online surveys
+
+__Server upgrade instructions__
+
+Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.
+
+```
+cd tangerine
+# Check the size of the data folder.
+du -sh data
+# Check disk for free space. Ensure there is at least 10GB + size of the data folder amount of free space in order to perform the upgrade.
+df -h
+# Turn off tangerine and database.
+docker stop tangerine couchdb
+# Create a backup of the data folder.
+cp -r data ../data-backup-$(date "+%F-%T")
+# Check logs for the past hour on the server to ensure it's not being actively used. Look for log messages like "Created sync session" for Devices that are syncing and "login success" for users logging in on the server. 
+docker logs --since=60m tangerine
+# Fetch the updates.
+git fetch origin
+git checkout -b v3.27.7 v3.27.7
+./start.sh v3.27.7
+# Remove Tangerine's previous version Docker Image.
+docker rmi tangerine/tangerine:v3.27.6
+```
+
 ## v3.27.7
 
 __Fixes__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,10 @@ cp -r data ../data-backup-$(date "+%F-%T")
 docker logs --since=60m tangerine
 # Fetch the updates.
 git fetch origin
-git checkout -b v3.27.7 v3.27.7
-./start.sh v3.27.7
+git checkout -b v3.27.8 v3.27.8
+./start.sh v3.27.8
 # Remove Tangerine's previous version Docker Image.
-docker rmi tangerine/tangerine:v3.27.6
+docker rmi tangerine/tangerine:v3.27.7
 ```
 
 ## v3.27.7

--- a/README.md
+++ b/README.md
@@ -120,29 +120,7 @@ When you start Tangerine, it creates two containers that need upgrades over time
 ### Server Upgrades
 Monitor <https://github.com/Tangerine-Community/Tangerine/releases> for new stable releases. Note that a "Pre-release" may not be stable, might corrupt your data, and there will not be an upgrade path for you.
 
-SSH into your server and run the following commands.
-```bash
-cd Tangerine
-git fetch origin
-git checkout <version tag>
-# Set up config.sh again.
-cp config.sh config.sh_backup
-cp config.defaults.sh config.sh
-# Migrate settings from config backup to config.sh.
-vim -O config.sh config.sh_backup
-rm config.sh_backup
-./start.sh <version number>
-# Check for upgrade scripts that need to be run. Note that you can only run scripts that end in .sh and you need to 
-# run every script between your prior version to version you have upgraded to. Also always check the release notes for
-# any special instructions -  for example:
-docker exec -it tangerine /tangerine/upgrades/<version>.sh
-# Upgrade scripts are also found in this location
-docker exec -it tangerine ls /tangerine/server/src/upgrade
-# Run an upgrade script indicated in release instructions.
-docker exec -it tangerine /tangerine/server/src/upgrade/<version>.sh
-# Remove the previous version of tangerine you had installed.
-docker rmi tangerine/tangerine:<previous tag>
-```
+SSH into your server and run the commands in the release.
 
 Note that if you have created groups already and you are now updating `T_HOST_NAME` or `T_PROTOCOL` in `config.sh`, you will manually need to edit the `settings` docs in each group. See [issue #114](https://github.com/Tangerine-Community/Tangerine/issues/114) for the status of this. 
 

--- a/server/src/scripts/release-online-survey-app.sh
+++ b/server/src/scripts/release-online-survey-app.sh
@@ -6,11 +6,6 @@ RELEASE_TYPE="$3"
 APP_NAME="$4"
 UPLOAD_KEY="$5"
 
-FORM_CLIENT_DIRECTORY="/tangerine/groups/$GROUP_ID/client/"
-FORM_DIRECTORY="$FORM_CLIENT_DIRECTORY/$FORM_ID"
-LOCATION_LIST_PATH="$FORM_CLIENT_DIRECTORY/location-list.json"
-MEDIA_DIRECTORY="$FORM_CLIENT_DIRECTORY/media/"
-
 if [ "$2" = "--help" ] || [ "$GROUP_ID" = "" ] || [ "$FORM_ID" = "" ] || [ "$RELEASE_TYPE" = "" ]; then
   echo ""
   echo "RELEASE Online Survey App"
@@ -37,11 +32,21 @@ RELEASE_DIRECTORY="/tangerine/client/releases/$RELEASE_TYPE/online-survey-apps/$
 echo $RELEASE_DIRECTORY
 
 rm -r $RELEASE_DIRECTORY
+
+
+FORM_CLIENT_DIRECTORY="/tangerine/groups/$GROUP_ID/client/"
+FORM_DIRECTORY="$FORM_CLIENT_DIRECTORY/$FORM_ID"
+LOCATION_LIST_PATH="$FORM_CLIENT_DIRECTORY/location-list.json"
+
+# Set up the release dir from the dist
 cp -r /tangerine/online-survey-app/dist/online-survey-app/ $RELEASE_DIRECTORY
-cp -r $FORM_DIRECTORY $RELEASE_DIRECTORY/assets/form
-cp $LOCATION_LIST_PATH $RELEASE_DIRECTORY/assets/
+
+# Copy the full contents of the client directory to the assets folder in the release
+cp -r $FORM_CLIENT_DIRECTORY/* $RELEASE_DIRECTORY/assets/
+# Rename the form folder to 'form' (required to load the form properly)
+mv $RELEASE_DIRECTORY/$FORM_ID $RELEASE_DIRECTORY/assets/form
+# Also copy in the translations
 cp /tangerine/translations/*.json $RELEASE_DIRECTORY/assets/
-cp -r $MEDIA_DIRECTORY $RELEASE_DIRECTORY/assets/media
 
 FORM_UPLOAD_URL="/onlineSurvey/saveResponse/$GROUP_ID/$FORM_ID"
 

--- a/server/src/scripts/release-online-survey-app.sh
+++ b/server/src/scripts/release-online-survey-app.sh
@@ -6,8 +6,11 @@ RELEASE_TYPE="$3"
 APP_NAME="$4"
 UPLOAD_KEY="$5"
 
-FORM_DIRECTORY="/tangerine/groups/$GROUP_ID/client/$FORM_ID"
-LOCATION_LIST_PATH="/tangerine/groups/$GROUP_ID/client/location-list.json"
+FORM_CLIENT_DIRECTORY="/tangerine/groups/$GROUP_ID/client/"
+FORM_DIRECTORY="$FORM_CLIENT_DIRECTORY/$FORM_ID"
+LOCATION_LIST_PATH="$FORM_CLIENT_DIRECTORY/location-list.json"
+MEDIA_DIRECTORY="$FORM_CLIENT_DIRECTORY/media/"
+SOUNDS_DIRECTORY="$FORM_CLIENT_DIRECTORY/sounds/"
 
 if [ "$2" = "--help" ] || [ "$GROUP_ID" = "" ] || [ "$FORM_ID" = "" ] || [ "$RELEASE_TYPE" = "" ]; then
   echo ""
@@ -39,6 +42,8 @@ cp -r /tangerine/online-survey-app/dist/online-survey-app/ $RELEASE_DIRECTORY
 cp -r $FORM_DIRECTORY $RELEASE_DIRECTORY/assets/form
 cp $LOCATION_LIST_PATH $RELEASE_DIRECTORY/assets/
 cp /tangerine/translations/*.json $RELEASE_DIRECTORY/assets/
+cp -r $MEDIA_DIRECTORY $RELEASE_DIRECTORY/assets/media
+cp -r $SOUNDS_DIRECTORY $RELEASE_DIRECTORY/assets/sounds
 
 FORM_UPLOAD_URL="/onlineSurvey/saveResponse/$GROUP_ID/$FORM_ID"
 

--- a/server/src/scripts/release-online-survey-app.sh
+++ b/server/src/scripts/release-online-survey-app.sh
@@ -42,11 +42,10 @@ LOCATION_LIST_PATH="$FORM_CLIENT_DIRECTORY/location-list.json"
 cp -r /tangerine/online-survey-app/dist/online-survey-app/ $RELEASE_DIRECTORY
 
 # Copy the full contents of the client directory to the assets folder in the release
+# Includes translations, media and any files added by the renderer and used by the forms
 cp -r $FORM_CLIENT_DIRECTORY/* $RELEASE_DIRECTORY/assets/
 # Rename the form folder to 'form' (required to load the form properly)
 mv $RELEASE_DIRECTORY/$FORM_ID $RELEASE_DIRECTORY/assets/form
-# Also copy in the translations
-cp /tangerine/translations/*.json $RELEASE_DIRECTORY/assets/
 
 FORM_UPLOAD_URL="/onlineSurvey/saveResponse/$GROUP_ID/$FORM_ID"
 

--- a/server/src/scripts/release-online-survey-app.sh
+++ b/server/src/scripts/release-online-survey-app.sh
@@ -10,7 +10,6 @@ FORM_CLIENT_DIRECTORY="/tangerine/groups/$GROUP_ID/client/"
 FORM_DIRECTORY="$FORM_CLIENT_DIRECTORY/$FORM_ID"
 LOCATION_LIST_PATH="$FORM_CLIENT_DIRECTORY/location-list.json"
 MEDIA_DIRECTORY="$FORM_CLIENT_DIRECTORY/media/"
-SOUNDS_DIRECTORY="$FORM_CLIENT_DIRECTORY/sounds/"
 
 if [ "$2" = "--help" ] || [ "$GROUP_ID" = "" ] || [ "$FORM_ID" = "" ] || [ "$RELEASE_TYPE" = "" ]; then
   echo ""
@@ -43,7 +42,6 @@ cp -r $FORM_DIRECTORY $RELEASE_DIRECTORY/assets/form
 cp $LOCATION_LIST_PATH $RELEASE_DIRECTORY/assets/
 cp /tangerine/translations/*.json $RELEASE_DIRECTORY/assets/
 cp -r $MEDIA_DIRECTORY $RELEASE_DIRECTORY/assets/media
-cp -r $SOUNDS_DIRECTORY $RELEASE_DIRECTORY/assets/sounds
 
 FORM_UPLOAD_URL="/onlineSurvey/saveResponse/$GROUP_ID/$FORM_ID"
 


### PR DESCRIPTION
## v3.27.8

__Fixes__
- Copy all media directories from the client form directories to ensure assets are available in online surveys
- Allows form developers to publish images and sounds in online surveys

__Server upgrade instructions__

Reminder: Consider using the [Tangerine Upgrade Checklist](https://docs.tangerinecentral.org/system-administrator/upgrade-checklist.html) for making sure you test the upgrade safely.

```
cd tangerine
# Check the size of the data folder.
du -sh data
# Check disk for free space. Ensure there is at least 10GB + size of the data folder amount of free space in order to perform the upgrade.
df -h
# Turn off tangerine and database.
docker stop tangerine couchdb
# Create a backup of the data folder.
cp -r data ../data-backup-$(date "+%F-%T")
# Check logs for the past hour on the server to ensure it's not being actively used. Look for log messages like "Created sync session" for Devices that are syncing and "login success" for users logging in on the server. 
docker logs --since=60m tangerine
# Fetch the updates.
git fetch origin
git checkout -b v3.27.7 v3.27.7
./start.sh v3.27.7
# Remove Tangerine's previous version Docker Image.
docker rmi tangerine/tangerine:v3.27.6
```