### PR TITLE
Re-order the way variable outputs are set based on metadata and tangy config

### DIFF
--- a/config.defaults.sh
+++ b/config.defaults.sh
@@ -108,16 +108,16 @@ T_TAG=""
 # Enforce Android tablet orientation. Options for T_ORIENTATION are at https://developer.mozilla.org/en-US/docs/Web/Manifest/orientation
 T_ORIENTATION="any"
 
-# In CSV output, set cell value to this when something is disabled or hidden. Set to "ORIGINAL_VALUE" if you want the actual value stored.
-T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH="999"
-
 # Set to false if you would like to use the skip-if functionality in editor. You would want to use skip-if as opposed to show-if if your form developers are stashing values in hidden fields.
 T_HIDE_SKIP_IF="true"
 
-# In CSV output, set cell value to this when something is skipped. Set to "ORIGINAL_VALUE" if you want the actual value stored.
+# In outputs, set cell value to this when something is disabled or hidden. Set to "ORIGINAL_VALUE" if you want the actual value stored.
+T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH="999"
+
+# In outputs, set cell value to this when something is skipped. Set to "ORIGINAL_VALUE" if you want the actual value stored.
 T_REPORTING_MARK_SKIPPED_WITH="SKIPPED"
 
-# In CSV output, set cell value to this when something is undefined. Set to "ORIGINAL_VALUE" if you want the actual value stored.
+# In outputs, set cell value to this when something is undefined. Set to "ORIGINAL_VALUE" if you want the actual value stored.
 T_REPORTING_MARK_UNDEFINED_WITH="UNDEFINED"
 
 # Set to true if you want Tangerine to ignore any settings in Sync Configuration and use Couchdb Sync for replication.

--- a/server/src/modules/csv/index.js
+++ b/server/src/modules/csv/index.js
@@ -251,17 +251,6 @@ const  generateFlatResponse = async function (formResponse, locationList, saniti
       participantId: formResponse.participantId || ''
     } : {}
   };
-  function set(input, key, value) {
-    flatFormResponse[key] = input.skipped
-        ? process.env.T_REPORTING_MARK_SKIPPED_WITH
-        : 
-        input.hidden && process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH !== "ORIGINAL_VALUE"
-            ? process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH 
-        : 
-        value === undefined && process.env.T_REPORTING_MARK_UNDEFINED_WITH !== "ORIGINAL_VALUE"
-            ? process.env.T_REPORTING_MARK_UNDEFINED_WITH
-            : value
-  }
   let formID = formResponse.form.id;
   for (let item of formResponse.items) {
     flatFormResponse[`${item.id}_firstOpenTime`]= item.firstOpenTime? item.firstOpenTime:''
@@ -278,29 +267,29 @@ const  generateFlatResponse = async function (formResponse, locationList, saniti
           // Populate the ID and Label columns for TANGY-LOCATION levels.
           locationKeys = []
           for (let group of input.value) {
-            set(input, `${formID}.${item.id}.${input.name}.${group.level}`, group.value)
+            tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.${group.level}`, group.value)
             locationKeys.push(group.value)
             try {
               const location = getLocationByKeys(locationKeys, locationList)
               for (let keyName in location) {
                 if (keyName !== 'children') {
-                  set(input, `${formID}.${item.id}.${input.name}.${group.level}_${keyName}`, location[keyName])
+                  tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.${group.level}_${keyName}`, location[keyName])
                 }
               }
             } catch (e) {
-              set(input, `${formID}.${item.id}.${input.name}.${group.level}_label`, 'orphaned')
+              tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.${group.level}_label`, 'orphaned')
             }
           }
         } else if (input.tagName === 'TANGY-RADIO-BUTTONS' || input.tagName === 'TANGY-RADIO-BLOCKS') {
           // Expected value type of input.value is Array, but custom logic may accidentally assign a different data type.
-          set(input, `${formID}.${item.id}.${input.name}`, Array.isArray(input.value) 
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, Array.isArray(input.value) 
             ? input.value.find(input => input.value == 'on')
               ? input.value.find(input => input.value == 'on').name
               : ''
             : `${input.value}`
           )
         } else if (input.tagName === 'TANGY-RADIO-BUTTON') {
-          set(input, `${formID}.${item.id}.${input.name}`, input.value
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, input.value
               ? '1'
               : '0'
           )
@@ -308,38 +297,38 @@ const  generateFlatResponse = async function (formResponse, locationList, saniti
           // Expected value type of input.value is Array, but custom logic may accidentally assign a different data type.
           if (Array.isArray(input.value)) {
             for (let checkboxInput of input.value) {
-              set(input, `${formID}.${item.id}.${input.name}_${checkboxInput.name}`, checkboxInput.value
+              tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}_${checkboxInput.name}`, checkboxInput.value
                   ? "1"
                   : "0"
               )
             }
           } else {
-            set(input, `${formID}.${item.id}.${input.name}`, `${input.value}`) 
+            tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, `${input.value}`) 
           }
         } else if (input.tagName === 'TANGY-CHECKBOX') {
-          set(input, `${formID}.${item.id}.${input.name}`, input.value
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, input.value
               ? "1"
               : "0"
           )
         } else if (input.tagName === 'TANGY-SIGNATURE') {
-          set(input, `${formID}.${item.id}.${input.name}`, input.value
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, input.value
               ? `${process.env.T_PROTOCOL}://${process.env.T_HOST_NAME}/app/${groupId}/response-variable-value/${formResponse._id}/${input.name}`
               : ""
           )         
         } else if (input.tagName === 'TANGY-PHOTO-CAPTURE') {
-          set(input, `${formID}.${item.id}.${input.name}`, input.value
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, input.value
               ? `${process.env.T_PROTOCOL}://${process.env.T_HOST_NAME}/app/${groupId}/response-variable-value/${formResponse._id}/${input.name}`
               : ""
           )         
         } else if (input.tagName === 'TANGY-VIDEO-CAPTURE') {
-          set(input, `${formID}.${item.id}.${input.name}`, input.value
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, input.value
               ? `${process.env.T_PROTOCOL}://${process.env.T_HOST_NAME}/app/${groupId}/response-variable-value/${formResponse._id}/${input.name}`
               : ""
           )
         } else if (input.tagName === 'TANGY-EFTOUCH') {
           let elementKeys = Object.keys(input.value);
           for (let key of elementKeys) {
-            set(
+            tangyModules.setVariable(flatFormResponse, 
               input, 
               `${formID}.${item.id}.${input.name}.${key}`, 
               Array.isArray(input.value[key])
@@ -361,26 +350,26 @@ const  generateFlatResponse = async function (formResponse, locationList, saniti
               // Correct.
               derivedValue = '1'
             }
-            set(input, `${formID}.${item.id}.${input.name}_${toggleInput.name}`, derivedValue)
+            tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}_${toggleInput.name}`, derivedValue)
             if (toggleInput.highlighted === true) {
               hitLastAttempted = true
             }
           }
           ;
-          set(input, `${formID}.${item.id}.${input.name}.duration`, input.duration)
-          set(input, `${formID}.${item.id}.${input.name}.time_remaining`, input.timeRemaining)
-          set(input, `${formID}.${item.id}.${input.name}.gridAutoStopped`, input.gridAutoStopped)
-          set(input, `${formID}.${item.id}.${input.name}.autoStop`, input.autoStop)
-          set(input, `${formID}.${item.id}.${input.name}.item_at_time`, input.gridVarItemAtTime ? input.gridVarItemAtTime : '')
-          set(input, `${formID}.${item.id}.${input.name}.time_intermediate_captured`, input.gridVarTimeIntermediateCaptured ? input.gridVarTimeIntermediateCaptured : '')
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.duration`, input.duration)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.time_remaining`, input.timeRemaining)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.gridAutoStopped`, input.gridAutoStopped)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.autoStop`, input.autoStop)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.item_at_time`, input.gridVarItemAtTime ? input.gridVarItemAtTime : '')
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.time_intermediate_captured`, input.gridVarTimeIntermediateCaptured ? input.gridVarTimeIntermediateCaptured : '')
           // Calculate Items Per Minute.
           let numberOfItemsAttempted = input.value.findIndex(el => el.highlighted ? true : false) + 1
           let numberOfItemsIncorrect = input.value.filter(el => el.value ? true : false).length
           let numberOfItemsCorrect = numberOfItemsAttempted - numberOfItemsIncorrect
-          set(input, `${formID}.${item.id}.${input.name}.number_of_items_correct`, numberOfItemsCorrect)
-          set(input, `${formID}.${item.id}.${input.name}.number_of_items_attempted`, numberOfItemsAttempted)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.number_of_items_correct`, numberOfItemsCorrect)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.number_of_items_attempted`, numberOfItemsAttempted)
           let timeSpent = input.duration - input.timeRemaining
-          set(input, `${formID}.${item.id}.${input.name}.items_per_minute`, Math.round(numberOfItemsCorrect / (timeSpent / 60)))
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.items_per_minute`, Math.round(numberOfItemsCorrect / (timeSpent / 60)))
         } else if (input.tagName === 'TANGY-UNTIMED-GRID') {
           let hitLastAttempted = false
           for (let toggleInput of input.value) {
@@ -395,7 +384,7 @@ const  generateFlatResponse = async function (formResponse, locationList, saniti
               // Correct.
               derivedValue = '1'
             }
-            set(input, `${formID}.${item.id}.${input.name}_${toggleInput.name}`, derivedValue)
+            tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}_${toggleInput.name}`, derivedValue)
             if (toggleInput.highlighted === true) {
               hitLastAttempted = true
             }
@@ -405,24 +394,24 @@ const  generateFlatResponse = async function (formResponse, locationList, saniti
           let totalNumberOfItems = input.value.length
           let numberOfItemsIncorrect = input.value.filter(el => el.value ? true : false).length
           let numberOfItemsCorrect = totalNumberOfItems - numberOfItemsIncorrect
-          set(input, `${formID}.${item.id}.${input.name}.number_of_items_correct`, numberOfItemsCorrect)
-          set(input, `${formID}.${item.id}.${input.name}.number_of_items_attempted`, numberOfItemsAttempted)
-          set(input, `${formID}.${item.id}.${input.name}.gridAutoStopped`, input.gridAutoStopped)
-          set(input, `${formID}.${item.id}.${input.name}.autoStop`, input.autoStop)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.number_of_items_correct`, numberOfItemsCorrect)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.number_of_items_attempted`, numberOfItemsAttempted)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.gridAutoStopped`, input.gridAutoStopped)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.autoStop`, input.autoStop)
         } else if (input.tagName === 'TANGY-BOX' || input.name === '') {
           // Do nothing :).
         } else if (input && typeof input.value === 'string') {
-          set(input, `${formID}.${item.id}.${input.name}`, input.value)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, input.value)
         } else if (input && typeof input.value === 'number') {
-          set(input, `${formID}.${item.id}.${input.name}`, input.value)
+          tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}`, input.value)
         } else if (input && Array.isArray(input.value)) {
           for (let group of input.value) {
-            set(input, `${formID}.${item.id}.${input.name}.${group.name}`, group.value)
+            tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.${group.name}`, group.value)
           }
         } else if ((input && typeof input.value === 'object') && (input && !Array.isArray(input.value)) && (input && input.value !== null)) {
           let elementKeys = Object.keys(input.value);
           for (let key of elementKeys) {
-            set(input, `${formID}.${item.id}.${input.name}.${key}`, input.value[key])
+            tangyModules.setVariable(flatFormResponse, input, `${formID}.${item.id}.${input.name}.${key}`, input.value[key])
           }
           ;
         }

--- a/server/src/modules/index.js
+++ b/server/src/modules/index.js
@@ -18,6 +18,33 @@ class TangyModules {
     return data;
   }
 
+  /*
+   * setVariable() is used in the modules to set the output value of a variable based on the input's metadata and the 
+   * Tangerine server level configurations related to reporting. The hierarchy of elements is based on our experience 
+   * in users want the data to appear.
+   * 
+   * Assumptions:
+   * 1. If the input is 'hidden' or 'disabled', it was not 'skipped' (intentionally) by the user
+   * 2. The input can only be 'skipped' if it is not 'hidden' or 'disabled'
+   * 3. 'undefined' variables are handled last
+   */
+  setVariable(flatFormResponse, input, key, value) {
+    if ((input.hidden || input.disabled)) {
+      if (process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH !== "ORIGINAL_VALUE") {
+        flatFormResponse[key] = process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH
+      } else {
+        flatFormResponse[key] = value
+      }
+    } else if (input.skipped && !input.required) {
+      flatFormResponse[key] = process.env.T_REPORTING_MARK_SKIPPED_WITH
+    } else if (value === undefined && process.env.T_REPORTING_MARK_UNDEFINED_WITH !== "ORIGINAL_VALUE") {
+      // value is neither hidden, disabled, nor skipped, but is still 'undefined'
+      flatFormResponse[key] = process.env.T_REPORTING_MARK_UNDEFINED_WITH
+    } else {
+      flatFormResponse[key] = value
+    }
+  }
+
 }
 
 module.exports = function() {

--- a/server/src/modules/mysql-js/index.js
+++ b/server/src/modules/mysql-js/index.js
@@ -331,13 +331,6 @@ const generateFlatResponse = async function (formResponse, locationList, sanitiz
     flatFormResponse['formId'] = formResponse.form.id
   }
 
-  function set(input, key, value) {
-    flatFormResponse[key.trim()] = input.skipped
-      ? process.env.T_REPORTING_MARK_SKIPPED_WITH
-      : input.hidden && process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH !== "ORIGINAL_VALUE"
-        ? process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH 
-        : value
-  }
   for (let item of formResponse.items) {
     for (let input of item.inputs) {
       let sanitize = false;
@@ -353,32 +346,32 @@ const generateFlatResponse = async function (formResponse, locationList, sanitiz
           // Populate the ID and Label columns for TANGY-LOCATION levels.
           locationKeys = []
           for (let group of input.value) {
-            set(input, `${firstIdSegment}${input.name}.${group.level}`, group.value)
+            tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${group.level}`, group.value)
             locationKeys.push(group.value)
             try {
               const location = getLocationByKeys(locationKeys, locationList)
               for (let keyName in location) {
                 if (keyName !== 'children') {
-                  set(input, `${firstIdSegment}${input.name}.${group.level}_${keyName}`, location[keyName])
+                  tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${group.level}_${keyName}`, location[keyName])
                 }
               }
             } catch(e) {
-              set(input, `${firstIdSegment}${input.name}.${group.level}_label`, 'orphaned')
+              tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${group.level}_label`, 'orphaned')
             }
           }
         } else if (input.tagName === 'TANGY-RADIO-BUTTONS' && Array.isArray(input.value)) {
           let selectedOption = input.value.find(option => !!option.value) 
-          set(input, `${firstIdSegment}${input.name}`, selectedOption ? selectedOption.name : '')
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, selectedOption ? selectedOption.name : '')
         } else if (input.tagName === 'TANGY-PHOTO-CAPTURE') {
-          set(input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
         } else if (input.tagName === 'TANGY-VIDEO-CAPTURE') {
-          set(input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
         } else if (input.tagName === 'TANGY-SIGNATURE') {
-          set(input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
         } else if (input && typeof input.value === 'string') {
-          set(input, `${firstIdSegment}${input.name}`, input.value)
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value)
         } else if (input && typeof input.value === 'number') {
-          set(input, `${firstIdSegment}${input.name}`, input.value)
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value)
         } else if (input && Array.isArray(input.value)) {
           let i = 0
           for (let group of input.value) {
@@ -387,7 +380,7 @@ const generateFlatResponse = async function (formResponse, locationList, sanitiz
             if (!group.name) {
               keyName = i
             }
-            set(input, `${firstIdSegment}${input.name}_${keyName}`, group.value)
+            tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}_${keyName}`, group.value)
           }
         } else if ((input && typeof input.value === 'object') && (input && !Array.isArray(input.value)) && (input && input.value !== null)) {
           let elementKeys = Object.keys(input.value);
@@ -398,7 +391,7 @@ const generateFlatResponse = async function (formResponse, locationList, sanitiz
             if (!key) {
               keyName = i
             }
-            set(input, `${firstIdSegment}${input.name}_${keyName}`, input.value[key])
+            tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}_${keyName}`, input.value[key])
           }
         }
       } // sanitize

--- a/server/src/modules/mysql/index.js
+++ b/server/src/modules/mysql/index.js
@@ -270,13 +270,6 @@ const generateFlatResponse = async function (formResponse, locationList, sanitiz
     complete: formResponse.complete,
     archived: formResponse.archived||''
   };
-  function set(input, key, value) {
-    flatFormResponse[key.trim()] = input.skipped
-      ? process.env.T_REPORTING_MARK_SKIPPED_WITH
-      : input.hidden && process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH !== "ORIGINAL_VALUE"
-        ? process.env.T_REPORTING_MARK_DISABLED_OR_HIDDEN_WITH 
-        : value
-  }
   for (let item of formResponse.items) {
     for (let input of item.inputs) {
       let sanitize = false;
@@ -292,38 +285,38 @@ const generateFlatResponse = async function (formResponse, locationList, sanitiz
         // Populate the ID and Label columns for TANGY-LOCATION levels.
         locationKeys = []
         for (let group of input.value) {
-          set(input, `${firstIdSegment}${input.name}.${group.level}`, group.value)
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${group.level}`, group.value)
           locationKeys.push(group.value)
           try {
             const location = getLocationByKeys(locationKeys, locationList)
             for (let keyName in location) {
               if (keyName !== 'children') {
-                set(input, `${firstIdSegment}${input.name}.${group.level}_${keyName}`, location[keyName])
+                tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${group.level}_${keyName}`, location[keyName])
               }
             }
           } catch(e) {
-            set(input, `${firstIdSegment}${input.name}.${group.level}_label`, 'orphaned')
+            tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${group.level}_label`, 'orphaned')
           }
         }
       } else if (input.tagName === 'TANGY-RADIO-BUTTONS' && Array.isArray(input.value)) {
         let selectedOption = input.value.find(option => !!option.value) 
-        set(input, `${firstIdSegment}${input.name}`, selectedOption ? selectedOption.name : '')
+        tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, selectedOption ? selectedOption.name : '')
       } else if (input.tagName === 'TANGY-PHOTO-CAPTURE') {
-        set(input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
+        tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
       } else if (input.tagName === 'TANGY-VIDEO-CAPTURE') {
-        set(input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
+        tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value ? 'true' : 'false')
       } else if (input && typeof input.value === 'string') {
-        set(input, `${firstIdSegment}${input.name}`, input.value)
+        tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value)
       } else if (input && typeof input.value === 'number') {
-        set(input, `${firstIdSegment}${input.name}`, input.value)
+        tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}`, input.value)
       } else if (input && Array.isArray(input.value)) {
         for (let group of input.value) {
-          set(input, `${firstIdSegment}${input.name}.${group.name}`, group.value)
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${group.name}`, group.value)
         }
       } else if ((input && typeof input.value === 'object') && (input && !Array.isArray(input.value)) && (input && input.value !== null)) {
         let elementKeys = Object.keys(input.value);
         for (let key of elementKeys) {
-          set(input, `${firstIdSegment}${input.name}.${key}`, input.value[key])
+          tangyModules.setVariable(flatFormResponse, input, `${firstIdSegment}${input.name}.${key}`, input.value[key])
         };
       }
       } // sanitize


### PR DESCRIPTION
This PR changes the order in which the Tangerine configurations related to skipped, hidden, disabled and unknown variables are applied. The order was to check 'skipped', then 'hidden' or 'disabled', then 'unknown'.  That is incorrect because all 'hidden' or 'disabled' variables are also 'skipped' so the second logic will never be applied. The 'skipped' variable (IMHO) is only useful: 1. if the variable is NOT required and 2. the user intentionally does not answer (value is ''). 

The updates in the PR change the order to 'hidden' or 'disabled', then 'skipped' and '!required', then 'unknown'.

I also think the 'unknown' might be moot as the third check and is only useful during the 'hidden' or 'disabled' check. 
