### PR TITLE
Data > Uploads: reset search and fix options in query

### DIFF
--- a/editor/src/app/groups/responses/responses.component.ts
+++ b/editor/src/app/groups/responses/responses.component.ts
@@ -64,11 +64,16 @@ export class ResponsesComponent implements OnInit {
       .nativeElement
       .addEventListener('keyup', event => {
         const searchString = event.target.value.trim()
+        if (searchString.length == 0) {
+          if (this.searchString === searchString) return;
+          this.onSearch$.next()
+        }         
         if (searchString.length > 2) {
           if (this.searchString === searchString) return;
           this.searchResults.nativeElement.innerHTML = 'Searching...'
           this.onSearch$.next(event.target.value)
-        } if(searchString.length <= 2 && searchString.length !==0 ) {
+        } 
+        if(searchString.length <= 2 && searchString.length !==0 ) {
           this.searchResults.nativeElement.innerHTML = `
             <span style="padding: 25px">
               ${t('Enter more than two characters...')}

--- a/server/src/routes/group-responses.js
+++ b/server/src/routes/group-responses.js
@@ -12,15 +12,15 @@ module.exports = async (req, res) => {
     if (req.params.skip) {
       options.skip = req.params.skip
     }
-    if (Object.keys(req.query).length < 1 ){
-      const results = await groupDb.query('responsesByStartUnixTime', options);
-      const docs = results.rows.map(row => row.doc)
-      res.send(docs)
-    } else{
-      const results = await groupDb.query('responsesByStartUnixTime', {include_docs: true, descending: true, startkey:req.query.id});
-      const docs = results.rows.filter(row => row.id.startsWith(req.query.id)).map(row => row.doc)
-      res.send(docs)
+    if (Object.keys(req.query).length < 1) {
+      options.startkey = req.query.id;
+      options.endkey = `${req.query.id}\ufff0`;
     }
+    
+    const results = await groupDb.query('responsesByStartUnixTime', options);
+    const docs = results.rows.map(row => row.doc)
+    res.send(docs)
+    
   } catch (error) {
     log.error(error);
     res.status(500).send(error);


### PR DESCRIPTION
- When the user clears the search bar, run the full search
- Include the 'limit' and 'skip' in the search when an 'id' is included for query