### PR TITLE
feat(editor): Disable GPS

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -49,7 +49,7 @@
     "redux": "^4.0.5",
     "rxjs": "~6.5.5",
     "rxjs-compat": "^6.5.5",
-    "tangy-form": "^4.45.0",
+    "tangy-form": "^4.45.1",
     "tangy-form-editor": "7.18.0",
     "translation-web-component": "0.0.3",
     "tslib": "^1.11.2",

--- a/editor/package.json
+++ b/editor/package.json
@@ -49,7 +49,7 @@
     "redux": "^4.0.5",
     "rxjs": "~6.5.5",
     "rxjs-compat": "^6.5.5",
-    "tangy-form": "^4.43.2",
+    "tangy-form": "^4.45.0",
     "tangy-form-editor": "7.18.0",
     "translation-web-component": "0.0.3",
     "tslib": "^1.11.2",

--- a/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -194,7 +194,7 @@ export class TangyFormsPlayerComponent {
         this.$afterResubmit.next(true)
       })
     }
-    this.unlockFormResponses? this.formEl.unlock(): null
+    this.unlockFormResponses? this.formEl.unlock({disableComponents:['TANGY-GPS']}): null
     this.$rendered.next(true)
     this.rendered = true
   }


### PR DESCRIPTION
Refs Tangerine-Community/Tangerine#3703

## Description

---

- Fixes #3703
- Part of Tangerine-Community/tangy-form#413

## Type of Change


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Proposed Solution

---

When calling `this.formEl.unlock` you pass in an object with optional property of `disableComponents` which is an array of strings with the tag names of the elements to disable when unlocking a form e.g 
``` javascript
this.formEl.unlock({disableComponents:['TANGY-GPS']})
```


