### PR TITLE
Add shared csv template parameter to generate csv data sets script

### DIFF
--- a/server/src/scripts/generate-csv-data-set/generate-csv-data-set.js
+++ b/server/src/scripts/generate-csv-data-set/generate-csv-data-set.js
@@ -31,7 +31,13 @@ function generateCsv(dbName, formId, outputPath, year = '*', month = '*', csvTem
     let csvTemplate
     if (csvTemplateId) {
       const url = `${process.env.T_COUCHDB_ENDPOINT}/${dbName.replace('-reporting', '')}-csv-templates/${csvTemplateId}`
-      csvTemplate = (await axios.get(url)).data
+      try {
+        const response = await axios.get(url)
+        csvTemplate = response?.data
+      } catch (e) {
+        log.debug(`Could not find csv template with id ${csvTemplateId}`)
+        return 0
+      }
     }
     const batchSize = (process.env.T_CSV_BATCH_SIZE) ? process.env.T_CSV_BATCH_SIZE : 5
     const sleepTimeBetweenBatches = 0
@@ -41,8 +47,8 @@ function generateCsv(dbName, formId, outputPath, year = '*', month = '*', csvTem
     } else {
       cmd += ` '' '' `
     }
+    log.debug(`generate-csv ${csvTemplate ? `with headers from ${csvTemplateId}` : ''}: ${cmd}`)
     cmd = `${cmd} ${csvTemplate ? `"${csvTemplate.headers.join(',')}"` : ''}`
-    log.debug("generate-csv: " + cmd)
     const maxBuffer = 1024 * 1024 * 100;
     exec(cmd, { maxBuffer }).then(status => {
       resolve(status)
@@ -105,7 +111,6 @@ async function generateCsvDataSet(groupId = '', formIds = [], outputPath = '', y
       const fileName = `${groupFormname}${excludePii ? '-sanitized' : ''}-${Date.now()}.csv`.replace(/'/g, "_")
       const csvOutputPath = `/csv/${fileName.replace(/['",]/g, "_")}`
       const csvStatePath = `${csvOutputPath.replace('.csv', '')}.state.json`
-      log.debug("About to generateCsv in generate-csv-data-set.js")
       generateCsv(state.dbName, formId, csvOutputPath, year, month, csv.csvTemplateId)
       while (!await fs.pathExists(csvStatePath)) {
         await sleep(1*1000)

--- a/server/src/scripts/generate-csv-data-sets/bin.js
+++ b/server/src/scripts/generate-csv-data-sets/bin.js
@@ -4,19 +4,21 @@ const generateCsvDataSets = require('./generate-csv-data-sets.js')
 
 if (process.argv[2] === '--help') {
   console.log('Usage:')
-  console.log('  generate-csv-data-sets <filename>')
+  console.log('  generate-csv-data-sets <filename> [sharedCsvTemplateId]')
   console.log('Examples:')
   console.log(`  generate-csv-data-sets 2022-01-03`)
+  console.log(`  generate-csv-data-sets 2022-01-03 shared-csv-template-id`)
   process.exit()
 }
 
 const params = {
-  filename: process.argv[2]
+  filename: process.argv[2],
+  sharedCsvTemplateId: process.argv[3] || undefined
 }
 
 async function go(params) {
   try {
-    await generateCsvDataSets(params.filename) 
+    await generateCsvDataSets(params.filename, params.sharedCsvTemplateId)
     process.exit()
   } catch (error) {
     console.error(error)

--- a/server/src/scripts/generate-csv-data-sets/generate-csv-data-sets.js
+++ b/server/src/scripts/generate-csv-data-sets/generate-csv-data-sets.js
@@ -1,18 +1,46 @@
 const util = require('util');
+const axios = require('axios')
 const exec = util.promisify(require('child_process').exec)
 const fs = require('fs-extra');
 const generateCsvDataSet = require('../generate-csv-data-set/generate-csv-data-set');
 const groupsList = require('../../groups-list.js');
 const writeFile = util.promisify(fs.writeFile);
+const log = require('tangy-log').log
 
 const writeState = async function (state) {
   await writeFile(state.statePath, JSON.stringify(state, null, 2))
 }
 
-async function generateCsvDataSets(filename) {
-  const groupIds = await groupsList() 
+async function getGroupIds(sharedCsvTemplateId) {
+  let groupIds = []
+  const groups = await groupsList()
+  for (const groupId of groups) {
+    if (sharedCsvTemplateId) {
+      // only include csvs for groups that have the shared csv template
+      const url = `${process.env.T_COUCHDB_ENDPOINT}/${groupId}-csv-templates/${sharedCsvTemplateId}`
+      try {
+        const response = await axios.head(url)
+        if (response && response.status == 200) {
+          groupIds.push({id: groupId})
+        }
+      } catch (e) {
+        log.warn(`Did not find csv template with id ${sharedCsvTemplateId} in ${groupId}`)
+      }
+    } else {
+      groupIds.push({id: groupId})
+    }
+  }
+  return groupIds
+}
+
+async function generateCsvDataSets(filename, sharedCsvTemplateId) {
+  const groupIds = await getGroupIds(sharedCsvTemplateId)
+  if (groupIds.length == 0) {
+    log.error(`No groups found for csv generation for ${filename} ${sharedCsvTemplateId}`)
+    return;
+  }
   const state = {
-    groups: groupIds.map(groupId => { return { id: groupId } }),
+    groups: groupIds,
     complete: false,
     startTime: new Date().toISOString(),
     outputPath: `/csv/${filename}.zip`,
@@ -20,7 +48,9 @@ async function generateCsvDataSets(filename) {
   }
   // Fetch all form IDs for each group.
   for (let group of state.groups) {
-    group.formIds =  (await fs.readJson(`/tangerine/client/content/groups/${group.id}/forms.json`)).map(form => form.id)
+    group.formIds =  (await fs.readJson(`/tangerine/client/content/groups/${group.id}/forms.json`)).map(
+      form => sharedCsvTemplateId ? `${form.id}:${sharedCsvTemplateId}` : form.id
+    )
     group.outputPath = `/csv/csv-data-sets-${filename}-${group.id}.zip`
     group.complete = false
   }


### PR DESCRIPTION
The `/api/create/csvDataSets/` API and script called [generate-csv-data-sets](./server/src/scripts/generate-csv-data-sets/bin.js) are useful to generate CSV Data Sets (Spreadsheets) across all forms in all groups. This change adds a second parameter called `sharedCsvTemplateId` which is the CouchDB Id of a Spreadsheet Template stored in the groups database named `group-<id>-csv-templates` which applied the template to the data set generation process. Only CSVs will be produced for groups that have the `sharedCsvTemplateId` template in the  `group-<id>-csv-templates` database. 