### PR TITLE
Add index to docs before search by ID

### DIFF
--- a/editor/src/app/groups/responses/responses.component.ts
+++ b/editor/src/app/groups/responses/responses.component.ts
@@ -62,7 +62,7 @@ export class ResponsesComponent implements OnInit {
     this
       .searchBar
       .nativeElement
-      .addEventListener('keyup', event => {
+      .addEventListener('keyup', async event => {
         const searchString = event.target.value.trim()
         if (searchString.length > 2) {
           if (this.searchString === searchString) return;
@@ -74,6 +74,10 @@ export class ResponsesComponent implements OnInit {
               ${t('Enter more than two characters...')}
             </span>
           `
+        } if(searchString.length===0){
+          this.searchResults.nativeElement.innerHTML = ''
+          this.searchString = ''
+          await this.getResponses()
         }
       })
   }

--- a/server/src/routes/group-responses.js
+++ b/server/src/routes/group-responses.js
@@ -36,7 +36,6 @@ module.exports = async (req, res) => {
     res.status(500).send(error);
   }
 }
-
 export const importViews = async (db) => {
   await db.put({
     _id: "_design/searchViews",


### PR DESCRIPTION
## Description

---

Ensure docs are indexed before running search query

- Refs Tangerine-Community/Tangerine#3691

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Proposed Solution

---

Index the docs to allow fast queries

## Limitations and Trade-offs

The first search may be slow unless the index is run first on the DB before search


