### PR TITLE
Add the detach option to the start-docker-compose script

### DIFF
--- a/start-docker-compose.sh
+++ b/start-docker-compose.sh
@@ -74,4 +74,4 @@ if [ ! -d state ]; then
   mkdir state
 fi
 
-docker compose up
+docker compose up -d

--- a/tangerine-preview/package.json
+++ b/tangerine-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangerine-preview",
-  "version": "3.12.5",
+  "version": "4.0.1",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Proposed fix that enables the v4 docker containers to be run detached so a session does not need to be active. 