### PR TITLE
Expose studentID When Enabling js code in feedback page

### DIFF
--- a/client/src/app/class/reports/student-grouping-report/student-grouping-report.component.html
+++ b/client/src/app/class/reports/student-grouping-report/student-grouping-report.component.html
@@ -59,13 +59,13 @@
           <!-- Student Column -->
           <ng-container matColumnDef="name">
             <th mat-header-cell *matHeaderCellDef title="{{'Student'|translate}}"> {{'Student'|translate}} </th>
-            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name)"> {{element["name"]}} </td>
+            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name, element.id)"> {{element["name"]}} </td>
           </ng-container>
 
           <!-- calculatedScore Column -->
           <ng-container matColumnDef="calculatedScore">
             <th mat-header-cell *matHeaderCellDef title="{{'Score'|translate}}"> {{'Score'|translate}} </th>
-            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name)">
+            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name, element.id)">
               <span *ngIf="element.score !== undefined">
                 {{element.customScore?element.customScore:tNumber(element.score)}}
                 /
@@ -77,7 +77,7 @@
           <!-- Percentile Column -->
           <ng-container matColumnDef="score">
             <th mat-header-cell *matHeaderCellDef title="{{'Percentile'|translate}}"> {{'Percentile'|translate}} </th>
-            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name)">
+            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name,element.id)">
               <span *ngIf="element.scorePercentageCorrect > -1">{{tNumber(element.scorePercentageCorrect)}} % </span>
             </td>
           </ng-container>
@@ -85,7 +85,7 @@
           <!-- Status Column -->
           <ng-container matColumnDef="status">
             <th mat-header-cell *matHeaderCellDef title="{{'Status'|translate}}"> {{'Status'|translate}} </th>
-            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name)">
+            <td mat-cell *matCellDef="let element" (click)="getFeedbackForPercentile(element.percentile, classGroupReport.curriculumId, classGroupReport.itemId, element.name, element.id)">
               <span *ngIf="element.status">{{element.status}}</span>
             </td>
           </ng-container>

--- a/client/src/app/class/reports/student-grouping-report/student-grouping-report.component.ts
+++ b/client/src/app/class/reports/student-grouping-report/student-grouping-report.component.ts
@@ -154,7 +154,7 @@ export class StudentGroupingReportComponent implements OnInit {
     }
   }
 
-  async getFeedbackForPercentile(percentile, curriculumId, itemId, name) {
+  async getFeedbackForPercentile(percentile, curriculumId, itemId, name, studentId) {
     // console.log("Get feedback for " + JSON.stringify(element))
     const feedback: Feedback = await this.dashboardService.getFeedback(percentile, curriculumId, itemId);
     if (feedback) {
@@ -163,7 +163,7 @@ export class StudentGroupingReportComponent implements OnInit {
     }
     // this.checkFeedbackMessagePosition = true;
     const dialogRef = this.dialog.open(FeedbackDialog, {
-      data: {classGroupReport: this.classGroupReport, name: name},
+      data: {classGroupReport: this.classGroupReport, name: name, studentId},
       width: '95vw',
       maxWidth: '95vw',
     });
@@ -209,6 +209,7 @@ export class StudentGroupingReportComponent implements OnInit {
 export interface DialogData {
   classGroupReport: ClassGroupingReport;
   name: string;
+  studentId
 }
 
 @Component({


### PR DESCRIPTION
## Description

---

Expose `studentId` property 

- Fixes #3706

## Type of Change

[Please delete irrelevant options]


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---

Make `studentId` available in the context of the feedback page

