### PR TITLE
Fix issue where userProfileId and tabletUserName are lost during edit on server in SP1

### DIFF
--- a/editor/src/app/case/components/event-form/event-form.component.ts
+++ b/editor/src/app/case/components/event-form/event-form.component.ts
@@ -78,7 +78,7 @@ export class EventFormComponent implements OnInit, OnDestroy {
         eventFormId: this.eventForm.id,
         participantId: this.eventForm.participantId
       }
-      this.formPlayer.render()
+      await this.formPlayer.render()
 
       this.caseService.onChangeLocation$.subscribe(location => {
         this.formPlayer.location = this.caseService.case.location

--- a/editor/src/app/case/components/issue-form/issue-form.component.ts
+++ b/editor/src/app/case/components/issue-form/issue-form.component.ts
@@ -79,13 +79,11 @@ export class IssueFormComponent implements OnInit {
         this.caseService.setContext(this.issue.eventId, this.issue.eventFormId)
         this.formPlayer.response = baseEvent.data.response
       }
-      this.formPlayer.render()
 
       // After render of the player, it will have created a new form response if one was not assigned.
       // Make sure to save that new form response ID into the EventForm.
-      this.formPlayer.$rendered.subscribe(async () => {
-        if (!params.eventId) this.formPlayer.unlock()
-      })
+      const unlockFormResponse = !params.eventId
+      await this.formPlayer.render(unlockFormResponse)
       this.formPlayer.$afterResubmit.subscribe(async () => {
         const issueSaveProcess = this.pm.start('issue-save', 'Saving proposal...')
         setTimeout(async () => {

--- a/editor/src/app/groups/group-device-user/group-device-user.component.ts
+++ b/editor/src/app/groups/group-device-user/group-device-user.component.ts
@@ -14,7 +14,9 @@ export class GroupDeviceUserComponent implements OnInit {
   title = _TRANSLATE('Device User')
   breadcrumbs:Array<Breadcrumb> = []
   @ViewChild('formPlayer', {static: true}) formPlayer: TangyFormsPlayerComponent
- 
+  
+  responseId:string
+
   constructor(
     private route:ActivatedRoute,
     private router:Router
@@ -22,6 +24,7 @@ export class GroupDeviceUserComponent implements OnInit {
 
   ngOnInit() {
     this.route.params.subscribe(params => {
+      this.responseId = params.responseId || ''
       this.breadcrumbs = [
         <Breadcrumb>{
           label: _TRANSLATE('Device Users'),
@@ -32,13 +35,17 @@ export class GroupDeviceUserComponent implements OnInit {
           url: `device-users/${params.responseId}` 
         }
       ]
-      this.formPlayer.formResponseId = params.responseId || ''
-      this.formPlayer.formId = 'user-profile'
-      this.formPlayer.preventSubmit = true
-      this.formPlayer.render()
-      this.formPlayer.$submit.subscribe(async () => {
-        this.router.navigate([`../`], { relativeTo: this.route })
-      })
+      this.ready();
+    })
+  }
+
+  async ready() {
+    this.formPlayer.formResponseId = this.responseId
+    this.formPlayer.formId = 'user-profile'
+    this.formPlayer.preventSubmit = true
+    await this.formPlayer.render()
+    this.formPlayer.$submit.subscribe(async () => {
+      this.router.navigate([`../`], { relativeTo: this.route })
     })
   }
 

--- a/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
+++ b/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
@@ -60,15 +60,21 @@ export class GroupUploadsEditComponent implements OnInit {
     }
 
     this.formPlayer.formResponseId = this.responseId
-    this.formPlayer.render()
-    this.formPlayer.$submit.subscribe(async () => {
-      let response = this.formPlayer.formEl.store.getState();
+    this.formPlayer.$afterResubmit.subscribe(async () => {
+      let response = this.formPlayer.formEl.store.getState()
+      
       if (this.appConfig.syncProtocol === '1') {
         this.restoreSP1DocumentVariables(response)
       }
-      this.formPlayer.saveResponse(response)
+      
+      // at this point the form has been locked by tangy-form
+      // form player will ignore the save unless we force it to save
+      await this.formPlayer.saveResponse(response, true)
+    })
+    this.formPlayer.$saveComplete.subscribe(async () => {
       this.router.navigate([`../`], { relativeTo: this.route })
     })
+    this.formPlayer.render();
   }
 
   async getSP1DocumentVariables() {

--- a/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
+++ b/editor/src/app/groups/group-uploads-edit/group-uploads-edit.component.ts
@@ -74,7 +74,7 @@ export class GroupUploadsEditComponent implements OnInit {
     this.formPlayer.$saveComplete.subscribe(async () => {
       this.router.navigate([`../`], { relativeTo: this.route })
     })
-    this.formPlayer.render();
+    await this.formPlayer.render(true, {disableComponents:['TANGY-GPS']})
   }
 
   async getSP1DocumentVariables() {

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.html
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.html
@@ -1,5 +1,5 @@
 <app-breadcrumb [title]="title" [breadcrumbs]="breadcrumbs"></app-breadcrumb>
-<div class="sticky">
+<div class="sticky" *ngIf="formResponse">
     <button *ngIf="!formResponse.verified" mat-raised-button color="accent" (click)="verify()">{{'Verify'|translate}}</button>
     <button *ngIf="formResponse.verified" mat-raised-button color="accent" (click)="unverify()">{{'Unverify'|translate}}</button>
     

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
@@ -28,7 +28,7 @@ export class GroupUploadsViewComponent implements OnInit {
   ) { }
 
   async ngOnInit() {
-    this.route.params.subscribe(async params => {
+    this.route.params.subscribe(params => {
       this.responseId = params.responseId
       this.groupId = params.groupId
       this.breadcrumbs = [
@@ -41,14 +41,17 @@ export class GroupUploadsViewComponent implements OnInit {
           url: `uploads/${params.responseId}`
         }
       ]
-      this.formPlayer.formResponseId = params.responseId
-      this.formResponse = await this.tangyFormService.getResponse(params.responseId)
-      this.formPlayer.render()
-      this.formPlayer.$submit.subscribe(async () => {
-        this.formPlayer.saveResponse(this.formPlayer.formEl.store.getState())
-        this.router.navigate([`../`], { relativeTo: this.route })
-      })
+
+      this.ready();
     })
+  }
+
+  async ready() {
+    // Load the form response instead of passing the responseId to the form player.
+    // If you pass the responseId, but the form player already has a response, responseId will be ignored
+    this.formResponse = await this.tangyFormService.getResponse(this.responseId)
+    this.formPlayer.response = this.formResponse
+    this.formPlayer.render()
   }
 
   async archive(){

--- a/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
+++ b/editor/src/app/groups/group-uploads-view/group-uploads-view.component.ts
@@ -51,7 +51,7 @@ export class GroupUploadsViewComponent implements OnInit {
     // If you pass the responseId, but the form player already has a response, responseId will be ignored
     this.formResponse = await this.tangyFormService.getResponse(this.responseId)
     this.formPlayer.response = this.formResponse
-    this.formPlayer.render()
+    await this.formPlayer.render()
   }
 
   async archive(){

--- a/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
+++ b/editor/src/app/tangy-forms/tangy-forms-player/tangy-forms-player.component.ts
@@ -26,7 +26,6 @@ export class TangyFormsPlayerComponent {
   @Input('response') response:TangyFormResponseModel
   // 3. Use this is you want a new form response.
   @Input('formId') formId:string
-  @Input('unlockFormResponses') unlockFormResponses:boolean
 
   @Input('templateId') templateId:string
   @Input('location') location:any
@@ -89,11 +88,7 @@ export class TangyFormsPlayerComponent {
     }
   }
 
-  unlock() {
-    this.formEl.unlock()
-  }
-
-  async render() {
+  async render(unlock=false, disabledComponents={}) {
     // Get form ingredients.
     const formResponse = this.response
       ? new TangyFormResponseModel(this.response)
@@ -195,8 +190,8 @@ export class TangyFormsPlayerComponent {
         this.$afterResubmit.next(true)
       })
     }
-    if (this.unlockFormResponses) {
-      this.formEl.unlock({disableComponents:['TANGY-GPS']})
+    if (unlock) {
+      this.formEl.unlock(disabledComponents)
     }
     this.$rendered.next(true)
     this.rendered = true


### PR DESCRIPTION
In sync-protocol 1, the userProfileId and tabletUserName are added as inputs in the first item of all documents. This happens in `syncing.service.ts` of the client. If these forms are edited on the server in Data > Uploads, these inputs are lost. It is important that these values are available, especially `userProfileId` for client imports and the two group-views `responsesByUserProfileId` and `responsesByUserProfileShortCode`.  

In order not to change the schema, this fix stashes the two inputs during edit, then re-adds them to the form after submit is clicked. 

It also fixes other issues with form editing on the server. 