### PR TITLE
feat(group-uploads-view): Add Verification to group uploads

### DIFF
--- a/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.html
+++ b/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.html
@@ -1,0 +1,2 @@
+<app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
+<app-tangy-forms-player #formPlayer></app-tangy-forms-player>

--- a/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.html
+++ b/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.html
@@ -1,2 +1,2 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
-<app-tangy-forms-player #formPlayer></app-tangy-forms-player>
+<app-tangy-forms-player unlockFormResponses="true" #formPlayer></app-tangy-forms-player>

--- a/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.spec.ts
+++ b/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GroupUploadsEditComponent } from './group-uploads-edit.component';
+
+describe('GroupUploadsEditComponent', () => {
+  let component: GroupUploadsEditComponent;
+  let fixture: ComponentFixture<GroupUploadsEditComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GroupUploadsEditComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupUploadsEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
+++ b/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
@@ -37,7 +37,6 @@ export class GroupUploadsEditComponent implements OnInit {
         }
       ]
       this.formPlayer.formResponseId = params.responseId
-      this.formPlayer.unlockFormResponses = true
       this.formPlayer.render()
       this.formPlayer.$submit.subscribe(async () => {
         this.formPlayer.saveResponse(this.formPlayer.formEl.store.getState())

--- a/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
+++ b/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
@@ -1,0 +1,49 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Breadcrumb } from 'src/app/shared/_components/breadcrumb/breadcrumb.component';
+import { _TRANSLATE } from 'src/app/shared/translation-marker';
+import { TangyFormsPlayerComponent } from 'src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component';
+
+@Component({
+  selector: 'app-group-uploads-edit',
+  templateUrl: './group-uploads-edit.component.html',
+  styleUrls: ['./group-uploads-edit.component.css']
+})
+export class GroupUploadsEditComponent implements OnInit {
+
+  title = _TRANSLATE('Edit Upload')
+  breadcrumbs:Array<Breadcrumb> = []
+  @ViewChild('formPlayer', {static: true}) formPlayer: TangyFormsPlayerComponent
+ 
+  constructor(
+    private route:ActivatedRoute,
+    private router:Router
+  ) { }
+
+  ngOnInit() {
+    this.route.params.subscribe(params => {
+      this.breadcrumbs = [
+        <Breadcrumb>{
+          label: _TRANSLATE('Uploads'),
+          url: 'uploads'
+        },
+        <Breadcrumb>{
+          label: _TRANSLATE('View Upload'),
+          url: `uploads/${params.responseId}` 
+        },
+        <Breadcrumb>{
+          label: this.title,
+          url: `uploads/${params.responseId}/edit` 
+        }
+      ]
+      this.formPlayer.formResponseId = params.responseId
+      this.formPlayer.unlockFormResponses = true
+      this.formPlayer.render()
+      this.formPlayer.$submit.subscribe(async () => {
+        this.formPlayer.saveResponse(this.formPlayer.formEl.store.getState())
+        this.router.navigate([`../`], { relativeTo: this.route })
+      })
+    })
+  }
+
+}

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.css
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.css
@@ -1,0 +1,12 @@
+.sticky {
+    position: sticky;
+    top: 20px;
+    max-width: fit-content;
+    margin-inline: auto;
+    z-index: 999;
+}
+
+button, a{
+    margin-right: 10px;
+    margin-top: 10px;
+}

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.html
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.html
@@ -6,4 +6,4 @@
 
     <button mat-raised-button color="warn" (click)="delete()">{{'Delete'|translate}}</button>
 </div>
-<app-tangy-forms-player #formPlayer></app-tangy-forms-player>
+<app-tangy-forms-player #formPlayer></app-tangy-forms-player>π

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.html
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.html
@@ -1,2 +1,9 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
+<div class="sticky">
+    <button mat-raised-button color="warn" (click)="verify()">{{'Verify'|translate}}</button>
+
+    <a routerLink="edit" mat-raised-button color="warn">{{'Edit'|translate}}</a>
+
+    <button mat-raised-button color="warn" (click)="delete()">{{'Delete'|translate}}</button>
+</div>
 <app-tangy-forms-player #formPlayer></app-tangy-forms-player>

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
@@ -4,6 +4,7 @@ import { Breadcrumb } from './../../shared/_components/breadcrumb/breadcrumb.com
 import { _TRANSLATE } from 'src/app/shared/_services/translation-marker';
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { TangyFormService } from 'src/app/tangy-forms/tangy-form.service';
 
 @Component({
   selector: 'app-group-uploads-view',
@@ -22,6 +23,7 @@ export class GroupUploadsViewComponent implements OnInit {
     private route:ActivatedRoute,
     private router:Router,
     private http: HttpClient,
+    private tangyFormService: TangyFormService,
   ) { }
 
   ngOnInit() {
@@ -55,7 +57,14 @@ export class GroupUploadsViewComponent implements OnInit {
   }
 
   async verify(){
-
+    try {
+      const data = {...this.formPlayer.formEl.store.getState(), verified:true};
+      await this.tangyFormService.saveResponse(data)
+      alert(_TRANSLATE('Verified successfully.'))
+    } catch (error) {
+      alert(_TRANSLATE('Verification was unsuccessful. Please try again.'))
+      console.log(error)
+    }
   }
 
 }

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Breadcrumb } from './../../shared/_components/breadcrumb/breadcrumb.component';
 import { _TRANSLATE } from 'src/app/shared/_services/translation-marker';
 import { Component, OnInit, ViewChild } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-group-uploads-view',
@@ -14,14 +15,19 @@ export class GroupUploadsViewComponent implements OnInit {
   title = _TRANSLATE('View Upload')
   breadcrumbs:Array<Breadcrumb> = []
   @ViewChild('formPlayer', {static: true}) formPlayer: TangyFormsPlayerComponent
+  responseId
+  groupId
  
   constructor(
     private route:ActivatedRoute,
-    private router:Router
+    private router:Router,
+    private http: HttpClient,
   ) { }
 
   ngOnInit() {
     this.route.params.subscribe(params => {
+      this.responseId = params.responseId
+      this.groupId = params.groupId
       this.breadcrumbs = [
         <Breadcrumb>{
           label: _TRANSLATE('Uploads'),
@@ -29,17 +35,27 @@ export class GroupUploadsViewComponent implements OnInit {
         },
         <Breadcrumb>{
           label: this.title,
-          url: `uploads/view/${params.responseId}` 
+          url: `uploads/${params.responseId}`
         }
       ]
       this.formPlayer.formResponseId = params.responseId
-      this.formPlayer.unlockFormResponses = true
       this.formPlayer.render()
       this.formPlayer.$submit.subscribe(async () => {
         this.formPlayer.saveResponse(this.formPlayer.formEl.store.getState())
         this.router.navigate([`../`], { relativeTo: this.route })
       })
     })
+  }
+
+  async delete(){
+    if(confirm('Are you sure you want to delete this form response?')) {
+      await this.http.delete(`/api/${this.groupId}/${this.responseId}`).toPromise()
+      this.router.navigate([`../`], { relativeTo: this.route })
+    }
+  }
+
+  async verify(){
+
   }
 
 }

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
@@ -59,8 +59,12 @@ export class GroupUploadsViewComponent implements OnInit {
   async verify(){
     try {
       const data = {...this.formPlayer.formEl.store.getState(), verified:true};
-      await this.tangyFormService.saveResponse(data)
-      alert(_TRANSLATE('Verified successfully.'))
+      const result = await this.tangyFormService.saveResponse(data)
+      if(result){
+        alert(_TRANSLATE('Verified successfully.'))
+      }else{
+        alert(_TRANSLATE('Verification was unsuccessful. Please try again.'))
+      }
     } catch (error) {
       alert(_TRANSLATE('Verification was unsuccessful. Please try again.'))
       console.log(error)

--- a/editor/src/app/groups/group-uploads/group-uploads.component.html
+++ b/editor/src/app/groups/group-uploads/group-uploads.component.html
@@ -1,4 +1,4 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
 <div class="responses-container">
-  <app-responses [groupId]="groupId" [excludeForms]="['user-profile']"></app-responses>
+  <app-responses [hideActionBar]="true" [groupId]="groupId" [excludeForms]="['user-profile']"></app-responses>
 </div>

--- a/editor/src/app/groups/groups-routing.module.ts
+++ b/editor/src/app/groups/groups-routing.module.ts
@@ -70,6 +70,7 @@ import { GroupCsvTemplatesComponent } from './group-csv-templates/group-csv-temp
 import { GroupDatabaseConflictsComponent } from './group-database-conflicts/group-database-conflicts.component';
 import { DownloadStatisticalFileComponent } from './download-statistical-file/download-statistical-file.component';
 import { GroupDevicePasswordPolicyComponent } from './group-device-password-policy/group-device-password-policy.component';
+import { GroupUploadsEditComponent } from './group-uploads-edit/group-uploads-edit.component';
 
 const groupsRoutes: Routes = [
   // { path: 'projects', component: GroupsComponent },
@@ -86,6 +87,7 @@ const groupsRoutes: Routes = [
   { path: 'groups/:groupId/data', component: GroupDataComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/data/uploads', component: GroupUploadsComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/data/uploads/:responseId', component: GroupUploadsViewComponent, canActivate: [LoginGuard] },
+  { path: 'groups/:groupId/data/uploads/:responseId/edit', component: GroupUploadsEditComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/data/download-csv', component: GroupFormsCsvComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/data/database-conflicts', component: GroupDatabaseConflictsComponent, canActivate: [LoginGuard] },
   { path: 'groups/:groupId/data/csv-templates', component: GroupCsvTemplatesComponent, canActivate: [LoginGuard] },

--- a/editor/src/app/groups/groups.module.ts
+++ b/editor/src/app/groups/groups.module.ts
@@ -99,6 +99,7 @@ import { DownloadStatisticalFileComponent } from './download-statistical-file/do
 import { GroupDevicePasswordPolicyComponent } from './group-device-password-policy/group-device-password-policy.component';
 import { GroupLocationListsComponent } from './group-location-lists/group-location-lists.component';
 import { GroupLocationListNewComponent } from './group-location-list-new/group-location-list-new.component';
+import { GroupUploadsEditComponent } from './group-uploads-edit/group-uploads-edit.component';
 
 
 @NgModule({
@@ -204,7 +205,8 @@ import { GroupLocationListNewComponent } from './group-location-list-new/group-l
     GroupCsvTemplatesComponent,
     GroupDatabaseConflictsComponent,
     DownloadStatisticalFileComponent,
-    GroupDevicePasswordPolicyComponent
+    GroupDevicePasswordPolicyComponent,
+    GroupUploadsEditComponent
   ],
   providers: [GroupsService, FilesService, TangerineFormsService, GroupDevicesService, TangyFormService ],
 })

--- a/editor/src/app/groups/responses/responses.component.html
+++ b/editor/src/app/groups/responses/responses.component.html
@@ -10,7 +10,7 @@
 <div id="search-results" #searchResults>
 </div>
 <div class="table" *ngIf="ready">
-  <app-dynamic-table [data]="responses" (rowEdit)="onRowEdit($event)" (rowClick)="onRowClick(($event))"></app-dynamic-table>
+  <app-dynamic-table [hideActionBar]="hideActionBar" [data]="responses" (rowEdit)="onRowEdit($event)" (rowDelete)="onRowDelete($event)" (rowClick)="onRowClick(($event))"></app-dynamic-table>
 </div>
 <paper-button *ngIf="this.skip !== 0" (click)="previousPage()">< back</paper-button>
 <paper-button  (click)="nextPage()">next ></paper-button>

--- a/editor/src/app/groups/responses/responses.component.html
+++ b/editor/src/app/groups/responses/responses.component.html
@@ -10,7 +10,7 @@
 <div id="search-results" #searchResults>
 </div>
 <div class="table" *ngIf="ready">
-  <app-dynamic-table [data]="responses" (rowDelete)="onRowDelete($event)" (rowEdit)="onRowEdit($event)"></app-dynamic-table>
+  <app-dynamic-table [data]="responses" (rowEdit)="onRowEdit($event)" (rowClick)="onRowClick(($event))"></app-dynamic-table>
 </div>
 <paper-button *ngIf="this.skip !== 0" (click)="previousPage()">< back</paper-button>
 <paper-button  (click)="nextPage()">next ></paper-button>

--- a/editor/src/app/groups/responses/responses.component.ts
+++ b/editor/src/app/groups/responses/responses.component.ts
@@ -22,6 +22,7 @@ export class ResponsesComponent implements OnInit {
   @Input() excludeForms:Array<string> = []
   @Input() excludeColumns:Array<string> = []
   @Input() hideFilterBy = false
+  @Input() hideActionBar = false
   @ViewChild('searchBar', {static: true}) searchBar: ElementRef
   @ViewChild('searchResults', {static: true}) searchResults: ElementRef
   onSearch$ = new Subject()
@@ -128,6 +129,12 @@ export class ResponsesComponent implements OnInit {
     this.skip = 0;
     this.getResponses();
   }
+  async deleteResponse(id) {
+    if(confirm('Are you sure you want to delete this form response?')) {
+      await this.http.delete(`/api/${this.groupId}/${id}`).toPromise()
+      this.getResponses()
+    }
+  }
   nextPage() {
     this.skip = this.skip + this.limit
     if(this.searchString){
@@ -148,6 +155,9 @@ export class ResponsesComponent implements OnInit {
 
   onRowEdit(row) {
     this.router.navigate([row._id ? row._id : row.id], {relativeTo: this.route})
+  }
+  onRowDelete(row) {
+    this.deleteResponse(row._id ? row._id : row.id)
   }
   onRowClick(row){
     this.router.navigate([row._id ? row._id : row.id], {relativeTo: this.route})

--- a/editor/src/app/groups/responses/responses.component.ts
+++ b/editor/src/app/groups/responses/responses.component.ts
@@ -128,14 +128,6 @@ export class ResponsesComponent implements OnInit {
     this.skip = 0;
     this.getResponses();
   }
-
-  async deleteResponse(id) {
-    if(confirm('Are you sure you want to delete this form response?')) {
-      await this.http.delete(`/api/${this.groupId}/${id}`).toPromise()
-      this.getResponses()
-    }
-  }
-
   nextPage() {
     this.skip = this.skip + this.limit
     if(this.searchString){

--- a/editor/src/app/groups/responses/responses.component.ts
+++ b/editor/src/app/groups/responses/responses.component.ts
@@ -149,9 +149,7 @@ export class ResponsesComponent implements OnInit {
   onRowEdit(row) {
     this.router.navigate([row._id ? row._id : row.id], {relativeTo: this.route})
   }
-
-  onRowDelete(row) {
-    this.deleteResponse(row._id ? row._id : row.id)
+  onRowClick(row){
+    this.router.navigate([row._id ? row._id : row.id], {relativeTo: this.route})
   }
-
 }

--- a/editor/src/app/groups/responses/tangy-form-response-flatten.ts
+++ b/editor/src/app/groups/responses/tangy-form-response-flatten.ts
@@ -22,6 +22,7 @@ export const generateFlatResponse = async function (formResponse, locationLists,
     deviceId: formResponse.deviceId||'',
     groupId: formResponse.groupId||'',
     complete: formResponse.complete,
+    verified: formResponse.verified||'',
     tangerineModifiedByUserId: formResponse.tangerineModifiedByUserId,
     ...formResponse.caseId ? {
       caseId: formResponse.caseId,

--- a/editor/src/app/shared/_components/dynamic-table/dynamic-table.component.css
+++ b/editor/src/app/shared/_components/dynamic-table/dynamic-table.component.css
@@ -36,3 +36,6 @@ mat-cell, mat-header-cell {
 .mat-header-cell, .mat-cell {
   padding-left: 5px;
 }
+.mat-row{
+  cursor: pointer;
+}

--- a/editor/src/app/shared/_components/dynamic-table/dynamic-table.component.html
+++ b/editor/src/app/shared/_components/dynamic-table/dynamic-table.component.html
@@ -5,10 +5,10 @@
     <td mat-cell *matCellDef="let row">{{ column.cell(row) }}</td>
   </ng-container>
 
-  <ng-container matColumnDef="actions" stickyEnd>
+  <ng-container matColumnDef="actions" stickyEnd *ngIf="!hideActionBar">
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let row">
-      <div class="actions-container" >
+      <div class="actions-container">
         <button class="actions-menu" mat-stroked-button color="primary" [matMenuTriggerFor]="menu">
           <mat-icon>more_vert</mat-icon>
         </button>
@@ -26,6 +26,6 @@
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
 
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="onRowClick(row)"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="onRowClick($event,row)"></tr>
 
 </table>

--- a/editor/src/app/shared/_components/dynamic-table/dynamic-table.component.ts
+++ b/editor/src/app/shared/_components/dynamic-table/dynamic-table.component.ts
@@ -13,6 +13,7 @@ export class DynamicTableComponent implements OnInit, OnChanges {
   @Output() rowDelete: EventEmitter<any> = new EventEmitter<any>();
   @Input() data:Array<any> = []
   @Input() columnLabels = {}
+  @Input() hideActionBar
   columns:Array<any>
   displayedColumns:Array<any>
   dataSource:any
@@ -44,19 +45,22 @@ export class DynamicTableComponent implements OnInit, OnChanges {
         cell: (element: any) => `${element[column] ? element[column] : ``}`     
       }
     })
-    this.displayedColumns = [...this.columns.map(c => c.columnDef), 'actions'];
+    this.displayedColumns = this.hideActionBar? [...this.columns.map(c => c.columnDef)]:[...this.columns.map(c => c.columnDef), 'actions']
     // Set the dataSource for <mat-table>.
     this.dataSource = this.data 
   }
 
-  onRowClick(row) {
-    this.rowClick.emit(row)
-  }
+  onRowClick(event,row) {
 
+    if (event.target.tagName === 'MAT-ICON'){
+      event.stopPropagation()
+    }else{
+      this.rowClick.emit(row)
+    }
+  }
   onRowEdit(row) {
     this.rowEdit.emit(row)
   }
-
   onRowDelete(row) {
     this.rowDelete.emit(row)
   }

--- a/server/src/core/group-responses/group-responses.controller.ts
+++ b/server/src/core/group-responses/group-responses.controller.ts
@@ -1,6 +1,8 @@
 import { GroupResponsesService } from './../../shared/services/group-responses/group-responses.service';
-import { Controller, All, Param, Body } from '@nestjs/common';
+import { Controller, All, Param, Body , Req} from '@nestjs/common';
 import { SSL_OP_TLS_BLOCK_PADDING_BUG } from 'constants';
+import { Request } from 'express';
+import { decodeJWT } from 'src/auth-utils';
 const log = require('tangy-log').log
 
 @Controller('group-responses')
@@ -48,8 +50,9 @@ export class GroupResponsesController {
   }
 
   @All('update/:groupId')
-  async update(@Param('groupId') groupId, @Body('response') response:any) {
-    const freshResponse = await this.groupResponsesService.update(groupId, response)
+  async update(@Param('groupId') groupId, @Body('response') response:any, @Req() request:Request) {
+    const tangerineModifiedByUserId = decodeJWT(request['headers']['authorization'])['username']
+    const freshResponse = await this.groupResponsesService.update(groupId, {...response, tangerineModifiedByUserId})
     return freshResponse
   }
 


### PR DESCRIPTION
## Description

---

Data editors should be able to verify uploaded form responses

- Fixes #3703

## Type of Change


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---
Hide action bar when user is on group responses table
Add handler for `onRowClick`
Add 3 sticky buttons to the group uploads form response view i.e.
- Verify
- Edit
- Delete
Add the verified property as a column to the group responses table
Show the user a message with the result of the verification
