### PR TITLE
feat(client): Add custom markup on Login page

### DIFF
--- a/client/src/app/core/auth/login/login.component.html
+++ b/client/src/app/core/auth/login/login.component.html
@@ -82,3 +82,4 @@
     </form>
   </div>
 </div>
+<span #customLoginMarkup></span>

--- a/client/src/app/core/auth/login/login.component.ts
+++ b/client/src/app/core/auth/login/login.component.ts
@@ -5,7 +5,7 @@ import { DeviceService } from './../../../device/services/device.service';
 import {from as observableFrom,  Observable } from 'rxjs';
 
 
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AppConfigService } from '../../../shared/_services/app-config.service';
 
@@ -33,6 +33,7 @@ export class LoginComponent implements OnInit {
   hidePassword = true
   passwordPolicy: string
   passwordRecipe: string
+  @ViewChild('customLoginMarkup', {static: true}) customLoginMarkup: ElementRef;
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -59,6 +60,7 @@ export class LoginComponent implements OnInit {
     if (this.userService.isLoggedIn()) {
       this.router.navigate([this.returnUrl]);
     }
+    this.customLoginMarkup.nativeElement.innerHTML = appConfig.customLoginMarkup || '';
 
   }
 

--- a/client/src/app/shared/_classes/app-config.class.ts
+++ b/client/src/app/shared/_classes/app-config.class.ts
@@ -10,7 +10,8 @@ export class AppConfig {
   // Tangerine Case Management: 'case-home'
   // Tangerine Teach: 'dashboard'
   homeUrl = "case-management"
-
+  // customLoginMarkup Custom Markup to include on the login page
+  customLoginMarkup: string
   //
   // i18n configuration.
   //


### PR DESCRIPTION

## Description

---

* Allow users to include custom markup to be rendered in the login page
* Add property `customLoginMarkup` to `app.config.json` that accepts valid `HTML` markup that will be rendered in the login page after the `Login` and `Reset Password` buttons.
* If `customLoginMarkup` is not defined in the `app.config.json`, customLoginMarkup defaults to an empty string thus nothing is rendered


## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
