### PR TITLE
feat(editor): Allow users to Add custom code Javascript in Feedback page

### DIFF
--- a/editor/src/app/ng-tangy-form-editor/feedback-editor/feedback-editor.component.html
+++ b/editor/src/app/ng-tangy-form-editor/feedback-editor/feedback-editor.component.html
@@ -89,6 +89,9 @@
             <mat-form-field>
               <textarea matInput placeholder="Feedback message" [(ngModel)]="message">{{message}}</textarea>
             </mat-form-field>
+            <mat-form-field>
+              <textarea matInput placeholder="Custom JS Code" [(ngModel)]="customJSCode">{{customJSCode}}</textarea>
+            </mat-form-field>
           <div style="display: flex; justify-content: flex-end">
             <div mat-dialog-actions>
               <button mat-button (click)="onNoClick()">Cancel</button>  <button mat-raised-button color="primary" (click)="save()">Save feedback</button>

--- a/editor/src/app/ng-tangy-form-editor/feedback-editor/feedback-editor.component.ts
+++ b/editor/src/app/ng-tangy-form-editor/feedback-editor/feedback-editor.component.ts
@@ -25,6 +25,7 @@ export class FeedbackEditorComponent implements OnInit {
   skill:string = ""
   assignment:string = ""
   message:string = ""
+  customJSCode:string = ""
   formItems:any
   formItem:string
   formItemName:string
@@ -122,6 +123,7 @@ export class FeedbackEditorComponent implements OnInit {
     this.skill = ""
     this.assignment = ""
     this.message = ""
+    this.customJSCode = ""
     this.formItem = ""
 
     this.showFeedbackForm = true
@@ -140,6 +142,7 @@ export class FeedbackEditorComponent implements OnInit {
       this.feedback.skill = this.skill
       this.feedback.assignment = this.assignment
       this.feedback.message = this.message
+      this.feedback.customJSCode = this.customJSCode
       this.feedback.formItem = this.formItem
       this.feedbackService.update(this.groupName, this.formId, this.feedback)
         .then(async (data) => {
@@ -168,6 +171,7 @@ export class FeedbackEditorComponent implements OnInit {
         this.skill = this.feedback.skill
         this.assignment = this.feedback.assignment
         this.message = this.feedback.message
+        this.customJSCode = this.feedback.customJSCode
         this.formItem = this.feedback.formItem
 
         this.percentileOptions = this.createPercentileOptions(null)

--- a/editor/src/app/ng-tangy-form-editor/feedback-editor/feedback.ts
+++ b/editor/src/app/ng-tangy-form-editor/feedback-editor/feedback.ts
@@ -8,5 +8,6 @@ export class Feedback {
   skill:string;
   assignment:string;
   message:string;
+  customJSCode: string;
   messageTruncated: string; // for listing
 }


### PR DESCRIPTION
## Description

---

Allow users to Add custom code Javascript in Feedback page

- Fixes #3706

## Type of Change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---

- Provide textarea for user to enter and edit custom JavaScript code
- Code is run when the specific feedback page is opened

