### PR TITLE
Save initial form response docs with included metadata

### DIFF
--- a/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/client/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -339,29 +339,28 @@ export class TangyFormsPlayerComponent implements OnInit {
   }
 
   async saveResponse(state) {
-    let stateDoc = {}
-    stateDoc = await this.tangyFormService.getResponse(state._id)
+    let stateDoc = await this.tangyFormService.getResponse(state._id)
     if (stateDoc && stateDoc['complete'] && state.complete && stateDoc['form'] && !stateDoc['form'].hasSummary) {
       // Since what is in the database is complete, and it's still complete, and it doesn't have 
       // a summary where they might add some input, don't save! They are probably reviewing data.
     } else {
-      if (!stateDoc) {
-        let r = await this.tangyFormService.saveResponse(state)
-        stateDoc = await this.tangyFormService.getResponse(state._id)
-      }
       // only reset incomplete-response-id when the form is complete. If the form is abandoned midway, do not reset incomplete-response-id.
       if (stateDoc && stateDoc['complete'] && state.complete) {
         await this.variableService.set('incomplete-response-id', null);
       }
+
       // reset some values.
-      stateDoc["uploadDatetime"] = ""
-      // now save the responseDoc.
-      await this.tangyFormService.saveResponse({
+      state["uploadDatetime"] = ""
+      state["_rev"] = stateDoc._rev
+
+      // add metadata
+      stateDoc = {
         ...state,
-        _rev: stateDoc['_rev'],
         location: this.location || state.location,
         ...this.metadata
-      })
+      }   
+      // now save the responseDoc.
+      await this.tangyFormService.saveResponse(stateDoc)
     }
     this.response = state
     this.$saved.next(state)

--- a/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -220,23 +220,19 @@ export class TangyFormsPlayerComponent {
   }
 
   async saveResponse(state) {
-    let stateDoc = {}
-    stateDoc = await this.tangyFormService.getResponse(state._id)
+    let stateDoc = await this.tangyFormService.getResponse(state._id)
     const archiveStateChange = state.archived === stateDoc['archived']
     if (stateDoc && stateDoc['complete'] && state.complete && stateDoc['form'] && !stateDoc['form'].hasSummary && archiveStateChange) {
       // Since what is in the database is complete, and it's still complete, and it doesn't have 
       // a summary where they might add some input, don't save! They are probably reviewing data.
     } else {
-      if (!stateDoc) {
-        let r = await this.tangyFormService.saveResponse(state)
-        stateDoc = await this.tangyFormService.getResponse(state._id)
-      }
-      await this.tangyFormService.saveResponse({
+      // add metadata
+      stateDoc = {
         ...state,
-        _rev: stateDoc['_rev'],
         location: this.location || state.location,
         ...this.metadata
-      })
+      }   
+      await this.tangyFormService.saveResponse(stateDoc)
     }
     this.response = state
   }


### PR DESCRIPTION
Users of the case module reported finding incomplete form responses with empty metadata include 'caseId', 'eventId', 'location' etc.. These erroneous forms can be created if the `tangyFormsPlayer.saveFormResponse()` function fails to complete (possibly due to a crash or database layer error). 

The code changed in this PR simplifies the `saveFormResponse` function so it **always** saves the form response with any metadata included in the tangy-form dom element.  There was no need that I can think of to save the form response without the metadata. 