### PR TITLE
Remove unused SSL_OP_TLS_BLOCK_PADDING_BUG import

### DIFF
--- a/server/src/core/group-responses/group-responses.controller.ts
+++ b/server/src/core/group-responses/group-responses.controller.ts
@@ -1,6 +1,5 @@
 import { GroupResponsesService } from './../../shared/services/group-responses/group-responses.service';
 import { Controller, All, Param, Body , Req} from '@nestjs/common';
-import { SSL_OP_TLS_BLOCK_PADDING_BUG } from 'constants';
 import { Request } from 'express';
 import { decodeJWT } from 'src/auth-utils';
 const log = require('tangy-log').log


### PR DESCRIPTION
## Description

The constant imported from Node.js internal `constants` module was unused and obsolete. Its removal has no impact on runtime behavior and avoids relying on deprecated APIs.

---

[What is the business, user experience or technical problem? What is the motivation or context? Any Dependencies required for the change? e.g `tangy-forms` version etc]
[List the issues fixed and any other relevant issues]

This is just a "first PR" while I'm looking at the code and searching for small things I can do without taking any risk.


## Type of Change

[Please delete irrelevant options]

- Bug fix (non-breaking change)

## Proposed Solution

- Remove unused import

---

[Please give a description of the solution proposed in the PR]

## Limitations and Trade-offs

[Optional. What are the limitations of the proposed solution? What are the potential edge cases that one should be aware of? What are some of the tradeoffs? What are some of the approaches considered and not used? Why were they not used? ]

## Security considerations


## Screenshots/Videos

---

[Optional. Post screenshots or videos to explain this change visually.]

## Tests

---

[How you tested (or have not tested) this PR and what where those steps.]

## Notices, Regressions, Breaking Changes

---

[Optional. Impacts to developers, project or structure that is required to be communicated.]

## TODOS/enhancements

---

[Optional. List out the remaining tasks that would complete this pull request.]

- [Develop more tests for this PR.]
- [Follow up on something else.]

=> Should I delete all the text above that is not relevant ? Or is it an indication that the proposed change is just too small and should not be worthy of a PR? (Sorry if that is the case)